### PR TITLE
Adds CI testing for Swift 5.8

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,9 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'Package.*'
+      - 'Sources/**'
   pull_request:
 
 jobs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,10 @@ jobs:
           - '5.5'
           - '5.6'
           - '5.7'
+          - '5.8'
         exclude:
+          - os: macos-11
+            swift: '5.8'
           - os: macos-12
             swift: '5.5'
           - os: macos-12


### PR DESCRIPTION
This PR enables CI build test with Swift 5.8, and reduces unnecessary CI runs to save runner resource.