### PR TITLE
Adds support for model member deprecations

### DIFF
--- a/Sources/Teco/Apigateway/V20180808/actions/DescribeLogSearch.swift
+++ b/Sources/Teco/Apigateway/V20180808/actions/DescribeLogSearch.swift
@@ -64,8 +64,21 @@ extension Apigateway {
         ///
         /// 说明：
         /// “:”表示包含，“!=”表示不等于，字段含义见输出参数的LogSet说明
-        public let logQuerys: [LogQuery]?
+        @available(*, deprecated)
+        public let logQuerys: [LogQuery]? = nil
 
+        public init(startTime: Date, endTime: Date, serviceId: String, filters: [Filter]? = nil, limit: UInt64? = nil, conText: String? = nil, sort: String? = nil, query: String? = nil) {
+            self._startTime = .init(wrappedValue: startTime)
+            self._endTime = .init(wrappedValue: endTime)
+            self.serviceId = serviceId
+            self.filters = filters
+            self.limit = limit
+            self.conText = conText
+            self.sort = sort
+            self.query = query
+        }
+
+        @available(*, deprecated, renamed: "init(startTime:endTime:serviceId:filters:limit:conText:sort:query:)", message: "'logQuerys' is deprecated in 'DescribeLogSearchRequest'. Setting this parameter has no effect.")
         public init(startTime: Date, endTime: Date, serviceId: String, filters: [Filter]? = nil, limit: UInt64? = nil, conText: String? = nil, sort: String? = nil, query: String? = nil, logQuerys: [LogQuery]? = nil) {
             self._startTime = .init(wrappedValue: startTime)
             self._endTime = .init(wrappedValue: endTime)
@@ -75,7 +88,6 @@ extension Apigateway {
             self.conText = conText
             self.sort = sort
             self.query = query
-            self.logQuerys = logQuerys
         }
 
         enum CodingKeys: String, CodingKey {
@@ -160,6 +172,15 @@ extension Apigateway {
     ///
     /// 本接口DescribeLogSearch用于搜索日志
     @inlinable
+    public func describeLogSearch(startTime: Date, endTime: Date, serviceId: String, filters: [Filter]? = nil, limit: UInt64? = nil, conText: String? = nil, sort: String? = nil, query: String? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<DescribeLogSearchResponse> {
+        self.describeLogSearch(.init(startTime: startTime, endTime: endTime, serviceId: serviceId, filters: filters, limit: limit, conText: conText, sort: sort, query: query), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 日志搜索服务
+    ///
+    /// 本接口DescribeLogSearch用于搜索日志
+    @available(*, deprecated, renamed: "describeLogSearch(startTime:endTime:serviceId:filters:limit:conText:sort:query:region:logger:on:)", message: "'logQuerys' is deprecated. Setting this parameter has no effect.")
+    @inlinable
     public func describeLogSearch(startTime: Date, endTime: Date, serviceId: String, filters: [Filter]? = nil, limit: UInt64? = nil, conText: String? = nil, sort: String? = nil, query: String? = nil, logQuerys: [LogQuery]? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<DescribeLogSearchResponse> {
         self.describeLogSearch(.init(startTime: startTime, endTime: endTime, serviceId: serviceId, filters: filters, limit: limit, conText: conText, sort: sort, query: query, logQuerys: logQuerys), region: region, logger: logger, on: eventLoop)
     }
@@ -167,6 +188,15 @@ extension Apigateway {
     /// 日志搜索服务
     ///
     /// 本接口DescribeLogSearch用于搜索日志
+    @inlinable
+    public func describeLogSearch(startTime: Date, endTime: Date, serviceId: String, filters: [Filter]? = nil, limit: UInt64? = nil, conText: String? = nil, sort: String? = nil, query: String? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> DescribeLogSearchResponse {
+        try await self.describeLogSearch(.init(startTime: startTime, endTime: endTime, serviceId: serviceId, filters: filters, limit: limit, conText: conText, sort: sort, query: query), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 日志搜索服务
+    ///
+    /// 本接口DescribeLogSearch用于搜索日志
+    @available(*, deprecated, renamed: "describeLogSearch(startTime:endTime:serviceId:filters:limit:conText:sort:query:region:logger:on:)", message: "'logQuerys' is deprecated. Setting this parameter has no effect.")
     @inlinable
     public func describeLogSearch(startTime: Date, endTime: Date, serviceId: String, filters: [Filter]? = nil, limit: UInt64? = nil, conText: String? = nil, sort: String? = nil, query: String? = nil, logQuerys: [LogQuery]? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> DescribeLogSearchResponse {
         try await self.describeLogSearch(.init(startTime: startTime, endTime: endTime, serviceId: serviceId, filters: filters, limit: limit, conText: conText, sort: sort, query: query, logQuerys: logQuerys), region: region, logger: logger, on: eventLoop)

--- a/Sources/Teco/Apigateway/V20180808/models.swift
+++ b/Sources/Teco/Apigateway/V20180808/models.swift
@@ -348,6 +348,7 @@ extension Apigateway {
 
         /// 授权API关联的业务API列表。
         /// 注意：此字段可能返回 null，表示取不到有效值。
+        @available(*, deprecated)
         public let relationBuniessApiIds: [String]?
 
         /// oauth配置信息。
@@ -1271,6 +1272,7 @@ extension Apigateway {
 
         /// 授权API关联的业务API列表。
         /// 注意：此字段可能返回 null，表示取不到有效值。
+        @available(*, deprecated)
         public let relationBuniessApiIds: [String]?
 
         /// API关联的标签信息。
@@ -1421,6 +1423,7 @@ extension Apigateway {
 
         /// 授权API关联的业务API列表。
         /// 注意：此字段可能返回 null，表示取不到有效值。
+        @available(*, deprecated)
         public let relationBuniessApiIds: [String]?
 
         /// API关联的标签信息。
@@ -2271,7 +2274,8 @@ extension Apigateway {
         ///
         /// While the wrapped date value is immutable just like other fields, you can customize the projected
         /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
-        @TCTimestampISO8601Encoding public var modifedTime: Date
+        @available(*, deprecated)
+        @TCTimestampISO8601Encoding public var modifedTime: Date?
 
         /// 字符类型的值，当Type为string时才有意义
         /// 注意：此字段可能返回 null，表示取不到有效值。

--- a/Sources/Teco/Asr/V20190614/actions/SentenceRecognition.swift
+++ b/Sources/Teco/Asr/V20190614/actions/SentenceRecognition.swift
@@ -53,16 +53,19 @@ extension Asr {
         public let voiceFormat: String
 
         /// 腾讯云项目 ID，废弃参数，填写0即可。
-        public let projectId: UInt64?
+        @available(*, deprecated)
+        public let projectId: UInt64? = nil
 
         /// 子服务类型。2： 一句话识别。
-        public let subServiceType: UInt64?
+        @available(*, deprecated)
+        public let subServiceType: UInt64? = nil
 
         /// 语音的URL地址，需要公网环境浏览器可下载。当 SourceType 值为 0时须填写该字段，为 1 时不填。音频时长不能超过60s，音频文件大小不能超过3MB。
         public let url: String?
 
         /// 废弃参数，填写任意字符串即可。
-        public let usrAudioKey: String?
+        @available(*, deprecated)
+        public let usrAudioKey: String? = nil
 
         /// 语音数据，当SourceType 值为1（本地语音数据上传）时必须填写，当SourceType 值为0（语音 URL上传）可不写。要使用base64编码(采用python语言时注意读取文件应该为string而不是byte，以byte格式读取后要decode()。编码后的数据不可带有回车换行符)。音频时长不能超过60s，音频文件大小不能超过3MB（Base64后）。
         public let data: String?
@@ -106,14 +109,31 @@ extension Asr {
         /// 支持pcm格式的8k音频在与引擎采样率不匹配的情况下升采样到16k后识别，能有效提升识别准确率。仅支持：8000。如：传入 8000 ，则pcm音频采样率为8k，当引擎选用16k_zh， 那么该8k采样率的pcm音频可以在16k_zh引擎下正常识别。 注：此参数仅适用于pcm格式音频，不传入值将维持默认状态，即默认调用的引擎采样率等于pcm音频采样率。
         public let inputSampleRate: Int64?
 
+        public init(engSerViceType: String, sourceType: UInt64, voiceFormat: String, url: String? = nil, data: String? = nil, dataLen: Int64? = nil, wordInfo: Int64? = nil, filterDirty: Int64? = nil, filterModal: Int64? = nil, filterPunc: Int64? = nil, convertNumMode: Int64? = nil, hotwordId: String? = nil, customizationId: String? = nil, reinforceHotword: Int64? = nil, hotwordList: String? = nil, inputSampleRate: Int64? = nil) {
+            self.engSerViceType = engSerViceType
+            self.sourceType = sourceType
+            self.voiceFormat = voiceFormat
+            self.url = url
+            self.data = data
+            self.dataLen = dataLen
+            self.wordInfo = wordInfo
+            self.filterDirty = filterDirty
+            self.filterModal = filterModal
+            self.filterPunc = filterPunc
+            self.convertNumMode = convertNumMode
+            self.hotwordId = hotwordId
+            self.customizationId = customizationId
+            self.reinforceHotword = reinforceHotword
+            self.hotwordList = hotwordList
+            self.inputSampleRate = inputSampleRate
+        }
+
+        @available(*, deprecated, renamed: "init(engSerViceType:sourceType:voiceFormat:url:data:dataLen:wordInfo:filterDirty:filterModal:filterPunc:convertNumMode:hotwordId:customizationId:reinforceHotword:hotwordList:inputSampleRate:)", message: "'projectId', 'subServiceType' and 'usrAudioKey' are deprecated in 'SentenceRecognitionRequest'. Setting these parameters has no effect.")
         public init(engSerViceType: String, sourceType: UInt64, voiceFormat: String, projectId: UInt64? = nil, subServiceType: UInt64? = nil, url: String? = nil, usrAudioKey: String? = nil, data: String? = nil, dataLen: Int64? = nil, wordInfo: Int64? = nil, filterDirty: Int64? = nil, filterModal: Int64? = nil, filterPunc: Int64? = nil, convertNumMode: Int64? = nil, hotwordId: String? = nil, customizationId: String? = nil, reinforceHotword: Int64? = nil, hotwordList: String? = nil, inputSampleRate: Int64? = nil) {
             self.engSerViceType = engSerViceType
             self.sourceType = sourceType
             self.voiceFormat = voiceFormat
-            self.projectId = projectId
-            self.subServiceType = subServiceType
             self.url = url
-            self.usrAudioKey = usrAudioKey
             self.data = data
             self.dataLen = dataLen
             self.wordInfo = wordInfo
@@ -199,6 +219,15 @@ extension Asr {
     ///
     /// 本接口用于对60秒之内的短音频文件进行识别。<br>•   支持中文普通话、英语、粤语、日语、越南语、马来语、印度尼西亚语、菲律宾语、泰语、葡萄牙语、土耳其语、阿拉伯语、上海话、四川话、武汉话、贵阳话、昆明话、西安话、郑州话、太原话、兰州话、银川话、西宁话、南京话、合肥话、南昌话、长沙话、苏州话、杭州话、济南话、天津话、石家庄话、黑龙江话、吉林话、辽宁话。<br>•   支持本地语音文件上传和语音URL上传两种请求方式，音频时长不能超过60s，音频文件大小不能超过3MB。<br>•   音频格式支持wav、pcm、ogg-opus、speex、silk、mp3、m4a、aac。<br>•   请求方法为 HTTP POST , Content-Type为"application/json; charset=utf-8"<br>•   签名方法参考 [公共参数](https://cloud.tencent.com/document/api/1093/35640) 中签名方法v3。<br>•   默认接口请求频率限制：30次/秒，如您有提高请求频率限制的需求，请[前往购买](https://buy.cloud.tencent.com/asr)。
     @inlinable
+    public func sentenceRecognition(engSerViceType: String, sourceType: UInt64, voiceFormat: String, url: String? = nil, data: String? = nil, dataLen: Int64? = nil, wordInfo: Int64? = nil, filterDirty: Int64? = nil, filterModal: Int64? = nil, filterPunc: Int64? = nil, convertNumMode: Int64? = nil, hotwordId: String? = nil, customizationId: String? = nil, reinforceHotword: Int64? = nil, hotwordList: String? = nil, inputSampleRate: Int64? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<SentenceRecognitionResponse> {
+        self.sentenceRecognition(.init(engSerViceType: engSerViceType, sourceType: sourceType, voiceFormat: voiceFormat, url: url, data: data, dataLen: dataLen, wordInfo: wordInfo, filterDirty: filterDirty, filterModal: filterModal, filterPunc: filterPunc, convertNumMode: convertNumMode, hotwordId: hotwordId, customizationId: customizationId, reinforceHotword: reinforceHotword, hotwordList: hotwordList, inputSampleRate: inputSampleRate), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 一句话识别
+    ///
+    /// 本接口用于对60秒之内的短音频文件进行识别。<br>•   支持中文普通话、英语、粤语、日语、越南语、马来语、印度尼西亚语、菲律宾语、泰语、葡萄牙语、土耳其语、阿拉伯语、上海话、四川话、武汉话、贵阳话、昆明话、西安话、郑州话、太原话、兰州话、银川话、西宁话、南京话、合肥话、南昌话、长沙话、苏州话、杭州话、济南话、天津话、石家庄话、黑龙江话、吉林话、辽宁话。<br>•   支持本地语音文件上传和语音URL上传两种请求方式，音频时长不能超过60s，音频文件大小不能超过3MB。<br>•   音频格式支持wav、pcm、ogg-opus、speex、silk、mp3、m4a、aac。<br>•   请求方法为 HTTP POST , Content-Type为"application/json; charset=utf-8"<br>•   签名方法参考 [公共参数](https://cloud.tencent.com/document/api/1093/35640) 中签名方法v3。<br>•   默认接口请求频率限制：30次/秒，如您有提高请求频率限制的需求，请[前往购买](https://buy.cloud.tencent.com/asr)。
+    @available(*, deprecated, renamed: "sentenceRecognition(engSerViceType:sourceType:voiceFormat:url:data:dataLen:wordInfo:filterDirty:filterModal:filterPunc:convertNumMode:hotwordId:customizationId:reinforceHotword:hotwordList:inputSampleRate:region:logger:on:)", message: "'projectId', 'subServiceType' and 'usrAudioKey' are deprecated. Setting these parameters has no effect.")
+    @inlinable
     public func sentenceRecognition(engSerViceType: String, sourceType: UInt64, voiceFormat: String, projectId: UInt64? = nil, subServiceType: UInt64? = nil, url: String? = nil, usrAudioKey: String? = nil, data: String? = nil, dataLen: Int64? = nil, wordInfo: Int64? = nil, filterDirty: Int64? = nil, filterModal: Int64? = nil, filterPunc: Int64? = nil, convertNumMode: Int64? = nil, hotwordId: String? = nil, customizationId: String? = nil, reinforceHotword: Int64? = nil, hotwordList: String? = nil, inputSampleRate: Int64? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<SentenceRecognitionResponse> {
         self.sentenceRecognition(.init(engSerViceType: engSerViceType, sourceType: sourceType, voiceFormat: voiceFormat, projectId: projectId, subServiceType: subServiceType, url: url, usrAudioKey: usrAudioKey, data: data, dataLen: dataLen, wordInfo: wordInfo, filterDirty: filterDirty, filterModal: filterModal, filterPunc: filterPunc, convertNumMode: convertNumMode, hotwordId: hotwordId, customizationId: customizationId, reinforceHotword: reinforceHotword, hotwordList: hotwordList, inputSampleRate: inputSampleRate), region: region, logger: logger, on: eventLoop)
     }
@@ -206,6 +235,15 @@ extension Asr {
     /// 一句话识别
     ///
     /// 本接口用于对60秒之内的短音频文件进行识别。<br>•   支持中文普通话、英语、粤语、日语、越南语、马来语、印度尼西亚语、菲律宾语、泰语、葡萄牙语、土耳其语、阿拉伯语、上海话、四川话、武汉话、贵阳话、昆明话、西安话、郑州话、太原话、兰州话、银川话、西宁话、南京话、合肥话、南昌话、长沙话、苏州话、杭州话、济南话、天津话、石家庄话、黑龙江话、吉林话、辽宁话。<br>•   支持本地语音文件上传和语音URL上传两种请求方式，音频时长不能超过60s，音频文件大小不能超过3MB。<br>•   音频格式支持wav、pcm、ogg-opus、speex、silk、mp3、m4a、aac。<br>•   请求方法为 HTTP POST , Content-Type为"application/json; charset=utf-8"<br>•   签名方法参考 [公共参数](https://cloud.tencent.com/document/api/1093/35640) 中签名方法v3。<br>•   默认接口请求频率限制：30次/秒，如您有提高请求频率限制的需求，请[前往购买](https://buy.cloud.tencent.com/asr)。
+    @inlinable
+    public func sentenceRecognition(engSerViceType: String, sourceType: UInt64, voiceFormat: String, url: String? = nil, data: String? = nil, dataLen: Int64? = nil, wordInfo: Int64? = nil, filterDirty: Int64? = nil, filterModal: Int64? = nil, filterPunc: Int64? = nil, convertNumMode: Int64? = nil, hotwordId: String? = nil, customizationId: String? = nil, reinforceHotword: Int64? = nil, hotwordList: String? = nil, inputSampleRate: Int64? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> SentenceRecognitionResponse {
+        try await self.sentenceRecognition(.init(engSerViceType: engSerViceType, sourceType: sourceType, voiceFormat: voiceFormat, url: url, data: data, dataLen: dataLen, wordInfo: wordInfo, filterDirty: filterDirty, filterModal: filterModal, filterPunc: filterPunc, convertNumMode: convertNumMode, hotwordId: hotwordId, customizationId: customizationId, reinforceHotword: reinforceHotword, hotwordList: hotwordList, inputSampleRate: inputSampleRate), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 一句话识别
+    ///
+    /// 本接口用于对60秒之内的短音频文件进行识别。<br>•   支持中文普通话、英语、粤语、日语、越南语、马来语、印度尼西亚语、菲律宾语、泰语、葡萄牙语、土耳其语、阿拉伯语、上海话、四川话、武汉话、贵阳话、昆明话、西安话、郑州话、太原话、兰州话、银川话、西宁话、南京话、合肥话、南昌话、长沙话、苏州话、杭州话、济南话、天津话、石家庄话、黑龙江话、吉林话、辽宁话。<br>•   支持本地语音文件上传和语音URL上传两种请求方式，音频时长不能超过60s，音频文件大小不能超过3MB。<br>•   音频格式支持wav、pcm、ogg-opus、speex、silk、mp3、m4a、aac。<br>•   请求方法为 HTTP POST , Content-Type为"application/json; charset=utf-8"<br>•   签名方法参考 [公共参数](https://cloud.tencent.com/document/api/1093/35640) 中签名方法v3。<br>•   默认接口请求频率限制：30次/秒，如您有提高请求频率限制的需求，请[前往购买](https://buy.cloud.tencent.com/asr)。
+    @available(*, deprecated, renamed: "sentenceRecognition(engSerViceType:sourceType:voiceFormat:url:data:dataLen:wordInfo:filterDirty:filterModal:filterPunc:convertNumMode:hotwordId:customizationId:reinforceHotword:hotwordList:inputSampleRate:region:logger:on:)", message: "'projectId', 'subServiceType' and 'usrAudioKey' are deprecated. Setting these parameters has no effect.")
     @inlinable
     public func sentenceRecognition(engSerViceType: String, sourceType: UInt64, voiceFormat: String, projectId: UInt64? = nil, subServiceType: UInt64? = nil, url: String? = nil, usrAudioKey: String? = nil, data: String? = nil, dataLen: Int64? = nil, wordInfo: Int64? = nil, filterDirty: Int64? = nil, filterModal: Int64? = nil, filterPunc: Int64? = nil, convertNumMode: Int64? = nil, hotwordId: String? = nil, customizationId: String? = nil, reinforceHotword: Int64? = nil, hotwordList: String? = nil, inputSampleRate: Int64? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> SentenceRecognitionResponse {
         try await self.sentenceRecognition(.init(engSerViceType: engSerViceType, sourceType: sourceType, voiceFormat: voiceFormat, projectId: projectId, subServiceType: subServiceType, url: url, usrAudioKey: usrAudioKey, data: data, dataLen: dataLen, wordInfo: wordInfo, filterDirty: filterDirty, filterModal: filterModal, filterPunc: filterPunc, convertNumMode: convertNumMode, hotwordId: hotwordId, customizationId: customizationId, reinforceHotword: reinforceHotword, hotwordList: hotwordList, inputSampleRate: inputSampleRate), region: region, logger: logger, on: eventLoop)

--- a/Sources/Teco/Asr/V20190614/models.swift
+++ b/Sources/Teco/Asr/V20190614/models.swift
@@ -54,7 +54,7 @@ extension Asr {
         /// 注意：此字段可能返回 null，表示取不到有效值。
         public let weight: Int64?
 
-        public init(word: String, weight: Int64) {
+        public init(word: String? = nil, weight: Int64? = nil) {
             self.word = word
             self.weight = weight
         }

--- a/Sources/Teco/Autoscaling/V20180419/models.swift
+++ b/Sources/Teco/Autoscaling/V20180419/models.swift
@@ -71,6 +71,7 @@ extension As {
         @TCTimestampISO8601Encoding public var createdTime: Date
 
         /// 该参数已废弃，请勿使用。
+        @available(*, deprecated)
         public let activityRelatedInstanceSet: [ActivtyRelatedInstance]
 
         /// 伸缩活动状态简要描述。
@@ -458,15 +459,22 @@ extension As {
         public let monitorService: RunMonitorServiceEnabled?
 
         /// 该参数已废弃，查询时会返回空值，请勿使用。
-        public let automationService: [RunAutomationServiceEnabled]?
+        @available(*, deprecated)
+        public let automationService: [RunAutomationServiceEnabled]? = nil
 
         /// 开启自动化助手服务。若不指定该参数，则默认逻辑与CVM保持一致。注意：此字段可能返回 null，表示取不到有效值。
         public let automationToolsService: RunAutomationServiceEnabled?
 
+        public init(securityService: RunSecurityServiceEnabled? = nil, monitorService: RunMonitorServiceEnabled? = nil, automationToolsService: RunAutomationServiceEnabled? = nil) {
+            self.securityService = securityService
+            self.monitorService = monitorService
+            self.automationToolsService = automationToolsService
+        }
+
+        @available(*, deprecated, renamed: "init(securityService:monitorService:automationToolsService:)", message: "'automationService' is deprecated in 'EnhancedService'. Setting this parameter has no effect.")
         public init(securityService: RunSecurityServiceEnabled? = nil, monitorService: RunMonitorServiceEnabled? = nil, automationService: [RunAutomationServiceEnabled]? = nil, automationToolsService: RunAutomationServiceEnabled? = nil) {
             self.securityService = securityService
             self.monitorService = monitorService
-            self.automationService = automationService
             self.automationToolsService = automationToolsService
         }
 

--- a/Sources/Teco/Billing/V20180709/models.swift
+++ b/Sources/Teco/Billing/V20180709/models.swift
@@ -213,6 +213,7 @@ extension Billing {
         public let singlePrice: String
 
         /// 组件指定价（已废弃）
+        @available(*, deprecated)
         public let specifiedPrice: String
 
         /// 组件价格单位：组件价格的单位，单位构成：元/用量单位/时长单位
@@ -293,6 +294,7 @@ extension Billing {
 
         /// 节省计划抵扣金额（已废弃）
         /// 注意：此字段可能返回 null，表示取不到有效值。
+        @available(*, deprecated)
         public let spDeduction: String?
 
         /// 节省计划抵扣组件原价：节省计划抵扣原价=节省计划包抵扣金额/节省计划抵扣率
@@ -458,6 +460,7 @@ extension Billing {
         public let originalCostWithRI: String
 
         /// 节省计划抵扣金额（已废弃）
+        @available(*, deprecated)
         public let spDeduction: String?
 
         /// 节省计划抵扣组件原价：节省计划抵扣原价=节省计划包抵扣金额/节省计划抵扣率

--- a/Sources/Teco/Cam/V20190116/actions/GetAccountSummary.swift
+++ b/Sources/Teco/Cam/V20190116/actions/GetAccountSummary.swift
@@ -34,6 +34,7 @@ extension Cam {
         public let roles: UInt64
 
         /// 身份提供商数
+        @available(*, deprecated)
         public let idps: UInt64
 
         /// 子账户数

--- a/Sources/Teco/Ciam/V20220331/actions/CreateUserGroup.swift
+++ b/Sources/Teco/Ciam/V20220331/actions/CreateUserGroup.swift
@@ -46,7 +46,7 @@ extension Ciam {
     /// CreateUserGroup返回参数结构体
     public struct CreateUserGroupResponse: TCResponseModel {
         /// 用户组ID
-        public let userGroupId: String
+        public let userGroupId: String?
 
         /// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
         public let requestId: String

--- a/Sources/Teco/Ciam/V20220331/actions/CreateUserStore.swift
+++ b/Sources/Teco/Ciam/V20220331/actions/CreateUserStore.swift
@@ -46,7 +46,7 @@ extension Ciam {
     /// CreateUserStore返回参数结构体
     public struct CreateUserStoreResponse: TCResponseModel {
         /// 用户目录ID
-        public let userStoreId: String
+        public let userStoreId: String?
 
         /// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
         public let requestId: String

--- a/Sources/Teco/Ckafka/V20190819/models.swift
+++ b/Sources/Teco/Ckafka/V20190819/models.swift
@@ -1054,6 +1054,7 @@ extension Ckafka {
 
         /// 删除时间。目前该参数字段已废弃，将会在未来被删除
         /// 注意：此字段可能返回 null，表示取不到有效值。
+        @available(*, deprecated)
         public let deleteRouteTimestamp: String?
 
         enum CodingKeys: String, CodingKey {

--- a/Sources/Teco/Clb/V20180317/models.swift
+++ b/Sources/Teco/Clb/V20180317/models.swift
@@ -2720,6 +2720,7 @@ extension Clb {
         public let healthStatusDetail: String
 
         /// (**该参数对象即将下线，不推荐使用，请使用HealthStatusDetail获取健康详情**) 当前健康状态的详细信息。如：Alive、Dead、Unknown。Alive状态为健康，Dead状态为异常，Unknown状态包括尚未开始探测、探测中、状态未知。
+        @available(*, deprecated)
         public let healthStatusDetial: String?
 
         enum CodingKeys: String, CodingKey {

--- a/Sources/Teco/Cms/V20190321/actions/CreateKeywordsSamples.swift
+++ b/Sources/Teco/Cms/V20190321/actions/CreateKeywordsSamples.swift
@@ -45,7 +45,7 @@ extension Cms {
         public let sampleIDs: [String]?
 
         /// 成功入库关键词列表
-        public let successInfos: [UserKeywordInfo]
+        public let successInfos: [UserKeywordInfo]?
 
         /// 重复关键词列表
         /// 注意：此字段可能返回 null，表示取不到有效值。

--- a/Sources/Teco/Cynosdb/V20190107/actions/CreateProxy.swift
+++ b/Sources/Teco/Cynosdb/V20190107/actions/CreateProxy.swift
@@ -97,7 +97,7 @@ extension Cynosdb {
         public let taskId: Int64
 
         /// 数据库代理组ID
-        public let proxyGroupId: String
+        public let proxyGroupId: String?
 
         /// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
         public let requestId: String

--- a/Sources/Teco/Cynosdb/V20190107/actions/CreateProxyEndPoint.swift
+++ b/Sources/Teco/Cynosdb/V20190107/actions/CreateProxyEndPoint.swift
@@ -131,7 +131,7 @@ extension Cynosdb {
         public let taskId: Int64
 
         /// 数据库代理组ID
-        public let proxyGroupId: String
+        public let proxyGroupId: String?
 
         /// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
         public let requestId: String

--- a/Sources/Teco/Cynosdb/V20190107/models.swift
+++ b/Sources/Teco/Cynosdb/V20190107/models.swift
@@ -2987,7 +2987,7 @@ extension Cynosdb {
         /// 注意：此字段可能返回 null，表示取不到有效值。
         public let newTable: String?
 
-        public init(oldTable: String, newTable: String) {
+        public init(oldTable: String? = nil, newTable: String? = nil) {
             self.oldTable = oldTable
             self.newTable = newTable
         }

--- a/Sources/Teco/Dlc/V20210125/actions/CreateDataEngine.swift
+++ b/Sources/Teco/Dlc/V20210125/actions/CreateDataEngine.swift
@@ -43,7 +43,8 @@ extension Dlc {
         public let maxClusters: Int64?
 
         /// 是否为默认虚拟集群
-        public let defaultDataEngine: Bool?
+        @available(*, deprecated)
+        public let defaultDataEngine: Bool? = nil
 
         /// VPC网段
         public let cidrBlock: String?
@@ -111,6 +112,39 @@ extension Dlc {
         /// spark作业集群session资源配置模板
         public let sessionResourceTemplate: SessionResourceTemplate?
 
+        public init(engineType: String, dataEngineName: String, clusterType: String, mode: Int64, autoResume: Bool, minClusters: Int64? = nil, maxClusters: Int64? = nil, cidrBlock: String? = nil, message: String? = nil, size: Int64? = nil, payMode: Int64? = nil, timeSpan: Int64? = nil, timeUnit: String? = nil, autoRenew: Int64? = nil, tags: [TagInfo]? = nil, autoSuspend: Bool? = nil, crontabResumeSuspend: Int64? = nil, crontabResumeSuspendStrategy: CrontabResumeSuspendStrategy? = nil, engineExecType: String? = nil, maxConcurrency: Int64? = nil, tolerableQueueTime: Int64? = nil, autoSuspendTime: Int64? = nil, resourceType: String? = nil, dataEngineConfigPairs: [DataEngineConfigPair]? = nil, imageVersionName: String? = nil, mainClusterName: String? = nil, elasticSwitch: Bool? = nil, elasticLimit: Int64? = nil, sessionResourceTemplate: SessionResourceTemplate? = nil) {
+            self.engineType = engineType
+            self.dataEngineName = dataEngineName
+            self.clusterType = clusterType
+            self.mode = mode
+            self.autoResume = autoResume
+            self.minClusters = minClusters
+            self.maxClusters = maxClusters
+            self.cidrBlock = cidrBlock
+            self.message = message
+            self.size = size
+            self.payMode = payMode
+            self.timeSpan = timeSpan
+            self.timeUnit = timeUnit
+            self.autoRenew = autoRenew
+            self.tags = tags
+            self.autoSuspend = autoSuspend
+            self.crontabResumeSuspend = crontabResumeSuspend
+            self.crontabResumeSuspendStrategy = crontabResumeSuspendStrategy
+            self.engineExecType = engineExecType
+            self.maxConcurrency = maxConcurrency
+            self.tolerableQueueTime = tolerableQueueTime
+            self.autoSuspendTime = autoSuspendTime
+            self.resourceType = resourceType
+            self.dataEngineConfigPairs = dataEngineConfigPairs
+            self.imageVersionName = imageVersionName
+            self.mainClusterName = mainClusterName
+            self.elasticSwitch = elasticSwitch
+            self.elasticLimit = elasticLimit
+            self.sessionResourceTemplate = sessionResourceTemplate
+        }
+
+        @available(*, deprecated, renamed: "init(engineType:dataEngineName:clusterType:mode:autoResume:minClusters:maxClusters:cidrBlock:message:size:payMode:timeSpan:timeUnit:autoRenew:tags:autoSuspend:crontabResumeSuspend:crontabResumeSuspendStrategy:engineExecType:maxConcurrency:tolerableQueueTime:autoSuspendTime:resourceType:dataEngineConfigPairs:imageVersionName:mainClusterName:elasticSwitch:elasticLimit:sessionResourceTemplate:)", message: "'defaultDataEngine' is deprecated in 'CreateDataEngineRequest'. Setting this parameter has no effect.")
         public init(engineType: String, dataEngineName: String, clusterType: String, mode: Int64, autoResume: Bool, minClusters: Int64? = nil, maxClusters: Int64? = nil, defaultDataEngine: Bool? = nil, cidrBlock: String? = nil, message: String? = nil, size: Int64? = nil, payMode: Int64? = nil, timeSpan: Int64? = nil, timeUnit: String? = nil, autoRenew: Int64? = nil, tags: [TagInfo]? = nil, autoSuspend: Bool? = nil, crontabResumeSuspend: Int64? = nil, crontabResumeSuspendStrategy: CrontabResumeSuspendStrategy? = nil, engineExecType: String? = nil, maxConcurrency: Int64? = nil, tolerableQueueTime: Int64? = nil, autoSuspendTime: Int64? = nil, resourceType: String? = nil, dataEngineConfigPairs: [DataEngineConfigPair]? = nil, imageVersionName: String? = nil, mainClusterName: String? = nil, elasticSwitch: Bool? = nil, elasticLimit: Int64? = nil, sessionResourceTemplate: SessionResourceTemplate? = nil) {
             self.engineType = engineType
             self.dataEngineName = dataEngineName
@@ -119,7 +153,6 @@ extension Dlc {
             self.autoResume = autoResume
             self.minClusters = minClusters
             self.maxClusters = maxClusters
-            self.defaultDataEngine = defaultDataEngine
             self.cidrBlock = cidrBlock
             self.message = message
             self.size = size
@@ -212,6 +245,15 @@ extension Dlc {
     ///
     /// 为用户创建数据引擎
     @inlinable
+    public func createDataEngine(engineType: String, dataEngineName: String, clusterType: String, mode: Int64, autoResume: Bool, minClusters: Int64? = nil, maxClusters: Int64? = nil, cidrBlock: String? = nil, message: String? = nil, size: Int64? = nil, payMode: Int64? = nil, timeSpan: Int64? = nil, timeUnit: String? = nil, autoRenew: Int64? = nil, tags: [TagInfo]? = nil, autoSuspend: Bool? = nil, crontabResumeSuspend: Int64? = nil, crontabResumeSuspendStrategy: CrontabResumeSuspendStrategy? = nil, engineExecType: String? = nil, maxConcurrency: Int64? = nil, tolerableQueueTime: Int64? = nil, autoSuspendTime: Int64? = nil, resourceType: String? = nil, dataEngineConfigPairs: [DataEngineConfigPair]? = nil, imageVersionName: String? = nil, mainClusterName: String? = nil, elasticSwitch: Bool? = nil, elasticLimit: Int64? = nil, sessionResourceTemplate: SessionResourceTemplate? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<CreateDataEngineResponse> {
+        self.createDataEngine(.init(engineType: engineType, dataEngineName: dataEngineName, clusterType: clusterType, mode: mode, autoResume: autoResume, minClusters: minClusters, maxClusters: maxClusters, cidrBlock: cidrBlock, message: message, size: size, payMode: payMode, timeSpan: timeSpan, timeUnit: timeUnit, autoRenew: autoRenew, tags: tags, autoSuspend: autoSuspend, crontabResumeSuspend: crontabResumeSuspend, crontabResumeSuspendStrategy: crontabResumeSuspendStrategy, engineExecType: engineExecType, maxConcurrency: maxConcurrency, tolerableQueueTime: tolerableQueueTime, autoSuspendTime: autoSuspendTime, resourceType: resourceType, dataEngineConfigPairs: dataEngineConfigPairs, imageVersionName: imageVersionName, mainClusterName: mainClusterName, elasticSwitch: elasticSwitch, elasticLimit: elasticLimit, sessionResourceTemplate: sessionResourceTemplate), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 创建数据引擎.
+    ///
+    /// 为用户创建数据引擎
+    @available(*, deprecated, renamed: "createDataEngine(engineType:dataEngineName:clusterType:mode:autoResume:minClusters:maxClusters:cidrBlock:message:size:payMode:timeSpan:timeUnit:autoRenew:tags:autoSuspend:crontabResumeSuspend:crontabResumeSuspendStrategy:engineExecType:maxConcurrency:tolerableQueueTime:autoSuspendTime:resourceType:dataEngineConfigPairs:imageVersionName:mainClusterName:elasticSwitch:elasticLimit:sessionResourceTemplate:region:logger:on:)", message: "'defaultDataEngine' is deprecated. Setting this parameter has no effect.")
+    @inlinable
     public func createDataEngine(engineType: String, dataEngineName: String, clusterType: String, mode: Int64, autoResume: Bool, minClusters: Int64? = nil, maxClusters: Int64? = nil, defaultDataEngine: Bool? = nil, cidrBlock: String? = nil, message: String? = nil, size: Int64? = nil, payMode: Int64? = nil, timeSpan: Int64? = nil, timeUnit: String? = nil, autoRenew: Int64? = nil, tags: [TagInfo]? = nil, autoSuspend: Bool? = nil, crontabResumeSuspend: Int64? = nil, crontabResumeSuspendStrategy: CrontabResumeSuspendStrategy? = nil, engineExecType: String? = nil, maxConcurrency: Int64? = nil, tolerableQueueTime: Int64? = nil, autoSuspendTime: Int64? = nil, resourceType: String? = nil, dataEngineConfigPairs: [DataEngineConfigPair]? = nil, imageVersionName: String? = nil, mainClusterName: String? = nil, elasticSwitch: Bool? = nil, elasticLimit: Int64? = nil, sessionResourceTemplate: SessionResourceTemplate? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<CreateDataEngineResponse> {
         self.createDataEngine(.init(engineType: engineType, dataEngineName: dataEngineName, clusterType: clusterType, mode: mode, autoResume: autoResume, minClusters: minClusters, maxClusters: maxClusters, defaultDataEngine: defaultDataEngine, cidrBlock: cidrBlock, message: message, size: size, payMode: payMode, timeSpan: timeSpan, timeUnit: timeUnit, autoRenew: autoRenew, tags: tags, autoSuspend: autoSuspend, crontabResumeSuspend: crontabResumeSuspend, crontabResumeSuspendStrategy: crontabResumeSuspendStrategy, engineExecType: engineExecType, maxConcurrency: maxConcurrency, tolerableQueueTime: tolerableQueueTime, autoSuspendTime: autoSuspendTime, resourceType: resourceType, dataEngineConfigPairs: dataEngineConfigPairs, imageVersionName: imageVersionName, mainClusterName: mainClusterName, elasticSwitch: elasticSwitch, elasticLimit: elasticLimit, sessionResourceTemplate: sessionResourceTemplate), region: region, logger: logger, on: eventLoop)
     }
@@ -219,6 +261,15 @@ extension Dlc {
     /// 创建数据引擎.
     ///
     /// 为用户创建数据引擎
+    @inlinable
+    public func createDataEngine(engineType: String, dataEngineName: String, clusterType: String, mode: Int64, autoResume: Bool, minClusters: Int64? = nil, maxClusters: Int64? = nil, cidrBlock: String? = nil, message: String? = nil, size: Int64? = nil, payMode: Int64? = nil, timeSpan: Int64? = nil, timeUnit: String? = nil, autoRenew: Int64? = nil, tags: [TagInfo]? = nil, autoSuspend: Bool? = nil, crontabResumeSuspend: Int64? = nil, crontabResumeSuspendStrategy: CrontabResumeSuspendStrategy? = nil, engineExecType: String? = nil, maxConcurrency: Int64? = nil, tolerableQueueTime: Int64? = nil, autoSuspendTime: Int64? = nil, resourceType: String? = nil, dataEngineConfigPairs: [DataEngineConfigPair]? = nil, imageVersionName: String? = nil, mainClusterName: String? = nil, elasticSwitch: Bool? = nil, elasticLimit: Int64? = nil, sessionResourceTemplate: SessionResourceTemplate? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> CreateDataEngineResponse {
+        try await self.createDataEngine(.init(engineType: engineType, dataEngineName: dataEngineName, clusterType: clusterType, mode: mode, autoResume: autoResume, minClusters: minClusters, maxClusters: maxClusters, cidrBlock: cidrBlock, message: message, size: size, payMode: payMode, timeSpan: timeSpan, timeUnit: timeUnit, autoRenew: autoRenew, tags: tags, autoSuspend: autoSuspend, crontabResumeSuspend: crontabResumeSuspend, crontabResumeSuspendStrategy: crontabResumeSuspendStrategy, engineExecType: engineExecType, maxConcurrency: maxConcurrency, tolerableQueueTime: tolerableQueueTime, autoSuspendTime: autoSuspendTime, resourceType: resourceType, dataEngineConfigPairs: dataEngineConfigPairs, imageVersionName: imageVersionName, mainClusterName: mainClusterName, elasticSwitch: elasticSwitch, elasticLimit: elasticLimit, sessionResourceTemplate: sessionResourceTemplate), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 创建数据引擎.
+    ///
+    /// 为用户创建数据引擎
+    @available(*, deprecated, renamed: "createDataEngine(engineType:dataEngineName:clusterType:mode:autoResume:minClusters:maxClusters:cidrBlock:message:size:payMode:timeSpan:timeUnit:autoRenew:tags:autoSuspend:crontabResumeSuspend:crontabResumeSuspendStrategy:engineExecType:maxConcurrency:tolerableQueueTime:autoSuspendTime:resourceType:dataEngineConfigPairs:imageVersionName:mainClusterName:elasticSwitch:elasticLimit:sessionResourceTemplate:region:logger:on:)", message: "'defaultDataEngine' is deprecated. Setting this parameter has no effect.")
     @inlinable
     public func createDataEngine(engineType: String, dataEngineName: String, clusterType: String, mode: Int64, autoResume: Bool, minClusters: Int64? = nil, maxClusters: Int64? = nil, defaultDataEngine: Bool? = nil, cidrBlock: String? = nil, message: String? = nil, size: Int64? = nil, payMode: Int64? = nil, timeSpan: Int64? = nil, timeUnit: String? = nil, autoRenew: Int64? = nil, tags: [TagInfo]? = nil, autoSuspend: Bool? = nil, crontabResumeSuspend: Int64? = nil, crontabResumeSuspendStrategy: CrontabResumeSuspendStrategy? = nil, engineExecType: String? = nil, maxConcurrency: Int64? = nil, tolerableQueueTime: Int64? = nil, autoSuspendTime: Int64? = nil, resourceType: String? = nil, dataEngineConfigPairs: [DataEngineConfigPair]? = nil, imageVersionName: String? = nil, mainClusterName: String? = nil, elasticSwitch: Bool? = nil, elasticLimit: Int64? = nil, sessionResourceTemplate: SessionResourceTemplate? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> CreateDataEngineResponse {
         try await self.createDataEngine(.init(engineType: engineType, dataEngineName: dataEngineName, clusterType: clusterType, mode: mode, autoResume: autoResume, minClusters: minClusters, maxClusters: maxClusters, defaultDataEngine: defaultDataEngine, cidrBlock: cidrBlock, message: message, size: size, payMode: payMode, timeSpan: timeSpan, timeUnit: timeUnit, autoRenew: autoRenew, tags: tags, autoSuspend: autoSuspend, crontabResumeSuspend: crontabResumeSuspend, crontabResumeSuspendStrategy: crontabResumeSuspendStrategy, engineExecType: engineExecType, maxConcurrency: maxConcurrency, tolerableQueueTime: tolerableQueueTime, autoSuspendTime: autoSuspendTime, resourceType: resourceType, dataEngineConfigPairs: dataEngineConfigPairs, imageVersionName: imageVersionName, mainClusterName: mainClusterName, elasticSwitch: elasticSwitch, elasticLimit: elasticLimit, sessionResourceTemplate: sessionResourceTemplate), region: region, logger: logger, on: eventLoop)

--- a/Sources/Teco/Ess/V20201111/actions/CreateConvertTaskApi.swift
+++ b/Sources/Teco/Ess/V20201111/actions/CreateConvertTaskApi.swift
@@ -34,18 +34,26 @@ extension Ess {
         public let `operator`: UserInfo?
 
         /// 应用号信息
-        public let agent: Agent?
+        @available(*, deprecated)
+        public let agent: Agent? = nil
 
         /// 暂未开放
-        public let organization: OrganizationInfo?
+        @available(*, deprecated)
+        public let organization: OrganizationInfo? = nil
 
+        public init(resourceType: String, resourceName: String, resourceId: String, operator: UserInfo? = nil) {
+            self.resourceType = resourceType
+            self.resourceName = resourceName
+            self.resourceId = resourceId
+            self.operator = `operator`
+        }
+
+        @available(*, deprecated, renamed: "init(resourceType:resourceName:resourceId:operator:)", message: "'agent' and 'organization' are deprecated in 'CreateConvertTaskApiRequest'. Setting these parameters has no effect.")
         public init(resourceType: String, resourceName: String, resourceId: String, operator: UserInfo? = nil, agent: Agent? = nil, organization: OrganizationInfo? = nil) {
             self.resourceType = resourceType
             self.resourceName = resourceName
             self.resourceId = resourceId
             self.operator = `operator`
-            self.agent = agent
-            self.organization = organization
         }
 
         enum CodingKeys: String, CodingKey {
@@ -92,6 +100,15 @@ extension Ess {
     ///
     /// 上传了word、excel、图片文件后，通过该接口发起文件转换任务，将word、excel、图片文件转换为pdf文件。
     @inlinable
+    public func createConvertTaskApi(resourceType: String, resourceName: String, resourceId: String, operator: UserInfo? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<CreateConvertTaskApiResponse> {
+        self.createConvertTaskApi(.init(resourceType: resourceType, resourceName: resourceName, resourceId: resourceId, operator: `operator`), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 创建文件转换任务
+    ///
+    /// 上传了word、excel、图片文件后，通过该接口发起文件转换任务，将word、excel、图片文件转换为pdf文件。
+    @available(*, deprecated, renamed: "createConvertTaskApi(resourceType:resourceName:resourceId:operator:region:logger:on:)", message: "'agent' and 'organization' are deprecated. Setting these parameters has no effect.")
+    @inlinable
     public func createConvertTaskApi(resourceType: String, resourceName: String, resourceId: String, operator: UserInfo? = nil, agent: Agent? = nil, organization: OrganizationInfo? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<CreateConvertTaskApiResponse> {
         self.createConvertTaskApi(.init(resourceType: resourceType, resourceName: resourceName, resourceId: resourceId, operator: `operator`, agent: agent, organization: organization), region: region, logger: logger, on: eventLoop)
     }
@@ -99,6 +116,15 @@ extension Ess {
     /// 创建文件转换任务
     ///
     /// 上传了word、excel、图片文件后，通过该接口发起文件转换任务，将word、excel、图片文件转换为pdf文件。
+    @inlinable
+    public func createConvertTaskApi(resourceType: String, resourceName: String, resourceId: String, operator: UserInfo? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> CreateConvertTaskApiResponse {
+        try await self.createConvertTaskApi(.init(resourceType: resourceType, resourceName: resourceName, resourceId: resourceId, operator: `operator`), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 创建文件转换任务
+    ///
+    /// 上传了word、excel、图片文件后，通过该接口发起文件转换任务，将word、excel、图片文件转换为pdf文件。
+    @available(*, deprecated, renamed: "createConvertTaskApi(resourceType:resourceName:resourceId:operator:region:logger:on:)", message: "'agent' and 'organization' are deprecated. Setting these parameters has no effect.")
     @inlinable
     public func createConvertTaskApi(resourceType: String, resourceName: String, resourceId: String, operator: UserInfo? = nil, agent: Agent? = nil, organization: OrganizationInfo? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> CreateConvertTaskApiResponse {
         try await self.createConvertTaskApi(.init(resourceType: resourceType, resourceName: resourceName, resourceId: resourceId, operator: `operator`, agent: agent, organization: organization), region: region, logger: logger, on: eventLoop)

--- a/Sources/Teco/Ess/V20201111/actions/CreateFlow.swift
+++ b/Sources/Teco/Ess/V20201111/actions/CreateFlow.swift
@@ -76,11 +76,32 @@ extension Ess {
         public let autoSignScene: String?
 
         /// 暂未开放
-        public let relatedFlowId: String?
+        @available(*, deprecated)
+        public let relatedFlowId: String? = nil
 
         /// 暂未开放
-        public let callbackUrl: String?
+        @available(*, deprecated)
+        public let callbackUrl: String? = nil
 
+        public init(operator: UserInfo, flowName: String, approvers: [FlowCreateApprover], flowType: String? = nil, clientToken: String? = nil, deadLine: Int64? = nil, remindedOn: Int64? = nil, userData: String? = nil, flowDescription: String? = nil, unordered: Bool? = nil, customShowMap: String? = nil, needSignReview: Bool? = nil, agent: Agent? = nil, ccInfos: [CcInfo]? = nil, autoSignScene: String? = nil) {
+            self.operator = `operator`
+            self.flowName = flowName
+            self.approvers = approvers
+            self.flowType = flowType
+            self.clientToken = clientToken
+            self.deadLine = deadLine
+            self.remindedOn = remindedOn
+            self.userData = userData
+            self.flowDescription = flowDescription
+            self.unordered = unordered
+            self.customShowMap = customShowMap
+            self.needSignReview = needSignReview
+            self.agent = agent
+            self.ccInfos = ccInfos
+            self.autoSignScene = autoSignScene
+        }
+
+        @available(*, deprecated, renamed: "init(operator:flowName:approvers:flowType:clientToken:deadLine:remindedOn:userData:flowDescription:unordered:customShowMap:needSignReview:agent:ccInfos:autoSignScene:)", message: "'relatedFlowId' and 'callbackUrl' are deprecated in 'CreateFlowRequest'. Setting these parameters has no effect.")
         public init(operator: UserInfo, flowName: String, approvers: [FlowCreateApprover], flowType: String? = nil, clientToken: String? = nil, deadLine: Int64? = nil, remindedOn: Int64? = nil, userData: String? = nil, flowDescription: String? = nil, unordered: Bool? = nil, customShowMap: String? = nil, needSignReview: Bool? = nil, agent: Agent? = nil, ccInfos: [CcInfo]? = nil, autoSignScene: String? = nil, relatedFlowId: String? = nil, callbackUrl: String? = nil) {
             self.operator = `operator`
             self.flowName = flowName
@@ -97,8 +118,6 @@ extension Ess {
             self.agent = agent
             self.ccInfos = ccInfos
             self.autoSignScene = autoSignScene
-            self.relatedFlowId = relatedFlowId
-            self.callbackUrl = callbackUrl
         }
 
         enum CodingKeys: String, CodingKey {
@@ -165,6 +184,18 @@ extension Ess {
     /// 注：该接口是通过模板生成合同流程的前置接口，先创建一个不包含签署文件的流程。<br/>
     /// 配合“创建电子文档”接口和“发起流程”接口使用。<br/>
     @inlinable
+    public func createFlow(operator: UserInfo, flowName: String, approvers: [FlowCreateApprover], flowType: String? = nil, clientToken: String? = nil, deadLine: Int64? = nil, remindedOn: Int64? = nil, userData: String? = nil, flowDescription: String? = nil, unordered: Bool? = nil, customShowMap: String? = nil, needSignReview: Bool? = nil, agent: Agent? = nil, ccInfos: [CcInfo]? = nil, autoSignScene: String? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<CreateFlowResponse> {
+        self.createFlow(.init(operator: `operator`, flowName: flowName, approvers: approvers, flowType: flowType, clientToken: clientToken, deadLine: deadLine, remindedOn: remindedOn, userData: userData, flowDescription: flowDescription, unordered: unordered, customShowMap: customShowMap, needSignReview: needSignReview, agent: agent, ccInfos: ccInfos, autoSignScene: autoSignScene), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 模板发起合同-创建签署流程
+    ///
+    /// 通过模板创建签署流程<br/>
+    /// 适用场景：在标准制式的合同场景中，可通过提前预制好模板文件，每次调用模板文件的id，补充合同内容信息及签署信息生成电子合同。<br/>
+    /// 注：该接口是通过模板生成合同流程的前置接口，先创建一个不包含签署文件的流程。<br/>
+    /// 配合“创建电子文档”接口和“发起流程”接口使用。<br/>
+    @available(*, deprecated, renamed: "createFlow(operator:flowName:approvers:flowType:clientToken:deadLine:remindedOn:userData:flowDescription:unordered:customShowMap:needSignReview:agent:ccInfos:autoSignScene:region:logger:on:)", message: "'relatedFlowId' and 'callbackUrl' are deprecated. Setting these parameters has no effect.")
+    @inlinable
     public func createFlow(operator: UserInfo, flowName: String, approvers: [FlowCreateApprover], flowType: String? = nil, clientToken: String? = nil, deadLine: Int64? = nil, remindedOn: Int64? = nil, userData: String? = nil, flowDescription: String? = nil, unordered: Bool? = nil, customShowMap: String? = nil, needSignReview: Bool? = nil, agent: Agent? = nil, ccInfos: [CcInfo]? = nil, autoSignScene: String? = nil, relatedFlowId: String? = nil, callbackUrl: String? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<CreateFlowResponse> {
         self.createFlow(.init(operator: `operator`, flowName: flowName, approvers: approvers, flowType: flowType, clientToken: clientToken, deadLine: deadLine, remindedOn: remindedOn, userData: userData, flowDescription: flowDescription, unordered: unordered, customShowMap: customShowMap, needSignReview: needSignReview, agent: agent, ccInfos: ccInfos, autoSignScene: autoSignScene, relatedFlowId: relatedFlowId, callbackUrl: callbackUrl), region: region, logger: logger, on: eventLoop)
     }
@@ -175,6 +206,18 @@ extension Ess {
     /// 适用场景：在标准制式的合同场景中，可通过提前预制好模板文件，每次调用模板文件的id，补充合同内容信息及签署信息生成电子合同。<br/>
     /// 注：该接口是通过模板生成合同流程的前置接口，先创建一个不包含签署文件的流程。<br/>
     /// 配合“创建电子文档”接口和“发起流程”接口使用。<br/>
+    @inlinable
+    public func createFlow(operator: UserInfo, flowName: String, approvers: [FlowCreateApprover], flowType: String? = nil, clientToken: String? = nil, deadLine: Int64? = nil, remindedOn: Int64? = nil, userData: String? = nil, flowDescription: String? = nil, unordered: Bool? = nil, customShowMap: String? = nil, needSignReview: Bool? = nil, agent: Agent? = nil, ccInfos: [CcInfo]? = nil, autoSignScene: String? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> CreateFlowResponse {
+        try await self.createFlow(.init(operator: `operator`, flowName: flowName, approvers: approvers, flowType: flowType, clientToken: clientToken, deadLine: deadLine, remindedOn: remindedOn, userData: userData, flowDescription: flowDescription, unordered: unordered, customShowMap: customShowMap, needSignReview: needSignReview, agent: agent, ccInfos: ccInfos, autoSignScene: autoSignScene), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 模板发起合同-创建签署流程
+    ///
+    /// 通过模板创建签署流程<br/>
+    /// 适用场景：在标准制式的合同场景中，可通过提前预制好模板文件，每次调用模板文件的id，补充合同内容信息及签署信息生成电子合同。<br/>
+    /// 注：该接口是通过模板生成合同流程的前置接口，先创建一个不包含签署文件的流程。<br/>
+    /// 配合“创建电子文档”接口和“发起流程”接口使用。<br/>
+    @available(*, deprecated, renamed: "createFlow(operator:flowName:approvers:flowType:clientToken:deadLine:remindedOn:userData:flowDescription:unordered:customShowMap:needSignReview:agent:ccInfos:autoSignScene:region:logger:on:)", message: "'relatedFlowId' and 'callbackUrl' are deprecated. Setting these parameters has no effect.")
     @inlinable
     public func createFlow(operator: UserInfo, flowName: String, approvers: [FlowCreateApprover], flowType: String? = nil, clientToken: String? = nil, deadLine: Int64? = nil, remindedOn: Int64? = nil, userData: String? = nil, flowDescription: String? = nil, unordered: Bool? = nil, customShowMap: String? = nil, needSignReview: Bool? = nil, agent: Agent? = nil, ccInfos: [CcInfo]? = nil, autoSignScene: String? = nil, relatedFlowId: String? = nil, callbackUrl: String? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> CreateFlowResponse {
         try await self.createFlow(.init(operator: `operator`, flowName: flowName, approvers: approvers, flowType: flowType, clientToken: clientToken, deadLine: deadLine, remindedOn: remindedOn, userData: userData, flowDescription: flowDescription, unordered: unordered, customShowMap: customShowMap, needSignReview: needSignReview, agent: agent, ccInfos: ccInfos, autoSignScene: autoSignScene, relatedFlowId: relatedFlowId, callbackUrl: callbackUrl), region: region, logger: logger, on: eventLoop)

--- a/Sources/Teco/Ess/V20201111/actions/CreateFlowSignUrl.swift
+++ b/Sources/Teco/Ess/V20201111/actions/CreateFlowSignUrl.swift
@@ -36,17 +36,26 @@ extension Ess {
         public let agent: Agent?
 
         /// 机构信息，暂未开放
-        public let organization: OrganizationInfo?
+        @available(*, deprecated)
+        public let organization: OrganizationInfo? = nil
 
         /// 签署完之后的H5页面的跳转链接，此链接支持http://和https://，最大长度1000个字符。
         public let jumpUrl: String?
 
+        public init(flowId: String, flowApproverInfos: [FlowCreateApprover], operator: UserInfo? = nil, agent: Agent? = nil, jumpUrl: String? = nil) {
+            self.flowId = flowId
+            self.flowApproverInfos = flowApproverInfos
+            self.operator = `operator`
+            self.agent = agent
+            self.jumpUrl = jumpUrl
+        }
+
+        @available(*, deprecated, renamed: "init(flowId:flowApproverInfos:operator:agent:jumpUrl:)", message: "'organization' is deprecated in 'CreateFlowSignUrlRequest'. Setting this parameter has no effect.")
         public init(flowId: String, flowApproverInfos: [FlowCreateApprover], operator: UserInfo? = nil, agent: Agent? = nil, organization: OrganizationInfo? = nil, jumpUrl: String? = nil) {
             self.flowId = flowId
             self.flowApproverInfos = flowApproverInfos
             self.operator = `operator`
             self.agent = agent
-            self.organization = organization
             self.jumpUrl = jumpUrl
         }
 
@@ -112,6 +121,21 @@ extension Ess {
     /// 注意：该接口可生成签署链接的C端签署人必须仅有手写签名和时间类型的签署控件<br/>
     /// 注意：该接口返回的签署链接是用于APP集成的场景，支持APP打开或浏览器直接打开，不支持微信小程序嵌入。微信小程序请使用小程序跳转或半屏弹窗的方式<br/>
     @inlinable
+    public func createFlowSignUrl(flowId: String, flowApproverInfos: [FlowCreateApprover], operator: UserInfo? = nil, agent: Agent? = nil, jumpUrl: String? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<CreateFlowSignUrlResponse> {
+        self.createFlowSignUrl(.init(flowId: flowId, flowApproverInfos: flowApproverInfos, operator: `operator`, agent: agent, jumpUrl: jumpUrl), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 创建个人用户H5签署链接
+    ///
+    /// 创建个人H5签署链接，请联系客户经理申请开通使用, 否则调用会返回失败 <br/>
+    ///
+    /// 该接口用于发起合同后，生成个人签署人的签署链接, 暂时不支持企业端签署 <br/>
+    ///
+    /// 注意：该接口目前签署人类型仅支持个人签署方（PERSON） <br/>
+    /// 注意：该接口可生成签署链接的C端签署人必须仅有手写签名和时间类型的签署控件<br/>
+    /// 注意：该接口返回的签署链接是用于APP集成的场景，支持APP打开或浏览器直接打开，不支持微信小程序嵌入。微信小程序请使用小程序跳转或半屏弹窗的方式<br/>
+    @available(*, deprecated, renamed: "createFlowSignUrl(flowId:flowApproverInfos:operator:agent:jumpUrl:region:logger:on:)", message: "'organization' is deprecated. Setting this parameter has no effect.")
+    @inlinable
     public func createFlowSignUrl(flowId: String, flowApproverInfos: [FlowCreateApprover], operator: UserInfo? = nil, agent: Agent? = nil, organization: OrganizationInfo? = nil, jumpUrl: String? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<CreateFlowSignUrlResponse> {
         self.createFlowSignUrl(.init(flowId: flowId, flowApproverInfos: flowApproverInfos, operator: `operator`, agent: agent, organization: organization, jumpUrl: jumpUrl), region: region, logger: logger, on: eventLoop)
     }
@@ -125,6 +149,21 @@ extension Ess {
     /// 注意：该接口目前签署人类型仅支持个人签署方（PERSON） <br/>
     /// 注意：该接口可生成签署链接的C端签署人必须仅有手写签名和时间类型的签署控件<br/>
     /// 注意：该接口返回的签署链接是用于APP集成的场景，支持APP打开或浏览器直接打开，不支持微信小程序嵌入。微信小程序请使用小程序跳转或半屏弹窗的方式<br/>
+    @inlinable
+    public func createFlowSignUrl(flowId: String, flowApproverInfos: [FlowCreateApprover], operator: UserInfo? = nil, agent: Agent? = nil, jumpUrl: String? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> CreateFlowSignUrlResponse {
+        try await self.createFlowSignUrl(.init(flowId: flowId, flowApproverInfos: flowApproverInfos, operator: `operator`, agent: agent, jumpUrl: jumpUrl), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 创建个人用户H5签署链接
+    ///
+    /// 创建个人H5签署链接，请联系客户经理申请开通使用, 否则调用会返回失败 <br/>
+    ///
+    /// 该接口用于发起合同后，生成个人签署人的签署链接, 暂时不支持企业端签署 <br/>
+    ///
+    /// 注意：该接口目前签署人类型仅支持个人签署方（PERSON） <br/>
+    /// 注意：该接口可生成签署链接的C端签署人必须仅有手写签名和时间类型的签署控件<br/>
+    /// 注意：该接口返回的签署链接是用于APP集成的场景，支持APP打开或浏览器直接打开，不支持微信小程序嵌入。微信小程序请使用小程序跳转或半屏弹窗的方式<br/>
+    @available(*, deprecated, renamed: "createFlowSignUrl(flowId:flowApproverInfos:operator:agent:jumpUrl:region:logger:on:)", message: "'organization' is deprecated. Setting this parameter has no effect.")
     @inlinable
     public func createFlowSignUrl(flowId: String, flowApproverInfos: [FlowCreateApprover], operator: UserInfo? = nil, agent: Agent? = nil, organization: OrganizationInfo? = nil, jumpUrl: String? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> CreateFlowSignUrlResponse {
         try await self.createFlowSignUrl(.init(flowId: flowId, flowApproverInfos: flowApproverInfos, operator: `operator`, agent: agent, organization: organization, jumpUrl: jumpUrl), region: region, logger: logger, on: eventLoop)

--- a/Sources/Teco/Ess/V20201111/actions/CreateMultiFlowSignQRCode.swift
+++ b/Sources/Teco/Ess/V20201111/actions/CreateMultiFlowSignQRCode.swift
@@ -55,11 +55,26 @@ extension Ess {
         public let callbackUrl: String?
 
         /// 应用信息
-        public let agent: Agent?
+        @available(*, deprecated)
+        public let agent: Agent? = nil
 
         /// 限制二维码用户条件（已弃用）
-        public let approverRestrictions: ApproverRestriction?
+        @available(*, deprecated)
+        public let approverRestrictions: ApproverRestriction? = nil
 
+        public init(operator: UserInfo, templateId: String, flowName: String, maxFlowNum: Int64? = nil, flowEffectiveDay: Int64? = nil, qrEffectiveDay: Int64? = nil, restrictions: [ApproverRestriction]? = nil, userData: String? = nil, callbackUrl: String? = nil) {
+            self.operator = `operator`
+            self.templateId = templateId
+            self.flowName = flowName
+            self.maxFlowNum = maxFlowNum
+            self.flowEffectiveDay = flowEffectiveDay
+            self.qrEffectiveDay = qrEffectiveDay
+            self.restrictions = restrictions
+            self.userData = userData
+            self.callbackUrl = callbackUrl
+        }
+
+        @available(*, deprecated, renamed: "init(operator:templateId:flowName:maxFlowNum:flowEffectiveDay:qrEffectiveDay:restrictions:userData:callbackUrl:)", message: "'agent' and 'approverRestrictions' are deprecated in 'CreateMultiFlowSignQRCodeRequest'. Setting these parameters has no effect.")
         public init(operator: UserInfo, templateId: String, flowName: String, maxFlowNum: Int64? = nil, flowEffectiveDay: Int64? = nil, qrEffectiveDay: Int64? = nil, restrictions: [ApproverRestriction]? = nil, userData: String? = nil, callbackUrl: String? = nil, agent: Agent? = nil, approverRestrictions: ApproverRestriction? = nil) {
             self.operator = `operator`
             self.templateId = templateId
@@ -70,8 +85,6 @@ extension Ess {
             self.restrictions = restrictions
             self.userData = userData
             self.callbackUrl = callbackUrl
-            self.agent = agent
-            self.approverRestrictions = approverRestrictions
         }
 
         enum CodingKeys: String, CodingKey {
@@ -151,6 +164,23 @@ extension Ess {
     /// - B端企业的签署方式是静默签署
     /// - B端企业是非首位签署
     @inlinable
+    public func createMultiFlowSignQRCode(operator: UserInfo, templateId: String, flowName: String, maxFlowNum: Int64? = nil, flowEffectiveDay: Int64? = nil, qrEffectiveDay: Int64? = nil, restrictions: [ApproverRestriction]? = nil, userData: String? = nil, callbackUrl: String? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<CreateMultiFlowSignQRCodeResponse> {
+        self.createMultiFlowSignQRCode(.init(operator: `operator`, templateId: templateId, flowName: flowName, maxFlowNum: maxFlowNum, flowEffectiveDay: flowEffectiveDay, qrEffectiveDay: qrEffectiveDay, restrictions: restrictions, userData: userData, callbackUrl: callbackUrl), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 创建一码多扫流程签署二维码
+    ///
+    /// 此接口（CreateMultiFlowSignQRCode）用于创建一码多扫流程签署二维码。
+    /// 适用场景：无需填写签署人信息，可通过模板id生成签署二维码，签署人可通过扫描二维码补充签署信息进行实名签署。常用于提前不知道签署人的身份信息场景，例如：劳务工招工、大批量员工入职等场景。
+    ///
+    /// **本接口适用于发起方没有填写控件的 B2C或者单C模板**
+    ///
+    /// **若是B2C模板,还要满足以下任意一个条件**
+    /// - 模板中配置的签署顺序是无序
+    /// - B端企业的签署方式是静默签署
+    /// - B端企业是非首位签署
+    @available(*, deprecated, renamed: "createMultiFlowSignQRCode(operator:templateId:flowName:maxFlowNum:flowEffectiveDay:qrEffectiveDay:restrictions:userData:callbackUrl:region:logger:on:)", message: "'agent' and 'approverRestrictions' are deprecated. Setting these parameters has no effect.")
+    @inlinable
     public func createMultiFlowSignQRCode(operator: UserInfo, templateId: String, flowName: String, maxFlowNum: Int64? = nil, flowEffectiveDay: Int64? = nil, qrEffectiveDay: Int64? = nil, restrictions: [ApproverRestriction]? = nil, userData: String? = nil, callbackUrl: String? = nil, agent: Agent? = nil, approverRestrictions: ApproverRestriction? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<CreateMultiFlowSignQRCodeResponse> {
         self.createMultiFlowSignQRCode(.init(operator: `operator`, templateId: templateId, flowName: flowName, maxFlowNum: maxFlowNum, flowEffectiveDay: flowEffectiveDay, qrEffectiveDay: qrEffectiveDay, restrictions: restrictions, userData: userData, callbackUrl: callbackUrl, agent: agent, approverRestrictions: approverRestrictions), region: region, logger: logger, on: eventLoop)
     }
@@ -166,6 +196,23 @@ extension Ess {
     /// - 模板中配置的签署顺序是无序
     /// - B端企业的签署方式是静默签署
     /// - B端企业是非首位签署
+    @inlinable
+    public func createMultiFlowSignQRCode(operator: UserInfo, templateId: String, flowName: String, maxFlowNum: Int64? = nil, flowEffectiveDay: Int64? = nil, qrEffectiveDay: Int64? = nil, restrictions: [ApproverRestriction]? = nil, userData: String? = nil, callbackUrl: String? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> CreateMultiFlowSignQRCodeResponse {
+        try await self.createMultiFlowSignQRCode(.init(operator: `operator`, templateId: templateId, flowName: flowName, maxFlowNum: maxFlowNum, flowEffectiveDay: flowEffectiveDay, qrEffectiveDay: qrEffectiveDay, restrictions: restrictions, userData: userData, callbackUrl: callbackUrl), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 创建一码多扫流程签署二维码
+    ///
+    /// 此接口（CreateMultiFlowSignQRCode）用于创建一码多扫流程签署二维码。
+    /// 适用场景：无需填写签署人信息，可通过模板id生成签署二维码，签署人可通过扫描二维码补充签署信息进行实名签署。常用于提前不知道签署人的身份信息场景，例如：劳务工招工、大批量员工入职等场景。
+    ///
+    /// **本接口适用于发起方没有填写控件的 B2C或者单C模板**
+    ///
+    /// **若是B2C模板,还要满足以下任意一个条件**
+    /// - 模板中配置的签署顺序是无序
+    /// - B端企业的签署方式是静默签署
+    /// - B端企业是非首位签署
+    @available(*, deprecated, renamed: "createMultiFlowSignQRCode(operator:templateId:flowName:maxFlowNum:flowEffectiveDay:qrEffectiveDay:restrictions:userData:callbackUrl:region:logger:on:)", message: "'agent' and 'approverRestrictions' are deprecated. Setting these parameters has no effect.")
     @inlinable
     public func createMultiFlowSignQRCode(operator: UserInfo, templateId: String, flowName: String, maxFlowNum: Int64? = nil, flowEffectiveDay: Int64? = nil, qrEffectiveDay: Int64? = nil, restrictions: [ApproverRestriction]? = nil, userData: String? = nil, callbackUrl: String? = nil, agent: Agent? = nil, approverRestrictions: ApproverRestriction? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> CreateMultiFlowSignQRCodeResponse {
         try await self.createMultiFlowSignQRCode(.init(operator: `operator`, templateId: templateId, flowName: flowName, maxFlowNum: maxFlowNum, flowEffectiveDay: flowEffectiveDay, qrEffectiveDay: qrEffectiveDay, restrictions: restrictions, userData: userData, callbackUrl: callbackUrl, agent: agent, approverRestrictions: approverRestrictions), region: region, logger: logger, on: eventLoop)

--- a/Sources/Teco/Ess/V20201111/actions/CreatePreparedPersonalEsign.swift
+++ b/Sources/Teco/Ess/V20201111/actions/CreatePreparedPersonalEsign.swift
@@ -44,7 +44,8 @@ extension Ess {
         /// 印章图片的base64
         /// 注：已废弃
         /// 请先通过UploadFiles接口上传文件，获取 FileId
-        public let sealImage: String?
+        @available(*, deprecated)
+        public let sealImage: String? = nil
 
         /// 是否开启印章图片压缩处理，默认不开启，如需开启请设置为 true。当印章超过 2M 时建议开启，开启后图片的 hash 将发生变化。
         public let sealImageCompress: Bool?
@@ -74,13 +75,27 @@ extension Ess {
         /// 填写的FileId通过UploadFiles接口上传文件获取。
         public let fileId: String?
 
+        public init(userName: String, idCardNumber: String, sealName: String, operator: UserInfo? = nil, idCardType: String? = nil, sealImageCompress: Bool? = nil, mobile: String? = nil, enableAutoSign: Bool? = nil, sealColor: String? = nil, processSeal: Bool? = nil, fileId: String? = nil) {
+            self.userName = userName
+            self.idCardNumber = idCardNumber
+            self.sealName = sealName
+            self.operator = `operator`
+            self.idCardType = idCardType
+            self.sealImageCompress = sealImageCompress
+            self.mobile = mobile
+            self.enableAutoSign = enableAutoSign
+            self.sealColor = sealColor
+            self.processSeal = processSeal
+            self.fileId = fileId
+        }
+
+        @available(*, deprecated, renamed: "init(userName:idCardNumber:sealName:operator:idCardType:sealImageCompress:mobile:enableAutoSign:sealColor:processSeal:fileId:)", message: "'sealImage' is deprecated in 'CreatePreparedPersonalEsignRequest'. Setting this parameter has no effect.")
         public init(userName: String, idCardNumber: String, sealName: String, operator: UserInfo? = nil, idCardType: String? = nil, sealImage: String? = nil, sealImageCompress: Bool? = nil, mobile: String? = nil, enableAutoSign: Bool? = nil, sealColor: String? = nil, processSeal: Bool? = nil, fileId: String? = nil) {
             self.userName = userName
             self.idCardNumber = idCardNumber
             self.sealName = sealName
             self.operator = `operator`
             self.idCardType = idCardType
-            self.sealImage = sealImage
             self.sealImageCompress = sealImageCompress
             self.mobile = mobile
             self.enableAutoSign = enableAutoSign
@@ -139,6 +154,15 @@ extension Ess {
     ///
     /// 本接口（CreatePreparedPersonalEsign）用于创建导入个人印章（处方单场景专用，使用此接口请与客户经理确认）。
     @inlinable
+    public func createPreparedPersonalEsign(userName: String, idCardNumber: String, sealName: String, operator: UserInfo? = nil, idCardType: String? = nil, sealImageCompress: Bool? = nil, mobile: String? = nil, enableAutoSign: Bool? = nil, sealColor: String? = nil, processSeal: Bool? = nil, fileId: String? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<CreatePreparedPersonalEsignResponse> {
+        self.createPreparedPersonalEsign(.init(userName: userName, idCardNumber: idCardNumber, sealName: sealName, operator: `operator`, idCardType: idCardType, sealImageCompress: sealImageCompress, mobile: mobile, enableAutoSign: enableAutoSign, sealColor: sealColor, processSeal: processSeal, fileId: fileId), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 创建导入处方单个人印章
+    ///
+    /// 本接口（CreatePreparedPersonalEsign）用于创建导入个人印章（处方单场景专用，使用此接口请与客户经理确认）。
+    @available(*, deprecated, renamed: "createPreparedPersonalEsign(userName:idCardNumber:sealName:operator:idCardType:sealImageCompress:mobile:enableAutoSign:sealColor:processSeal:fileId:region:logger:on:)", message: "'sealImage' is deprecated. Setting this parameter has no effect.")
+    @inlinable
     public func createPreparedPersonalEsign(userName: String, idCardNumber: String, sealName: String, operator: UserInfo? = nil, idCardType: String? = nil, sealImage: String? = nil, sealImageCompress: Bool? = nil, mobile: String? = nil, enableAutoSign: Bool? = nil, sealColor: String? = nil, processSeal: Bool? = nil, fileId: String? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<CreatePreparedPersonalEsignResponse> {
         self.createPreparedPersonalEsign(.init(userName: userName, idCardNumber: idCardNumber, sealName: sealName, operator: `operator`, idCardType: idCardType, sealImage: sealImage, sealImageCompress: sealImageCompress, mobile: mobile, enableAutoSign: enableAutoSign, sealColor: sealColor, processSeal: processSeal, fileId: fileId), region: region, logger: logger, on: eventLoop)
     }
@@ -146,6 +170,15 @@ extension Ess {
     /// 创建导入处方单个人印章
     ///
     /// 本接口（CreatePreparedPersonalEsign）用于创建导入个人印章（处方单场景专用，使用此接口请与客户经理确认）。
+    @inlinable
+    public func createPreparedPersonalEsign(userName: String, idCardNumber: String, sealName: String, operator: UserInfo? = nil, idCardType: String? = nil, sealImageCompress: Bool? = nil, mobile: String? = nil, enableAutoSign: Bool? = nil, sealColor: String? = nil, processSeal: Bool? = nil, fileId: String? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> CreatePreparedPersonalEsignResponse {
+        try await self.createPreparedPersonalEsign(.init(userName: userName, idCardNumber: idCardNumber, sealName: sealName, operator: `operator`, idCardType: idCardType, sealImageCompress: sealImageCompress, mobile: mobile, enableAutoSign: enableAutoSign, sealColor: sealColor, processSeal: processSeal, fileId: fileId), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 创建导入处方单个人印章
+    ///
+    /// 本接口（CreatePreparedPersonalEsign）用于创建导入个人印章（处方单场景专用，使用此接口请与客户经理确认）。
+    @available(*, deprecated, renamed: "createPreparedPersonalEsign(userName:idCardNumber:sealName:operator:idCardType:sealImageCompress:mobile:enableAutoSign:sealColor:processSeal:fileId:region:logger:on:)", message: "'sealImage' is deprecated. Setting this parameter has no effect.")
     @inlinable
     public func createPreparedPersonalEsign(userName: String, idCardNumber: String, sealName: String, operator: UserInfo? = nil, idCardType: String? = nil, sealImage: String? = nil, sealImageCompress: Bool? = nil, mobile: String? = nil, enableAutoSign: Bool? = nil, sealColor: String? = nil, processSeal: Bool? = nil, fileId: String? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> CreatePreparedPersonalEsignResponse {
         try await self.createPreparedPersonalEsign(.init(userName: userName, idCardNumber: idCardNumber, sealName: sealName, operator: `operator`, idCardType: idCardType, sealImage: sealImage, sealImageCompress: sealImageCompress, mobile: mobile, enableAutoSign: enableAutoSign, sealColor: sealColor, processSeal: processSeal, fileId: fileId), region: region, logger: logger, on: eventLoop)

--- a/Sources/Teco/Ess/V20201111/actions/DescribeFileUrls.swift
+++ b/Sources/Teco/Ess/V20201111/actions/DescribeFileUrls.swift
@@ -52,14 +52,29 @@ extension Ess {
         public let urlTtl: Int64?
 
         /// 暂不开放
-        public let ccToken: String?
+        @available(*, deprecated)
+        public let ccToken: String? = nil
 
         /// 暂不开放
-        public let scene: String?
+        @available(*, deprecated)
+        public let scene: String? = nil
 
         /// 应用相关信息
-        public let agent: Agent?
+        @available(*, deprecated)
+        public let agent: Agent? = nil
 
+        public init(operator: UserInfo, businessType: String, businessIds: [String], fileName: String? = nil, fileType: String? = nil, offset: Int64? = nil, limit: Int64? = nil, urlTtl: Int64? = nil) {
+            self.operator = `operator`
+            self.businessType = businessType
+            self.businessIds = businessIds
+            self.fileName = fileName
+            self.fileType = fileType
+            self.offset = offset
+            self.limit = limit
+            self.urlTtl = urlTtl
+        }
+
+        @available(*, deprecated, renamed: "init(operator:businessType:businessIds:fileName:fileType:offset:limit:urlTtl:)", message: "'ccToken', 'scene' and 'agent' are deprecated in 'DescribeFileUrlsRequest'. Setting these parameters has no effect.")
         public init(operator: UserInfo, businessType: String, businessIds: [String], fileName: String? = nil, fileType: String? = nil, offset: Int64? = nil, limit: Int64? = nil, urlTtl: Int64? = nil, ccToken: String? = nil, scene: String? = nil, agent: Agent? = nil) {
             self.operator = `operator`
             self.businessType = businessType
@@ -69,9 +84,6 @@ extension Ess {
             self.offset = offset
             self.limit = limit
             self.urlTtl = urlTtl
-            self.ccToken = ccToken
-            self.scene = scene
-            self.agent = agent
         }
 
         enum CodingKeys: String, CodingKey {
@@ -93,7 +105,7 @@ extension Ess {
             guard !response.getItems().isEmpty else {
                 return nil
             }
-            return DescribeFileUrlsRequest(operator: self.operator, businessType: self.businessType, businessIds: self.businessIds, fileName: self.fileName, fileType: self.fileType, offset: (self.offset ?? 0) + .init(response.getItems().count), limit: self.limit, urlTtl: self.urlTtl, ccToken: self.ccToken, scene: self.scene, agent: self.agent)
+            return DescribeFileUrlsRequest(operator: self.operator, businessType: self.businessType, businessIds: self.businessIds, fileName: self.fileName, fileType: self.fileType, offset: (self.offset ?? 0) + .init(response.getItems().count), limit: self.limit, urlTtl: self.urlTtl)
         }
     }
 
@@ -149,6 +161,16 @@ extension Ess {
     /// 查询文件下载URL。
     /// 适用场景：通过传参合同流程编号，下载对应的合同PDF文件流到本地。
     @inlinable
+    public func describeFileUrls(operator: UserInfo, businessType: String, businessIds: [String], fileName: String? = nil, fileType: String? = nil, offset: Int64? = nil, limit: Int64? = nil, urlTtl: Int64? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<DescribeFileUrlsResponse> {
+        self.describeFileUrls(.init(operator: `operator`, businessType: businessType, businessIds: businessIds, fileName: fileName, fileType: fileType, offset: offset, limit: limit, urlTtl: urlTtl), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 查询文件下载URL
+    ///
+    /// 查询文件下载URL。
+    /// 适用场景：通过传参合同流程编号，下载对应的合同PDF文件流到本地。
+    @available(*, deprecated, renamed: "describeFileUrls(operator:businessType:businessIds:fileName:fileType:offset:limit:urlTtl:region:logger:on:)", message: "'ccToken', 'scene' and 'agent' are deprecated. Setting these parameters has no effect.")
+    @inlinable
     public func describeFileUrls(operator: UserInfo, businessType: String, businessIds: [String], fileName: String? = nil, fileType: String? = nil, offset: Int64? = nil, limit: Int64? = nil, urlTtl: Int64? = nil, ccToken: String? = nil, scene: String? = nil, agent: Agent? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<DescribeFileUrlsResponse> {
         self.describeFileUrls(.init(operator: `operator`, businessType: businessType, businessIds: businessIds, fileName: fileName, fileType: fileType, offset: offset, limit: limit, urlTtl: urlTtl, ccToken: ccToken, scene: scene, agent: agent), region: region, logger: logger, on: eventLoop)
     }
@@ -157,6 +179,16 @@ extension Ess {
     ///
     /// 查询文件下载URL。
     /// 适用场景：通过传参合同流程编号，下载对应的合同PDF文件流到本地。
+    @inlinable
+    public func describeFileUrls(operator: UserInfo, businessType: String, businessIds: [String], fileName: String? = nil, fileType: String? = nil, offset: Int64? = nil, limit: Int64? = nil, urlTtl: Int64? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> DescribeFileUrlsResponse {
+        try await self.describeFileUrls(.init(operator: `operator`, businessType: businessType, businessIds: businessIds, fileName: fileName, fileType: fileType, offset: offset, limit: limit, urlTtl: urlTtl), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 查询文件下载URL
+    ///
+    /// 查询文件下载URL。
+    /// 适用场景：通过传参合同流程编号，下载对应的合同PDF文件流到本地。
+    @available(*, deprecated, renamed: "describeFileUrls(operator:businessType:businessIds:fileName:fileType:offset:limit:urlTtl:region:logger:on:)", message: "'ccToken', 'scene' and 'agent' are deprecated. Setting these parameters has no effect.")
     @inlinable
     public func describeFileUrls(operator: UserInfo, businessType: String, businessIds: [String], fileName: String? = nil, fileType: String? = nil, offset: Int64? = nil, limit: Int64? = nil, urlTtl: Int64? = nil, ccToken: String? = nil, scene: String? = nil, agent: Agent? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> DescribeFileUrlsResponse {
         try await self.describeFileUrls(.init(operator: `operator`, businessType: businessType, businessIds: businessIds, fileName: fileName, fileType: fileType, offset: offset, limit: limit, urlTtl: urlTtl, ccToken: ccToken, scene: scene, agent: agent), region: region, logger: logger, on: eventLoop)

--- a/Sources/Teco/Ess/V20201111/actions/DescribeFlowInfo.swift
+++ b/Sources/Teco/Ess/V20201111/actions/DescribeFlowInfo.swift
@@ -57,10 +57,10 @@ extension Ess {
         public let flowDetailInfos: [FlowDetailInfo]
 
         /// 合同组ID
-        public let flowGroupId: String
+        public let flowGroupId: String?
 
         /// 合同组名称
-        public let flowGroupName: String
+        public let flowGroupName: String?
 
         /// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
         public let requestId: String

--- a/Sources/Teco/Ess/V20201111/actions/DescribeFlowTemplates.swift
+++ b/Sources/Teco/Ess/V20201111/actions/DescribeFlowTemplates.swift
@@ -54,14 +54,28 @@ extension Ess {
 
         /// 默认为false，查询SaaS模板库列表；
         /// 为true，查询第三方应用集成平台企业模板库管理列表
-        public let isChannel: Bool?
+        @available(*, deprecated)
+        public let isChannel: Bool? = nil
 
         /// 暂未开放
-        public let organization: OrganizationInfo?
+        @available(*, deprecated)
+        public let organization: OrganizationInfo? = nil
 
         /// 暂未开放
-        public let generateSource: UInt64?
+        @available(*, deprecated)
+        public let generateSource: UInt64? = nil
 
+        public init(operator: UserInfo, agent: Agent? = nil, contentType: Int64? = nil, filters: [Filter]? = nil, offset: UInt64? = nil, limit: UInt64? = nil, applicationId: String? = nil) {
+            self.operator = `operator`
+            self.agent = agent
+            self.contentType = contentType
+            self.filters = filters
+            self.offset = offset
+            self.limit = limit
+            self.applicationId = applicationId
+        }
+
+        @available(*, deprecated, renamed: "init(operator:agent:contentType:filters:offset:limit:applicationId:)", message: "'isChannel', 'organization' and 'generateSource' are deprecated in 'DescribeFlowTemplatesRequest'. Setting these parameters has no effect.")
         public init(operator: UserInfo, agent: Agent? = nil, contentType: Int64? = nil, filters: [Filter]? = nil, offset: UInt64? = nil, limit: UInt64? = nil, applicationId: String? = nil, isChannel: Bool? = nil, organization: OrganizationInfo? = nil, generateSource: UInt64? = nil) {
             self.operator = `operator`
             self.agent = agent
@@ -70,9 +84,6 @@ extension Ess {
             self.offset = offset
             self.limit = limit
             self.applicationId = applicationId
-            self.isChannel = isChannel
-            self.organization = organization
-            self.generateSource = generateSource
         }
 
         enum CodingKeys: String, CodingKey {
@@ -93,7 +104,7 @@ extension Ess {
             guard !response.getItems().isEmpty else {
                 return nil
             }
-            return DescribeFlowTemplatesRequest(operator: self.operator, agent: self.agent, contentType: self.contentType, filters: self.filters, offset: (self.offset ?? 0) + .init(response.getItems().count), limit: self.limit, applicationId: self.applicationId, isChannel: self.isChannel, organization: self.organization, generateSource: self.generateSource)
+            return DescribeFlowTemplatesRequest(operator: self.operator, agent: self.agent, contentType: self.contentType, filters: self.filters, offset: (self.offset ?? 0) + .init(response.getItems().count), limit: self.limit, applicationId: self.applicationId)
         }
     }
 
@@ -181,6 +192,27 @@ extension Ess {
     /// >- 签署控件 SignComponents
     /// >- 生成模板的文件基础信息 FileInfos
     @inlinable
+    public func describeFlowTemplates(operator: UserInfo, agent: Agent? = nil, contentType: Int64? = nil, filters: [Filter]? = nil, offset: UInt64? = nil, limit: UInt64? = nil, applicationId: String? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<DescribeFlowTemplatesResponse> {
+        self.describeFlowTemplates(.init(operator: `operator`, agent: agent, contentType: contentType, filters: filters, offset: offset, limit: limit, applicationId: applicationId), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 查询模板
+    ///
+    /// 本接口用于查询本企业模板列表。
+    ///
+    /// 当模板较多或模板中的控件较多时，可以通过查询模板接口更方便的获取模板列表，以及每个模板内的控件信息。
+    ///
+    /// > **适用场景**
+    /// >
+    /// >  该接口常用来配合“模板发起合同-创建电子文档”接口作为前置的接口使用。
+    /// >  一个模板通常会包含以下结构信息
+    /// >- 模板基本信息
+    /// >- 发起方参与信息Promoter、签署参与方 Recipients，后者会在模板发起合同时用于指定参与方
+    /// >- 填写控件 Components
+    /// >- 签署控件 SignComponents
+    /// >- 生成模板的文件基础信息 FileInfos
+    @available(*, deprecated, renamed: "describeFlowTemplates(operator:agent:contentType:filters:offset:limit:applicationId:region:logger:on:)", message: "'isChannel', 'organization' and 'generateSource' are deprecated. Setting these parameters has no effect.")
+    @inlinable
     public func describeFlowTemplates(operator: UserInfo, agent: Agent? = nil, contentType: Int64? = nil, filters: [Filter]? = nil, offset: UInt64? = nil, limit: UInt64? = nil, applicationId: String? = nil, isChannel: Bool? = nil, organization: OrganizationInfo? = nil, generateSource: UInt64? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<DescribeFlowTemplatesResponse> {
         self.describeFlowTemplates(.init(operator: `operator`, agent: agent, contentType: contentType, filters: filters, offset: offset, limit: limit, applicationId: applicationId, isChannel: isChannel, organization: organization, generateSource: generateSource), region: region, logger: logger, on: eventLoop)
     }
@@ -200,6 +232,27 @@ extension Ess {
     /// >- 填写控件 Components
     /// >- 签署控件 SignComponents
     /// >- 生成模板的文件基础信息 FileInfos
+    @inlinable
+    public func describeFlowTemplates(operator: UserInfo, agent: Agent? = nil, contentType: Int64? = nil, filters: [Filter]? = nil, offset: UInt64? = nil, limit: UInt64? = nil, applicationId: String? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> DescribeFlowTemplatesResponse {
+        try await self.describeFlowTemplates(.init(operator: `operator`, agent: agent, contentType: contentType, filters: filters, offset: offset, limit: limit, applicationId: applicationId), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 查询模板
+    ///
+    /// 本接口用于查询本企业模板列表。
+    ///
+    /// 当模板较多或模板中的控件较多时，可以通过查询模板接口更方便的获取模板列表，以及每个模板内的控件信息。
+    ///
+    /// > **适用场景**
+    /// >
+    /// >  该接口常用来配合“模板发起合同-创建电子文档”接口作为前置的接口使用。
+    /// >  一个模板通常会包含以下结构信息
+    /// >- 模板基本信息
+    /// >- 发起方参与信息Promoter、签署参与方 Recipients，后者会在模板发起合同时用于指定参与方
+    /// >- 填写控件 Components
+    /// >- 签署控件 SignComponents
+    /// >- 生成模板的文件基础信息 FileInfos
+    @available(*, deprecated, renamed: "describeFlowTemplates(operator:agent:contentType:filters:offset:limit:applicationId:region:logger:on:)", message: "'isChannel', 'organization' and 'generateSource' are deprecated. Setting these parameters has no effect.")
     @inlinable
     public func describeFlowTemplates(operator: UserInfo, agent: Agent? = nil, contentType: Int64? = nil, filters: [Filter]? = nil, offset: UInt64? = nil, limit: UInt64? = nil, applicationId: String? = nil, isChannel: Bool? = nil, organization: OrganizationInfo? = nil, generateSource: UInt64? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> DescribeFlowTemplatesResponse {
         try await self.describeFlowTemplates(.init(operator: `operator`, agent: agent, contentType: contentType, filters: filters, offset: offset, limit: limit, applicationId: applicationId, isChannel: isChannel, organization: organization, generateSource: generateSource), region: region, logger: logger, on: eventLoop)

--- a/Sources/Teco/Ess/V20201111/actions/DescribeOrganizationGroupOrganizations.swift
+++ b/Sources/Teco/Ess/V20201111/actions/DescribeOrganizationGroupOrganizations.swift
@@ -84,6 +84,7 @@ extension Ess {
 
         /// 已加入的企业数量(废弃,请使用ActivatedTotal)
         /// 注意：此字段可能返回 null，表示取不到有效值。
+        @available(*, deprecated)
         public let activedTotal: UInt64?
 
         /// 导出文件的url

--- a/Sources/Teco/Ess/V20201111/actions/GetTaskResultApi.swift
+++ b/Sources/Teco/Ess/V20201111/actions/GetTaskResultApi.swift
@@ -28,16 +28,22 @@ extension Ess {
         public let `operator`: UserInfo?
 
         /// 应用号信息
-        public let agent: Agent?
+        @available(*, deprecated)
+        public let agent: Agent? = nil
 
         /// 暂未开放
-        public let organization: OrganizationInfo?
+        @available(*, deprecated)
+        public let organization: OrganizationInfo? = nil
 
+        public init(taskId: String, operator: UserInfo? = nil) {
+            self.taskId = taskId
+            self.operator = `operator`
+        }
+
+        @available(*, deprecated, renamed: "init(taskId:operator:)", message: "'agent' and 'organization' are deprecated in 'GetTaskResultApiRequest'. Setting these parameters has no effect.")
         public init(taskId: String, operator: UserInfo? = nil, agent: Agent? = nil, organization: OrganizationInfo? = nil) {
             self.taskId = taskId
             self.operator = `operator`
-            self.agent = agent
-            self.organization = organization
         }
 
         enum CodingKeys: String, CodingKey {
@@ -109,6 +115,16 @@ extension Ess {
     /// 查询转换任务的状态。转换任务Id通过发起转换任务接口（CreateConvertTaskApi）获取。
     /// 注意：大文件转换所需的时间可能会比较长。
     @inlinable
+    public func getTaskResultApi(taskId: String, operator: UserInfo? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<GetTaskResultApiResponse> {
+        self.getTaskResultApi(.init(taskId: taskId, operator: `operator`), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 查询转换任务状态
+    ///
+    /// 查询转换任务的状态。转换任务Id通过发起转换任务接口（CreateConvertTaskApi）获取。
+    /// 注意：大文件转换所需的时间可能会比较长。
+    @available(*, deprecated, renamed: "getTaskResultApi(taskId:operator:region:logger:on:)", message: "'agent' and 'organization' are deprecated. Setting these parameters has no effect.")
+    @inlinable
     public func getTaskResultApi(taskId: String, operator: UserInfo? = nil, agent: Agent? = nil, organization: OrganizationInfo? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<GetTaskResultApiResponse> {
         self.getTaskResultApi(.init(taskId: taskId, operator: `operator`, agent: agent, organization: organization), region: region, logger: logger, on: eventLoop)
     }
@@ -117,6 +133,16 @@ extension Ess {
     ///
     /// 查询转换任务的状态。转换任务Id通过发起转换任务接口（CreateConvertTaskApi）获取。
     /// 注意：大文件转换所需的时间可能会比较长。
+    @inlinable
+    public func getTaskResultApi(taskId: String, operator: UserInfo? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> GetTaskResultApiResponse {
+        try await self.getTaskResultApi(.init(taskId: taskId, operator: `operator`), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 查询转换任务状态
+    ///
+    /// 查询转换任务的状态。转换任务Id通过发起转换任务接口（CreateConvertTaskApi）获取。
+    /// 注意：大文件转换所需的时间可能会比较长。
+    @available(*, deprecated, renamed: "getTaskResultApi(taskId:operator:region:logger:on:)", message: "'agent' and 'organization' are deprecated. Setting these parameters has no effect.")
     @inlinable
     public func getTaskResultApi(taskId: String, operator: UserInfo? = nil, agent: Agent? = nil, organization: OrganizationInfo? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> GetTaskResultApiResponse {
         try await self.getTaskResultApi(.init(taskId: taskId, operator: `operator`, agent: agent, organization: organization), region: region, logger: logger, on: eventLoop)

--- a/Sources/Teco/Ess/V20201111/actions/UploadFiles.swift
+++ b/Sources/Teco/Ess/V20201111/actions/UploadFiles.swift
@@ -46,8 +46,19 @@ extension Ess {
         public let customIds: [String]?
 
         /// 不再使用，上传文件链接数组，最多支持20个URL
-        public let fileUrls: String?
+        @available(*, deprecated)
+        public let fileUrls: String? = nil
 
+        public init(businessType: String, caller: Caller? = nil, fileInfos: [UploadFile]? = nil, fileType: String? = nil, coverRect: Bool? = nil, customIds: [String]? = nil) {
+            self.businessType = businessType
+            self.caller = caller
+            self.fileInfos = fileInfos
+            self.fileType = fileType
+            self.coverRect = coverRect
+            self.customIds = customIds
+        }
+
+        @available(*, deprecated, renamed: "init(businessType:caller:fileInfos:fileType:coverRect:customIds:)", message: "'fileUrls' is deprecated in 'UploadFilesRequest'. Setting this parameter has no effect.")
         public init(businessType: String, caller: Caller? = nil, fileInfos: [UploadFile]? = nil, fileType: String? = nil, coverRect: Bool? = nil, customIds: [String]? = nil, fileUrls: String? = nil) {
             self.businessType = businessType
             self.caller = caller
@@ -55,7 +66,6 @@ extension Ess {
             self.fileType = fileType
             self.coverRect = coverRect
             self.customIds = customIds
-            self.fileUrls = fileUrls
         }
 
         enum CodingKeys: String, CodingKey {
@@ -125,6 +135,21 @@ extension Ess {
     /// HttpProfile httpProfile = new HttpProfile();<br/>
     /// httpProfile.setEndpoint("file.test.ess.tencent.cn");<br/>
     @inlinable
+    public func uploadFiles(businessType: String, caller: Caller? = nil, fileInfos: [UploadFile]? = nil, fileType: String? = nil, coverRect: Bool? = nil, customIds: [String]? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<UploadFilesResponse> {
+        self.uploadFiles(.init(businessType: businessType, caller: caller, fileInfos: fileInfos, fileType: fileType, coverRect: coverRect, customIds: customIds), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 多文件上传
+    ///
+    /// 此接口（UploadFiles）用于文件上传。<br/>
+    /// 适用场景：用于生成pdf资源编号（FileIds）来配合“用PDF创建流程”接口使用，使用场景可详见“用PDF创建流程”接口说明。<br/>
+    ///
+    /// 其中上传的文件，图片类型(png/jpg/jpeg)大小限制为5M，其他大小限制为60M。<br/>
+    /// 调用时需要设置Domain/接口请求域名为 file.ess.tencent.cn,代码示例：<br/>
+    /// HttpProfile httpProfile = new HttpProfile();<br/>
+    /// httpProfile.setEndpoint("file.test.ess.tencent.cn");<br/>
+    @available(*, deprecated, renamed: "uploadFiles(businessType:caller:fileInfos:fileType:coverRect:customIds:region:logger:on:)", message: "'fileUrls' is deprecated. Setting this parameter has no effect.")
+    @inlinable
     public func uploadFiles(businessType: String, caller: Caller? = nil, fileInfos: [UploadFile]? = nil, fileType: String? = nil, coverRect: Bool? = nil, customIds: [String]? = nil, fileUrls: String? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<UploadFilesResponse> {
         self.uploadFiles(.init(businessType: businessType, caller: caller, fileInfos: fileInfos, fileType: fileType, coverRect: coverRect, customIds: customIds, fileUrls: fileUrls), region: region, logger: logger, on: eventLoop)
     }
@@ -138,6 +163,21 @@ extension Ess {
     /// 调用时需要设置Domain/接口请求域名为 file.ess.tencent.cn,代码示例：<br/>
     /// HttpProfile httpProfile = new HttpProfile();<br/>
     /// httpProfile.setEndpoint("file.test.ess.tencent.cn");<br/>
+    @inlinable
+    public func uploadFiles(businessType: String, caller: Caller? = nil, fileInfos: [UploadFile]? = nil, fileType: String? = nil, coverRect: Bool? = nil, customIds: [String]? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> UploadFilesResponse {
+        try await self.uploadFiles(.init(businessType: businessType, caller: caller, fileInfos: fileInfos, fileType: fileType, coverRect: coverRect, customIds: customIds), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 多文件上传
+    ///
+    /// 此接口（UploadFiles）用于文件上传。<br/>
+    /// 适用场景：用于生成pdf资源编号（FileIds）来配合“用PDF创建流程”接口使用，使用场景可详见“用PDF创建流程”接口说明。<br/>
+    ///
+    /// 其中上传的文件，图片类型(png/jpg/jpeg)大小限制为5M，其他大小限制为60M。<br/>
+    /// 调用时需要设置Domain/接口请求域名为 file.ess.tencent.cn,代码示例：<br/>
+    /// HttpProfile httpProfile = new HttpProfile();<br/>
+    /// httpProfile.setEndpoint("file.test.ess.tencent.cn");<br/>
+    @available(*, deprecated, renamed: "uploadFiles(businessType:caller:fileInfos:fileType:coverRect:customIds:region:logger:on:)", message: "'fileUrls' is deprecated. Setting this parameter has no effect.")
     @inlinable
     public func uploadFiles(businessType: String, caller: Caller? = nil, fileInfos: [UploadFile]? = nil, fileType: String? = nil, coverRect: Bool? = nil, customIds: [String]? = nil, fileUrls: String? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> UploadFilesResponse {
         try await self.uploadFiles(.init(businessType: businessType, caller: caller, fileInfos: fileInfos, fileType: fileType, coverRect: coverRect, customIds: customIds, fileUrls: fileUrls), region: region, logger: logger, on: eventLoop)

--- a/Sources/Teco/Ess/V20201111/models.swift
+++ b/Sources/Teco/Ess/V20201111/models.swift
@@ -36,22 +36,27 @@ extension Ess {
     /// 代理相关应用信息，如集团主企业代子企业操作
     public struct Agent: TCInputModel {
         /// 代理机构的应用编号,32位字符串，一般不用传
-        public let appId: String?
+        @available(*, deprecated)
+        public let appId: String? = nil
 
         /// 被代理机构的应用号，一般不用传
-        public let proxyAppId: String?
+        @available(*, deprecated)
+        public let proxyAppId: String? = nil
 
         /// 被代理机构在电子签平台的机构编号，集团代理下场景必传
         public let proxyOrganizationId: String?
 
         /// 被代理机构的经办人，一般不用传
-        public let proxyOperator: String?
+        @available(*, deprecated)
+        public let proxyOperator: String? = nil
 
-        public init(appId: String? = nil, proxyAppId: String? = nil, proxyOrganizationId: String? = nil, proxyOperator: String? = nil) {
-            self.appId = appId
-            self.proxyAppId = proxyAppId
+        public init(proxyOrganizationId: String? = nil) {
             self.proxyOrganizationId = proxyOrganizationId
-            self.proxyOperator = proxyOperator
+        }
+
+        @available(*, deprecated, renamed: "init(proxyOrganizationId:)", message: "'appId', 'proxyAppId' and 'proxyOperator' are deprecated in 'Agent'. Setting these parameters has no effect.")
+        public init(appId: String? = nil, proxyAppId: String? = nil, proxyOrganizationId: String? = nil, proxyOperator: String? = nil) {
+            self.proxyOrganizationId = proxyOrganizationId
         }
 
         enum CodingKeys: String, CodingKey {
@@ -294,7 +299,8 @@ extension Ess {
         public let callbackUrl: String
 
         /// 回调加密key，已废弃
-        public let token: String?
+        @available(*, deprecated)
+        public let token: String? = nil
 
         /// 回调加密key
         public let callbackKey: String?
@@ -302,9 +308,15 @@ extension Ess {
         /// 回调验签token
         public let callbackToken: String?
 
+        public init(callbackUrl: String, callbackKey: String? = nil, callbackToken: String? = nil) {
+            self.callbackUrl = callbackUrl
+            self.callbackKey = callbackKey
+            self.callbackToken = callbackToken
+        }
+
+        @available(*, deprecated, renamed: "init(callbackUrl:callbackKey:callbackToken:)", message: "'token' is deprecated in 'CallbackInfo'. Setting this parameter has no effect.")
         public init(callbackUrl: String, token: String? = nil, callbackKey: String? = nil, callbackToken: String? = nil) {
             self.callbackUrl = callbackUrl
-            self.token = token
             self.callbackKey = callbackKey
             self.callbackToken = callbackToken
         }
@@ -320,22 +332,27 @@ extension Ess {
     /// 此结构体 (Caller) 用于描述调用方属性。
     public struct Caller: TCInputModel {
         /// 应用号
-        public let applicationId: String?
+        @available(*, deprecated)
+        public let applicationId: String? = nil
 
         /// 主机构ID
-        public let organizationId: String?
+        @available(*, deprecated)
+        public let organizationId: String? = nil
 
         /// 经办人的用户ID，同UserId
         public let operatorId: String?
 
         /// 下属机构ID
-        public let subOrganizationId: String?
+        @available(*, deprecated)
+        public let subOrganizationId: String? = nil
 
-        public init(applicationId: String? = nil, organizationId: String? = nil, operatorId: String? = nil, subOrganizationId: String? = nil) {
-            self.applicationId = applicationId
-            self.organizationId = organizationId
+        public init(operatorId: String? = nil) {
             self.operatorId = operatorId
-            self.subOrganizationId = subOrganizationId
+        }
+
+        @available(*, deprecated, renamed: "init(operatorId:)", message: "'applicationId', 'organizationId' and 'subOrganizationId' are deprecated in 'Caller'. Setting these parameters has no effect.")
+        public init(applicationId: String? = nil, organizationId: String? = nil, operatorId: String? = nil, subOrganizationId: String? = nil) {
+            self.operatorId = operatorId
         }
 
         enum CodingKeys: String, CodingKey {
@@ -896,7 +913,7 @@ extension Ess {
         public let mobile: String
 
         /// 传入的企微账号id
-        public let weworkOpenId: String
+        public let weworkOpenId: String?
 
         /// 失败原因
         public let reason: String
@@ -1342,7 +1359,8 @@ extension Ess {
         public let approverOption: ApproverOption?
 
         /// 签署完前端跳转的url，暂未使用
-        public let jumpUrl: String?
+        @available(*, deprecated)
+        public let jumpUrl: String? = nil
 
         /// 签署ID
         /// - 发起流程时系统自动补充
@@ -1376,6 +1394,34 @@ extension Ess {
         /// 合同签署方式(默认1,2) <br/>1-人脸认证 <br/>2-签署密码 <br/>3-运营商三要素
         public let approverSignTypes: [UInt64]?
 
+        public init(approverType: Int64, organizationName: String? = nil, approverName: String? = nil, approverMobile: String? = nil, approverIdCardType: String? = nil, approverIdCardNumber: String? = nil, recipientId: String? = nil, verifyChannel: [String]? = nil, notifyType: String? = nil, isFullText: Bool? = nil, preReadTime: UInt64? = nil, userId: String? = nil, required: Bool? = nil, approverSource: String? = nil, customApproverTag: String? = nil, registerInfo: RegisterInfo? = nil, approverOption: ApproverOption? = nil, signId: String? = nil, approverNeedSignReview: Bool? = nil, signComponents: [Component]? = nil, components: [Component]? = nil, componentLimitType: [String]? = nil, approverVerifyTypes: [Int64]? = nil, approverSignTypes: [UInt64]? = nil) {
+            self.approverType = approverType
+            self.organizationName = organizationName
+            self.approverName = approverName
+            self.approverMobile = approverMobile
+            self.approverIdCardType = approverIdCardType
+            self.approverIdCardNumber = approverIdCardNumber
+            self.recipientId = recipientId
+            self.verifyChannel = verifyChannel
+            self.notifyType = notifyType
+            self.isFullText = isFullText
+            self.preReadTime = preReadTime
+            self.userId = userId
+            self.required = required
+            self.approverSource = approverSource
+            self.customApproverTag = customApproverTag
+            self.registerInfo = registerInfo
+            self.approverOption = approverOption
+            self.signId = signId
+            self.approverNeedSignReview = approverNeedSignReview
+            self.signComponents = signComponents
+            self.components = components
+            self.componentLimitType = componentLimitType
+            self.approverVerifyTypes = approverVerifyTypes
+            self.approverSignTypes = approverSignTypes
+        }
+
+        @available(*, deprecated, renamed: "init(approverType:organizationName:approverName:approverMobile:approverIdCardType:approverIdCardNumber:recipientId:verifyChannel:notifyType:isFullText:preReadTime:userId:required:approverSource:customApproverTag:registerInfo:approverOption:signId:approverNeedSignReview:signComponents:components:componentLimitType:approverVerifyTypes:approverSignTypes:)", message: "'jumpUrl' is deprecated in 'FlowCreateApprover'. Setting this parameter has no effect.")
         public init(approverType: Int64, organizationName: String? = nil, approverName: String? = nil, approverMobile: String? = nil, approverIdCardType: String? = nil, approverIdCardNumber: String? = nil, recipientId: String? = nil, verifyChannel: [String]? = nil, notifyType: String? = nil, isFullText: Bool? = nil, preReadTime: UInt64? = nil, userId: String? = nil, required: Bool? = nil, approverSource: String? = nil, customApproverTag: String? = nil, registerInfo: RegisterInfo? = nil, approverOption: ApproverOption? = nil, jumpUrl: String? = nil, signId: String? = nil, approverNeedSignReview: Bool? = nil, signComponents: [Component]? = nil, components: [Component]? = nil, componentLimitType: [String]? = nil, approverVerifyTypes: [Int64]? = nil, approverSignTypes: [UInt64]? = nil) {
             self.approverType = approverType
             self.organizationName = organizationName
@@ -1394,7 +1440,6 @@ extension Ess {
             self.customApproverTag = customApproverTag
             self.registerInfo = registerInfo
             self.approverOption = approverOption
-            self.jumpUrl = jumpUrl
             self.signId = signId
             self.approverNeedSignReview = approverNeedSignReview
             self.signComponents = signComponents
@@ -2029,26 +2074,30 @@ extension Ess {
     /// 机构信息
     public struct OrganizationInfo: TCInputModel, TCOutputModel {
         /// 机构在平台的编号，内部字段，暂未开放
-        public let organizationId: String?
+        @available(*, deprecated)
+        public let organizationId: String? = nil
 
         /// 用户渠道，内部字段，暂未开放
-        public let channel: String?
+        @available(*, deprecated)
+        public let channel: String? = nil
 
         /// 用户在渠道的机构编号，内部字段，暂未开放
-        public let organizationOpenId: String?
+        @available(*, deprecated)
+        public let organizationOpenId: String? = nil
 
         /// 用户真实的IP，内部字段，暂未开放
-        public let clientIp: String?
+        @available(*, deprecated)
+        public let clientIp: String? = nil
 
         /// 机构的代理IP，内部字段，暂未开放
-        public let proxyIp: String?
+        @available(*, deprecated)
+        public let proxyIp: String? = nil
 
+        public init() {
+        }
+
+        @available(*, deprecated, renamed: "init()", message: "'organizationId', 'channel', 'organizationOpenId', 'clientIp' and 'proxyIp' are deprecated in 'OrganizationInfo'. Setting these parameters has no effect.")
         public init(organizationId: String? = nil, channel: String? = nil, organizationOpenId: String? = nil, clientIp: String? = nil, proxyIp: String? = nil) {
-            self.organizationId = organizationId
-            self.channel = channel
-            self.organizationOpenId = organizationOpenId
-            self.clientIp = clientIp
-            self.proxyIp = proxyIp
         }
 
         enum CodingKeys: String, CodingKey {
@@ -2234,14 +2283,20 @@ extension Ess {
         public let legalName: String
 
         /// 社会统一信用代码
-        public let uscc: String?
+        @available(*, deprecated)
+        public let uscc: String? = nil
 
         /// 社会统一信用代码
         public let unifiedSocialCreditCode: String?
 
+        public init(legalName: String, unifiedSocialCreditCode: String? = nil) {
+            self.legalName = legalName
+            self.unifiedSocialCreditCode = unifiedSocialCreditCode
+        }
+
+        @available(*, deprecated, renamed: "init(legalName:unifiedSocialCreditCode:)", message: "'uscc' is deprecated in 'RegisterInfo'. Setting this parameter has no effect.")
         public init(legalName: String, uscc: String? = nil, unifiedSocialCreditCode: String? = nil) {
             self.legalName = legalName
-            self.uscc = uscc
             self.unifiedSocialCreditCode = unifiedSocialCreditCode
         }
 
@@ -2561,7 +2616,7 @@ extension Ess {
         public let note: String?
 
         /// 传入的企微账号id
-        public let weworkOpenId: String
+        public let weworkOpenId: String?
 
         enum CodingKeys: String, CodingKey {
             case displayName = "DisplayName"
@@ -2699,8 +2754,34 @@ extension Ess {
 
         /// 模板内部指定的印章列表
         /// 注意：此字段可能返回 null，表示取不到有效值。
-        public let seals: [SealInfo]?
+        @available(*, deprecated)
+        public let seals: [SealInfo]? = nil
 
+        public init(templateId: String? = nil, templateName: String? = nil, description: String? = nil, documentResourceIds: [String]? = nil, fileInfos: [FileInfo]? = nil, attachmentResourceIds: [String]? = nil, signOrder: [Int64]? = nil, recipients: [Recipient]? = nil, components: [Component]? = nil, signComponents: [Component]? = nil, status: Int64? = nil, creator: String? = nil, createdOn: Int64? = nil, promoter: Recipient? = nil, templateType: Int64? = nil, available: Int64? = nil, organizationId: String? = nil, previewUrl: String? = nil, templateVersion: String? = nil, published: Bool? = nil, templateSeals: [SealInfo]? = nil) {
+            self.templateId = templateId
+            self.templateName = templateName
+            self.description = description
+            self.documentResourceIds = documentResourceIds
+            self.fileInfos = fileInfos
+            self.attachmentResourceIds = attachmentResourceIds
+            self.signOrder = signOrder
+            self.recipients = recipients
+            self.components = components
+            self.signComponents = signComponents
+            self.status = status
+            self.creator = creator
+            self.createdOn = createdOn
+            self.promoter = promoter
+            self.templateType = templateType
+            self.available = available
+            self.organizationId = organizationId
+            self.previewUrl = previewUrl
+            self.templateVersion = templateVersion
+            self.published = published
+            self.templateSeals = templateSeals
+        }
+
+        @available(*, deprecated, renamed: "init(templateId:templateName:description:documentResourceIds:fileInfos:attachmentResourceIds:signOrder:recipients:components:signComponents:status:creator:createdOn:promoter:templateType:available:organizationId:previewUrl:templateVersion:published:templateSeals:)", message: "'seals' is deprecated in 'TemplateInfo'. Setting this parameter has no effect.")
         public init(templateId: String? = nil, templateName: String? = nil, description: String? = nil, documentResourceIds: [String]? = nil, fileInfos: [FileInfo]? = nil, attachmentResourceIds: [String]? = nil, signOrder: [Int64]? = nil, recipients: [Recipient]? = nil, components: [Component]? = nil, signComponents: [Component]? = nil, status: Int64? = nil, creator: String? = nil, createdOn: Int64? = nil, promoter: Recipient? = nil, templateType: Int64? = nil, available: Int64? = nil, organizationId: String? = nil, previewUrl: String? = nil, templateVersion: String? = nil, published: Bool? = nil, templateSeals: [SealInfo]? = nil, seals: [SealInfo]? = nil) {
             self.templateId = templateId
             self.templateName = templateName
@@ -2723,7 +2804,6 @@ extension Ess {
             self.templateVersion = templateVersion
             self.published = published
             self.templateSeals = templateSeals
-            self.seals = seals
         }
 
         enum CodingKeys: String, CodingKey {
@@ -2777,23 +2857,28 @@ extension Ess {
         public let userId: String?
 
         /// 用户的来源渠道，一般不用传，特定场景根据接口说明传值
-        public let channel: String?
+        @available(*, deprecated)
+        public let channel: String? = nil
 
         /// 用户在渠道的编号，一般不用传，特定场景根据接口说明传值
-        public let openId: String?
+        @available(*, deprecated)
+        public let openId: String? = nil
 
         /// 用户真实IP，内部字段，暂未开放
-        public let clientIp: String?
+        @available(*, deprecated)
+        public let clientIp: String? = nil
 
         /// 用户代理IP，内部字段，暂未开放
-        public let proxyIp: String?
+        @available(*, deprecated)
+        public let proxyIp: String? = nil
 
+        public init(userId: String? = nil) {
+            self.userId = userId
+        }
+
+        @available(*, deprecated, renamed: "init(userId:)", message: "'channel', 'openId', 'clientIp' and 'proxyIp' are deprecated in 'UserInfo'. Setting these parameters has no effect.")
         public init(userId: String? = nil, channel: String? = nil, openId: String? = nil, clientIp: String? = nil, proxyIp: String? = nil) {
             self.userId = userId
-            self.channel = channel
-            self.openId = openId
-            self.clientIp = clientIp
-            self.proxyIp = proxyIp
         }
 
         enum CodingKeys: String, CodingKey {

--- a/Sources/Teco/Essbasic/V20210526/actions/ChannelBatchCancelFlows.swift
+++ b/Sources/Teco/Essbasic/V20210526/actions/ChannelBatchCancelFlows.swift
@@ -39,14 +39,22 @@ extension Essbasic {
         public let cancelMessageFormat: Int64?
 
         /// 暂未开放
-        public let `operator`: UserInfo?
+        @available(*, deprecated)
+        public let `operator`: UserInfo? = nil
 
+        public init(agent: Agent, flowIds: [String], cancelMessage: String? = nil, cancelMessageFormat: Int64? = nil) {
+            self.agent = agent
+            self.flowIds = flowIds
+            self.cancelMessage = cancelMessage
+            self.cancelMessageFormat = cancelMessageFormat
+        }
+
+        @available(*, deprecated, renamed: "init(agent:flowIds:cancelMessage:cancelMessageFormat:)", message: "'operator' is deprecated in 'ChannelBatchCancelFlowsRequest'. Setting this parameter has no effect.")
         public init(agent: Agent, flowIds: [String], cancelMessage: String? = nil, cancelMessageFormat: Int64? = nil, operator: UserInfo? = nil) {
             self.agent = agent
             self.flowIds = flowIds
             self.cancelMessage = cancelMessage
             self.cancelMessageFormat = cancelMessageFormat
-            self.operator = `operator`
         }
 
         enum CodingKeys: String, CodingKey {
@@ -125,6 +133,26 @@ extension Essbasic {
     /// **注意:
     /// 能撤回合同的只能是合同的发起人或者发起企业的超管、法人**
     @inlinable
+    public func channelBatchCancelFlows(agent: Agent, flowIds: [String], cancelMessage: String? = nil, cancelMessageFormat: Int64? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<ChannelBatchCancelFlowsResponse> {
+        self.channelBatchCancelFlows(.init(agent: agent, flowIds: flowIds, cancelMessage: cancelMessage, cancelMessageFormat: cancelMessageFormat), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 根据签署流程id批量撤销合同
+    ///
+    /// 指定需要批量撤销的签署流程Id，批量撤销合同
+    /// 客户指定需要撤销的签署流程Id，最多100个，超过100不处理；
+    ///
+    /// 可以撤回：未全部签署完成
+    ///  不可以撤回：已全部签署完成、已拒签、已过期、已撤回、拒绝填写、已解除等合同状态。
+    ///
+    /// **满足撤销条件的合同会发起异步撤销流程，不满足撤销条件的合同返回失败原因。**
+    ///
+    /// **合同撤销成功后，会通过合同状态为 CANCEL 的回调消息通知调用方 [具体可参考回调消息](https://qian.tencent.com/developers/scenes/partner/callback_data_types#-%E5%90%88%E5%90%8C%E7%8A%B6%E6%80%81%E9%80%9A%E7%9F%A5---flowstatuschange)**
+    ///
+    /// **注意:
+    /// 能撤回合同的只能是合同的发起人或者发起企业的超管、法人**
+    @available(*, deprecated, renamed: "channelBatchCancelFlows(agent:flowIds:cancelMessage:cancelMessageFormat:region:logger:on:)", message: "'operator' is deprecated. Setting this parameter has no effect.")
+    @inlinable
     public func channelBatchCancelFlows(agent: Agent, flowIds: [String], cancelMessage: String? = nil, cancelMessageFormat: Int64? = nil, operator: UserInfo? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<ChannelBatchCancelFlowsResponse> {
         self.channelBatchCancelFlows(.init(agent: agent, flowIds: flowIds, cancelMessage: cancelMessage, cancelMessageFormat: cancelMessageFormat, operator: `operator`), region: region, logger: logger, on: eventLoop)
     }
@@ -143,6 +171,26 @@ extension Essbasic {
     ///
     /// **注意:
     /// 能撤回合同的只能是合同的发起人或者发起企业的超管、法人**
+    @inlinable
+    public func channelBatchCancelFlows(agent: Agent, flowIds: [String], cancelMessage: String? = nil, cancelMessageFormat: Int64? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> ChannelBatchCancelFlowsResponse {
+        try await self.channelBatchCancelFlows(.init(agent: agent, flowIds: flowIds, cancelMessage: cancelMessage, cancelMessageFormat: cancelMessageFormat), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 根据签署流程id批量撤销合同
+    ///
+    /// 指定需要批量撤销的签署流程Id，批量撤销合同
+    /// 客户指定需要撤销的签署流程Id，最多100个，超过100不处理；
+    ///
+    /// 可以撤回：未全部签署完成
+    ///  不可以撤回：已全部签署完成、已拒签、已过期、已撤回、拒绝填写、已解除等合同状态。
+    ///
+    /// **满足撤销条件的合同会发起异步撤销流程，不满足撤销条件的合同返回失败原因。**
+    ///
+    /// **合同撤销成功后，会通过合同状态为 CANCEL 的回调消息通知调用方 [具体可参考回调消息](https://qian.tencent.com/developers/scenes/partner/callback_data_types#-%E5%90%88%E5%90%8C%E7%8A%B6%E6%80%81%E9%80%9A%E7%9F%A5---flowstatuschange)**
+    ///
+    /// **注意:
+    /// 能撤回合同的只能是合同的发起人或者发起企业的超管、法人**
+    @available(*, deprecated, renamed: "channelBatchCancelFlows(agent:flowIds:cancelMessage:cancelMessageFormat:region:logger:on:)", message: "'operator' is deprecated. Setting this parameter has no effect.")
     @inlinable
     public func channelBatchCancelFlows(agent: Agent, flowIds: [String], cancelMessage: String? = nil, cancelMessageFormat: Int64? = nil, operator: UserInfo? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> ChannelBatchCancelFlowsResponse {
         try await self.channelBatchCancelFlows(.init(agent: agent, flowIds: flowIds, cancelMessage: cancelMessage, cancelMessageFormat: cancelMessageFormat, operator: `operator`), region: region, logger: logger, on: eventLoop)

--- a/Sources/Teco/Essbasic/V20210526/actions/ChannelCancelFlow.swift
+++ b/Sources/Teco/Essbasic/V20210526/actions/ChannelCancelFlow.swift
@@ -38,14 +38,22 @@ extension Essbasic {
         public let cancelMessageFormat: Int64?
 
         /// 暂未开放
-        public let `operator`: UserInfo?
+        @available(*, deprecated)
+        public let `operator`: UserInfo? = nil
 
+        public init(flowId: String, agent: Agent? = nil, cancelMessage: String? = nil, cancelMessageFormat: Int64? = nil) {
+            self.flowId = flowId
+            self.agent = agent
+            self.cancelMessage = cancelMessage
+            self.cancelMessageFormat = cancelMessageFormat
+        }
+
+        @available(*, deprecated, renamed: "init(flowId:agent:cancelMessage:cancelMessageFormat:)", message: "'operator' is deprecated in 'ChannelCancelFlowRequest'. Setting this parameter has no effect.")
         public init(flowId: String, agent: Agent? = nil, cancelMessage: String? = nil, cancelMessageFormat: Int64? = nil, operator: UserInfo? = nil) {
             self.flowId = flowId
             self.agent = agent
             self.cancelMessage = cancelMessage
             self.cancelMessageFormat = cancelMessageFormat
-            self.operator = `operator`
         }
 
         enum CodingKeys: String, CodingKey {
@@ -93,6 +101,17 @@ extension Essbasic {
     /// 注意:
     /// 能撤回合同的只能是合同的发起人或者发起企业的超管、法人
     @inlinable @discardableResult
+    public func channelCancelFlow(flowId: String, agent: Agent? = nil, cancelMessage: String? = nil, cancelMessageFormat: Int64? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<ChannelCancelFlowResponse> {
+        self.channelCancelFlow(.init(flowId: flowId, agent: agent, cancelMessage: cancelMessage, cancelMessageFormat: cancelMessageFormat), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 撤销签署流程
+    ///
+    /// 撤销签署流程接口，可以撤回：未全部签署完成；不可以撤回（终态）：已全部签署完成、已拒签、已过期、已撤回。
+    /// 注意:
+    /// 能撤回合同的只能是合同的发起人或者发起企业的超管、法人
+    @available(*, deprecated, renamed: "channelCancelFlow(flowId:agent:cancelMessage:cancelMessageFormat:region:logger:on:)", message: "'operator' is deprecated. Setting this parameter has no effect.")
+    @inlinable @discardableResult
     public func channelCancelFlow(flowId: String, agent: Agent? = nil, cancelMessage: String? = nil, cancelMessageFormat: Int64? = nil, operator: UserInfo? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<ChannelCancelFlowResponse> {
         self.channelCancelFlow(.init(flowId: flowId, agent: agent, cancelMessage: cancelMessage, cancelMessageFormat: cancelMessageFormat, operator: `operator`), region: region, logger: logger, on: eventLoop)
     }
@@ -102,6 +121,17 @@ extension Essbasic {
     /// 撤销签署流程接口，可以撤回：未全部签署完成；不可以撤回（终态）：已全部签署完成、已拒签、已过期、已撤回。
     /// 注意:
     /// 能撤回合同的只能是合同的发起人或者发起企业的超管、法人
+    @inlinable @discardableResult
+    public func channelCancelFlow(flowId: String, agent: Agent? = nil, cancelMessage: String? = nil, cancelMessageFormat: Int64? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> ChannelCancelFlowResponse {
+        try await self.channelCancelFlow(.init(flowId: flowId, agent: agent, cancelMessage: cancelMessage, cancelMessageFormat: cancelMessageFormat), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 撤销签署流程
+    ///
+    /// 撤销签署流程接口，可以撤回：未全部签署完成；不可以撤回（终态）：已全部签署完成、已拒签、已过期、已撤回。
+    /// 注意:
+    /// 能撤回合同的只能是合同的发起人或者发起企业的超管、法人
+    @available(*, deprecated, renamed: "channelCancelFlow(flowId:agent:cancelMessage:cancelMessageFormat:region:logger:on:)", message: "'operator' is deprecated. Setting this parameter has no effect.")
     @inlinable @discardableResult
     public func channelCancelFlow(flowId: String, agent: Agent? = nil, cancelMessage: String? = nil, cancelMessageFormat: Int64? = nil, operator: UserInfo? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> ChannelCancelFlowResponse {
         try await self.channelCancelFlow(.init(flowId: flowId, agent: agent, cancelMessage: cancelMessage, cancelMessageFormat: cancelMessageFormat, operator: `operator`), region: region, logger: logger, on: eventLoop)

--- a/Sources/Teco/Essbasic/V20210526/actions/ChannelCancelMultiFlowSignQRCode.swift
+++ b/Sources/Teco/Essbasic/V20210526/actions/ChannelCancelMultiFlowSignQRCode.swift
@@ -28,12 +28,18 @@ extension Essbasic {
         public let qrCodeId: String
 
         /// 暂未开放
-        public let `operator`: UserInfo?
+        @available(*, deprecated)
+        public let `operator`: UserInfo? = nil
 
+        public init(agent: Agent, qrCodeId: String) {
+            self.agent = agent
+            self.qrCodeId = qrCodeId
+        }
+
+        @available(*, deprecated, renamed: "init(agent:qrCodeId:)", message: "'operator' is deprecated in 'ChannelCancelMultiFlowSignQRCodeRequest'. Setting this parameter has no effect.")
         public init(agent: Agent, qrCodeId: String, operator: UserInfo? = nil) {
             self.agent = agent
             self.qrCodeId = qrCodeId
-            self.operator = `operator`
         }
 
         enum CodingKeys: String, CodingKey {
@@ -73,6 +79,15 @@ extension Essbasic {
     ///
     /// 此接口（ChannelCancelMultiFlowSignQRCode）用于取消一码多扫二维码。该接口对传入的二维码ID，若还在有效期内，可以提前失效。
     @inlinable @discardableResult
+    public func channelCancelMultiFlowSignQRCode(agent: Agent, qrCodeId: String, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<ChannelCancelMultiFlowSignQRCodeResponse> {
+        self.channelCancelMultiFlowSignQRCode(.init(agent: agent, qrCodeId: qrCodeId), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 取消一码多扫二维码
+    ///
+    /// 此接口（ChannelCancelMultiFlowSignQRCode）用于取消一码多扫二维码。该接口对传入的二维码ID，若还在有效期内，可以提前失效。
+    @available(*, deprecated, renamed: "channelCancelMultiFlowSignQRCode(agent:qrCodeId:region:logger:on:)", message: "'operator' is deprecated. Setting this parameter has no effect.")
+    @inlinable @discardableResult
     public func channelCancelMultiFlowSignQRCode(agent: Agent, qrCodeId: String, operator: UserInfo? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<ChannelCancelMultiFlowSignQRCodeResponse> {
         self.channelCancelMultiFlowSignQRCode(.init(agent: agent, qrCodeId: qrCodeId, operator: `operator`), region: region, logger: logger, on: eventLoop)
     }
@@ -80,6 +95,15 @@ extension Essbasic {
     /// 取消一码多扫二维码
     ///
     /// 此接口（ChannelCancelMultiFlowSignQRCode）用于取消一码多扫二维码。该接口对传入的二维码ID，若还在有效期内，可以提前失效。
+    @inlinable @discardableResult
+    public func channelCancelMultiFlowSignQRCode(agent: Agent, qrCodeId: String, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> ChannelCancelMultiFlowSignQRCodeResponse {
+        try await self.channelCancelMultiFlowSignQRCode(.init(agent: agent, qrCodeId: qrCodeId), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 取消一码多扫二维码
+    ///
+    /// 此接口（ChannelCancelMultiFlowSignQRCode）用于取消一码多扫二维码。该接口对传入的二维码ID，若还在有效期内，可以提前失效。
+    @available(*, deprecated, renamed: "channelCancelMultiFlowSignQRCode(agent:qrCodeId:region:logger:on:)", message: "'operator' is deprecated. Setting this parameter has no effect.")
     @inlinable @discardableResult
     public func channelCancelMultiFlowSignQRCode(agent: Agent, qrCodeId: String, operator: UserInfo? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> ChannelCancelMultiFlowSignQRCodeResponse {
         try await self.channelCancelMultiFlowSignQRCode(.init(agent: agent, qrCodeId: qrCodeId, operator: `operator`), region: region, logger: logger, on: eventLoop)

--- a/Sources/Teco/Essbasic/V20210526/actions/ChannelCreateBatchCancelFlowUrl.swift
+++ b/Sources/Teco/Essbasic/V20210526/actions/ChannelCreateBatchCancelFlowUrl.swift
@@ -28,12 +28,18 @@ extension Essbasic {
         public let flowIds: [String]
 
         /// 暂未开放
-        public let `operator`: UserInfo?
+        @available(*, deprecated)
+        public let `operator`: UserInfo? = nil
 
+        public init(agent: Agent, flowIds: [String]) {
+            self.agent = agent
+            self.flowIds = flowIds
+        }
+
+        @available(*, deprecated, renamed: "init(agent:flowIds:)", message: "'operator' is deprecated in 'ChannelCreateBatchCancelFlowUrlRequest'. Setting this parameter has no effect.")
         public init(agent: Agent, flowIds: [String], operator: UserInfo? = nil) {
             self.agent = agent
             self.flowIds = flowIds
-            self.operator = `operator`
         }
 
         enum CodingKeys: String, CodingKey {
@@ -109,6 +115,23 @@ extension Essbasic {
     /// 注意:
     /// 能撤回合同的只能是合同的发起人或者发起企业的超管、法人
     @inlinable
+    public func channelCreateBatchCancelFlowUrl(agent: Agent, flowIds: [String], region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<ChannelCreateBatchCancelFlowUrlResponse> {
+        self.channelCreateBatchCancelFlowUrl(.init(agent: agent, flowIds: flowIds), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 根据签署流程id创建批量撤销url
+    ///
+    /// 指定需要批量撤销的签署流程Id，获取批量撤销链接 - 不建议使用此接口，可使用ChannelBatchCancelFlows
+    /// 客户指定需要撤销的签署流程Id，最多100个，超过100不处理；
+    /// 接口调用成功返回批量撤销合同的链接，通过链接跳转到电子签小程序完成批量撤销;
+    ///
+    /// 可以撤回：未全部签署完成
+    ///  不可以撤回：已全部签署完成、已拒签、已过期、已撤回、拒绝填写、已解除等合同状态。
+    ///
+    /// 注意:
+    /// 能撤回合同的只能是合同的发起人或者发起企业的超管、法人
+    @available(*, deprecated, renamed: "channelCreateBatchCancelFlowUrl(agent:flowIds:region:logger:on:)", message: "'operator' is deprecated. Setting this parameter has no effect.")
+    @inlinable
     public func channelCreateBatchCancelFlowUrl(agent: Agent, flowIds: [String], operator: UserInfo? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<ChannelCreateBatchCancelFlowUrlResponse> {
         self.channelCreateBatchCancelFlowUrl(.init(agent: agent, flowIds: flowIds, operator: `operator`), region: region, logger: logger, on: eventLoop)
     }
@@ -124,6 +147,23 @@ extension Essbasic {
     ///
     /// 注意:
     /// 能撤回合同的只能是合同的发起人或者发起企业的超管、法人
+    @inlinable
+    public func channelCreateBatchCancelFlowUrl(agent: Agent, flowIds: [String], region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> ChannelCreateBatchCancelFlowUrlResponse {
+        try await self.channelCreateBatchCancelFlowUrl(.init(agent: agent, flowIds: flowIds), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 根据签署流程id创建批量撤销url
+    ///
+    /// 指定需要批量撤销的签署流程Id，获取批量撤销链接 - 不建议使用此接口，可使用ChannelBatchCancelFlows
+    /// 客户指定需要撤销的签署流程Id，最多100个，超过100不处理；
+    /// 接口调用成功返回批量撤销合同的链接，通过链接跳转到电子签小程序完成批量撤销;
+    ///
+    /// 可以撤回：未全部签署完成
+    ///  不可以撤回：已全部签署完成、已拒签、已过期、已撤回、拒绝填写、已解除等合同状态。
+    ///
+    /// 注意:
+    /// 能撤回合同的只能是合同的发起人或者发起企业的超管、法人
+    @available(*, deprecated, renamed: "channelCreateBatchCancelFlowUrl(agent:flowIds:region:logger:on:)", message: "'operator' is deprecated. Setting this parameter has no effect.")
     @inlinable
     public func channelCreateBatchCancelFlowUrl(agent: Agent, flowIds: [String], operator: UserInfo? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> ChannelCreateBatchCancelFlowUrlResponse {
         try await self.channelCreateBatchCancelFlowUrl(.init(agent: agent, flowIds: flowIds, operator: `operator`), region: region, logger: logger, on: eventLoop)

--- a/Sources/Teco/Essbasic/V20210526/actions/ChannelCreateBoundFlows.swift
+++ b/Sources/Teco/Essbasic/V20210526/actions/ChannelCreateBoundFlows.swift
@@ -29,12 +29,18 @@ extension Essbasic {
         public let flowIds: [String]?
 
         /// 暂未开放
-        public let `operator`: UserInfo?
+        @available(*, deprecated)
+        public let `operator`: UserInfo? = nil
 
+        public init(agent: Agent, flowIds: [String]? = nil) {
+            self.agent = agent
+            self.flowIds = flowIds
+        }
+
+        @available(*, deprecated, renamed: "init(agent:flowIds:)", message: "'operator' is deprecated in 'ChannelCreateBoundFlowsRequest'. Setting this parameter has no effect.")
         public init(agent: Agent, flowIds: [String]? = nil, operator: UserInfo? = nil) {
             self.agent = agent
             self.flowIds = flowIds
-            self.operator = `operator`
         }
 
         enum CodingKeys: String, CodingKey {
@@ -74,6 +80,15 @@ extension Essbasic {
     ///
     /// 此接口（ChannelCreateBoundFlows）用于子客领取合同，经办人需要有相应的角色，合同不能重复领取。
     @inlinable @discardableResult
+    public func channelCreateBoundFlows(agent: Agent, flowIds: [String]? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<ChannelCreateBoundFlowsResponse> {
+        self.channelCreateBoundFlows(.init(agent: agent, flowIds: flowIds), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 领取未归属的合同
+    ///
+    /// 此接口（ChannelCreateBoundFlows）用于子客领取合同，经办人需要有相应的角色，合同不能重复领取。
+    @available(*, deprecated, renamed: "channelCreateBoundFlows(agent:flowIds:region:logger:on:)", message: "'operator' is deprecated. Setting this parameter has no effect.")
+    @inlinable @discardableResult
     public func channelCreateBoundFlows(agent: Agent, flowIds: [String]? = nil, operator: UserInfo? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<ChannelCreateBoundFlowsResponse> {
         self.channelCreateBoundFlows(.init(agent: agent, flowIds: flowIds, operator: `operator`), region: region, logger: logger, on: eventLoop)
     }
@@ -81,6 +96,15 @@ extension Essbasic {
     /// 领取未归属的合同
     ///
     /// 此接口（ChannelCreateBoundFlows）用于子客领取合同，经办人需要有相应的角色，合同不能重复领取。
+    @inlinable @discardableResult
+    public func channelCreateBoundFlows(agent: Agent, flowIds: [String]? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> ChannelCreateBoundFlowsResponse {
+        try await self.channelCreateBoundFlows(.init(agent: agent, flowIds: flowIds), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 领取未归属的合同
+    ///
+    /// 此接口（ChannelCreateBoundFlows）用于子客领取合同，经办人需要有相应的角色，合同不能重复领取。
+    @available(*, deprecated, renamed: "channelCreateBoundFlows(agent:flowIds:region:logger:on:)", message: "'operator' is deprecated. Setting this parameter has no effect.")
     @inlinable @discardableResult
     public func channelCreateBoundFlows(agent: Agent, flowIds: [String]? = nil, operator: UserInfo? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> ChannelCreateBoundFlowsResponse {
         try await self.channelCreateBoundFlows(.init(agent: agent, flowIds: flowIds, operator: `operator`), region: region, logger: logger, on: eventLoop)

--- a/Sources/Teco/Essbasic/V20210526/actions/ChannelCreateConvertTaskApi.swift
+++ b/Sources/Teco/Essbasic/V20210526/actions/ChannelCreateConvertTaskApi.swift
@@ -34,18 +34,26 @@ extension Essbasic {
         public let resourceId: String
 
         /// 调用方用户信息，不用传
-        public let `operator`: UserInfo?
+        @available(*, deprecated)
+        public let `operator`: UserInfo? = nil
 
         /// 暂未开放
-        public let organization: OrganizationInfo?
+        @available(*, deprecated)
+        public let organization: OrganizationInfo? = nil
 
+        public init(agent: Agent, resourceType: String, resourceName: String, resourceId: String) {
+            self.agent = agent
+            self.resourceType = resourceType
+            self.resourceName = resourceName
+            self.resourceId = resourceId
+        }
+
+        @available(*, deprecated, renamed: "init(agent:resourceType:resourceName:resourceId:)", message: "'operator' and 'organization' are deprecated in 'ChannelCreateConvertTaskApiRequest'. Setting these parameters has no effect.")
         public init(agent: Agent, resourceType: String, resourceName: String, resourceId: String, operator: UserInfo? = nil, organization: OrganizationInfo? = nil) {
             self.agent = agent
             self.resourceType = resourceType
             self.resourceName = resourceName
             self.resourceId = resourceId
-            self.operator = `operator`
-            self.organization = organization
         }
 
         enum CodingKeys: String, CodingKey {
@@ -92,6 +100,15 @@ extension Essbasic {
     ///
     /// 上传了word、excel、图片文件后，通过该接口发起文件转换任务，将word、excel、图片文件转换为pdf文件。
     @inlinable
+    public func channelCreateConvertTaskApi(agent: Agent, resourceType: String, resourceName: String, resourceId: String, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<ChannelCreateConvertTaskApiResponse> {
+        self.channelCreateConvertTaskApi(.init(agent: agent, resourceType: resourceType, resourceName: resourceName, resourceId: resourceId), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 创建文件转换任务
+    ///
+    /// 上传了word、excel、图片文件后，通过该接口发起文件转换任务，将word、excel、图片文件转换为pdf文件。
+    @available(*, deprecated, renamed: "channelCreateConvertTaskApi(agent:resourceType:resourceName:resourceId:region:logger:on:)", message: "'operator' and 'organization' are deprecated. Setting these parameters has no effect.")
+    @inlinable
     public func channelCreateConvertTaskApi(agent: Agent, resourceType: String, resourceName: String, resourceId: String, operator: UserInfo? = nil, organization: OrganizationInfo? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<ChannelCreateConvertTaskApiResponse> {
         self.channelCreateConvertTaskApi(.init(agent: agent, resourceType: resourceType, resourceName: resourceName, resourceId: resourceId, operator: `operator`, organization: organization), region: region, logger: logger, on: eventLoop)
     }
@@ -99,6 +116,15 @@ extension Essbasic {
     /// 创建文件转换任务
     ///
     /// 上传了word、excel、图片文件后，通过该接口发起文件转换任务，将word、excel、图片文件转换为pdf文件。
+    @inlinable
+    public func channelCreateConvertTaskApi(agent: Agent, resourceType: String, resourceName: String, resourceId: String, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> ChannelCreateConvertTaskApiResponse {
+        try await self.channelCreateConvertTaskApi(.init(agent: agent, resourceType: resourceType, resourceName: resourceName, resourceId: resourceId), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 创建文件转换任务
+    ///
+    /// 上传了word、excel、图片文件后，通过该接口发起文件转换任务，将word、excel、图片文件转换为pdf文件。
+    @available(*, deprecated, renamed: "channelCreateConvertTaskApi(agent:resourceType:resourceName:resourceId:region:logger:on:)", message: "'operator' and 'organization' are deprecated. Setting these parameters has no effect.")
     @inlinable
     public func channelCreateConvertTaskApi(agent: Agent, resourceType: String, resourceName: String, resourceId: String, operator: UserInfo? = nil, organization: OrganizationInfo? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> ChannelCreateConvertTaskApiResponse {
         try await self.channelCreateConvertTaskApi(.init(agent: agent, resourceType: resourceType, resourceName: resourceName, resourceId: resourceId, operator: `operator`, organization: organization), region: region, logger: logger, on: eventLoop)

--- a/Sources/Teco/Essbasic/V20210526/actions/ChannelCreateEmbedWebUrl.swift
+++ b/Sources/Teco/Essbasic/V20210526/actions/ChannelCreateEmbedWebUrl.swift
@@ -48,14 +48,22 @@ extension Essbasic {
         public let hiddenComponents: Bool?
 
         /// 渠道操作者信息
-        public let `operator`: UserInfo?
+        @available(*, deprecated)
+        public let `operator`: UserInfo? = nil
 
+        public init(agent: Agent, embedType: String, businessId: String? = nil, hiddenComponents: Bool? = nil) {
+            self.agent = agent
+            self.embedType = embedType
+            self.businessId = businessId
+            self.hiddenComponents = hiddenComponents
+        }
+
+        @available(*, deprecated, renamed: "init(agent:embedType:businessId:hiddenComponents:)", message: "'operator' is deprecated in 'ChannelCreateEmbedWebUrlRequest'. Setting this parameter has no effect.")
         public init(agent: Agent, embedType: String, businessId: String? = nil, hiddenComponents: Bool? = nil, operator: UserInfo? = nil) {
             self.agent = agent
             self.embedType = embedType
             self.businessId = businessId
             self.hiddenComponents = hiddenComponents
-            self.operator = `operator`
         }
 
         enum CodingKeys: String, CodingKey {
@@ -107,6 +115,17 @@ extension Essbasic {
     /// 本接口支持创建：创建印章，创建模板，修改模板，预览模板，预览合同流程的web链接
     /// 进入web连接后与当前控制台操作保持一致
     @inlinable
+    public func channelCreateEmbedWebUrl(agent: Agent, embedType: String, businessId: String? = nil, hiddenComponents: Bool? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<ChannelCreateEmbedWebUrlResponse> {
+        self.channelCreateEmbedWebUrl(.init(agent: agent, embedType: embedType, businessId: businessId, hiddenComponents: hiddenComponents), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 获取常规模块web页面
+    ///
+    /// 本接口（ChannelCreateEmbedWebUrl）用于创建常规模块嵌入web的链接
+    /// 本接口支持创建：创建印章，创建模板，修改模板，预览模板，预览合同流程的web链接
+    /// 进入web连接后与当前控制台操作保持一致
+    @available(*, deprecated, renamed: "channelCreateEmbedWebUrl(agent:embedType:businessId:hiddenComponents:region:logger:on:)", message: "'operator' is deprecated. Setting this parameter has no effect.")
+    @inlinable
     public func channelCreateEmbedWebUrl(agent: Agent, embedType: String, businessId: String? = nil, hiddenComponents: Bool? = nil, operator: UserInfo? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<ChannelCreateEmbedWebUrlResponse> {
         self.channelCreateEmbedWebUrl(.init(agent: agent, embedType: embedType, businessId: businessId, hiddenComponents: hiddenComponents, operator: `operator`), region: region, logger: logger, on: eventLoop)
     }
@@ -116,6 +135,17 @@ extension Essbasic {
     /// 本接口（ChannelCreateEmbedWebUrl）用于创建常规模块嵌入web的链接
     /// 本接口支持创建：创建印章，创建模板，修改模板，预览模板，预览合同流程的web链接
     /// 进入web连接后与当前控制台操作保持一致
+    @inlinable
+    public func channelCreateEmbedWebUrl(agent: Agent, embedType: String, businessId: String? = nil, hiddenComponents: Bool? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> ChannelCreateEmbedWebUrlResponse {
+        try await self.channelCreateEmbedWebUrl(.init(agent: agent, embedType: embedType, businessId: businessId, hiddenComponents: hiddenComponents), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 获取常规模块web页面
+    ///
+    /// 本接口（ChannelCreateEmbedWebUrl）用于创建常规模块嵌入web的链接
+    /// 本接口支持创建：创建印章，创建模板，修改模板，预览模板，预览合同流程的web链接
+    /// 进入web连接后与当前控制台操作保持一致
+    @available(*, deprecated, renamed: "channelCreateEmbedWebUrl(agent:embedType:businessId:hiddenComponents:region:logger:on:)", message: "'operator' is deprecated. Setting this parameter has no effect.")
     @inlinable
     public func channelCreateEmbedWebUrl(agent: Agent, embedType: String, businessId: String? = nil, hiddenComponents: Bool? = nil, operator: UserInfo? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> ChannelCreateEmbedWebUrlResponse {
         try await self.channelCreateEmbedWebUrl(.init(agent: agent, embedType: embedType, businessId: businessId, hiddenComponents: hiddenComponents, operator: `operator`), region: region, logger: logger, on: eventLoop)

--- a/Sources/Teco/Essbasic/V20210526/actions/ChannelCreateFlowByFiles.swift
+++ b/Sources/Teco/Essbasic/V20210526/actions/ChannelCreateFlowByFiles.swift
@@ -79,8 +79,31 @@ extension Essbasic {
         public let autoSignScene: String?
 
         /// 操作者的信息，不用传
-        public let `operator`: UserInfo?
+        @available(*, deprecated)
+        public let `operator`: UserInfo? = nil
 
+        public init(agent: Agent? = nil, flowName: String? = nil, flowApprovers: [FlowApproverInfo]? = nil, fileIds: [String]? = nil, components: [Component]? = nil, deadline: Int64? = nil, callbackUrl: String? = nil, unordered: Bool? = nil, flowType: String? = nil, flowDescription: String? = nil, customShowMap: String? = nil, customerData: String? = nil, needSignReview: Bool? = nil, approverVerifyType: String? = nil, signBeanTag: Int64? = nil, ccInfos: [CcInfo]? = nil, ccNotifyType: Int64? = nil, autoSignScene: String? = nil) {
+            self.agent = agent
+            self.flowName = flowName
+            self.flowApprovers = flowApprovers
+            self.fileIds = fileIds
+            self.components = components
+            self.deadline = deadline
+            self.callbackUrl = callbackUrl
+            self.unordered = unordered
+            self.flowType = flowType
+            self.flowDescription = flowDescription
+            self.customShowMap = customShowMap
+            self.customerData = customerData
+            self.needSignReview = needSignReview
+            self.approverVerifyType = approverVerifyType
+            self.signBeanTag = signBeanTag
+            self.ccInfos = ccInfos
+            self.ccNotifyType = ccNotifyType
+            self.autoSignScene = autoSignScene
+        }
+
+        @available(*, deprecated, renamed: "init(agent:flowName:flowApprovers:fileIds:components:deadline:callbackUrl:unordered:flowType:flowDescription:customShowMap:customerData:needSignReview:approverVerifyType:signBeanTag:ccInfos:ccNotifyType:autoSignScene:)", message: "'operator' is deprecated in 'ChannelCreateFlowByFilesRequest'. Setting this parameter has no effect.")
         public init(agent: Agent? = nil, flowName: String? = nil, flowApprovers: [FlowApproverInfo]? = nil, fileIds: [String]? = nil, components: [Component]? = nil, deadline: Int64? = nil, callbackUrl: String? = nil, unordered: Bool? = nil, flowType: String? = nil, flowDescription: String? = nil, customShowMap: String? = nil, customerData: String? = nil, needSignReview: Bool? = nil, approverVerifyType: String? = nil, signBeanTag: Int64? = nil, ccInfos: [CcInfo]? = nil, ccNotifyType: Int64? = nil, autoSignScene: String? = nil, operator: UserInfo? = nil) {
             self.agent = agent
             self.flowName = flowName
@@ -100,7 +123,6 @@ extension Essbasic {
             self.ccInfos = ccInfos
             self.ccNotifyType = ccNotifyType
             self.autoSignScene = autoSignScene
-            self.operator = `operator`
         }
 
         enum CodingKeys: String, CodingKey {
@@ -161,6 +183,15 @@ extension Essbasic {
     ///
     /// 接口（ChannelCreateFlowByFiles）用于通过文件创建签署流程。此接口静默签能力不可直接使用，请联系客户经理申请使用
     @inlinable
+    public func channelCreateFlowByFiles(agent: Agent? = nil, flowName: String? = nil, flowApprovers: [FlowApproverInfo]? = nil, fileIds: [String]? = nil, components: [Component]? = nil, deadline: Int64? = nil, callbackUrl: String? = nil, unordered: Bool? = nil, flowType: String? = nil, flowDescription: String? = nil, customShowMap: String? = nil, customerData: String? = nil, needSignReview: Bool? = nil, approverVerifyType: String? = nil, signBeanTag: Int64? = nil, ccInfos: [CcInfo]? = nil, ccNotifyType: Int64? = nil, autoSignScene: String? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<ChannelCreateFlowByFilesResponse> {
+        self.channelCreateFlowByFiles(.init(agent: agent, flowName: flowName, flowApprovers: flowApprovers, fileIds: fileIds, components: components, deadline: deadline, callbackUrl: callbackUrl, unordered: unordered, flowType: flowType, flowDescription: flowDescription, customShowMap: customShowMap, customerData: customerData, needSignReview: needSignReview, approverVerifyType: approverVerifyType, signBeanTag: signBeanTag, ccInfos: ccInfos, ccNotifyType: ccNotifyType, autoSignScene: autoSignScene), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 通过文件创建签署流程
+    ///
+    /// 接口（ChannelCreateFlowByFiles）用于通过文件创建签署流程。此接口静默签能力不可直接使用，请联系客户经理申请使用
+    @available(*, deprecated, renamed: "channelCreateFlowByFiles(agent:flowName:flowApprovers:fileIds:components:deadline:callbackUrl:unordered:flowType:flowDescription:customShowMap:customerData:needSignReview:approverVerifyType:signBeanTag:ccInfos:ccNotifyType:autoSignScene:region:logger:on:)", message: "'operator' is deprecated. Setting this parameter has no effect.")
+    @inlinable
     public func channelCreateFlowByFiles(agent: Agent? = nil, flowName: String? = nil, flowApprovers: [FlowApproverInfo]? = nil, fileIds: [String]? = nil, components: [Component]? = nil, deadline: Int64? = nil, callbackUrl: String? = nil, unordered: Bool? = nil, flowType: String? = nil, flowDescription: String? = nil, customShowMap: String? = nil, customerData: String? = nil, needSignReview: Bool? = nil, approverVerifyType: String? = nil, signBeanTag: Int64? = nil, ccInfos: [CcInfo]? = nil, ccNotifyType: Int64? = nil, autoSignScene: String? = nil, operator: UserInfo? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<ChannelCreateFlowByFilesResponse> {
         self.channelCreateFlowByFiles(.init(agent: agent, flowName: flowName, flowApprovers: flowApprovers, fileIds: fileIds, components: components, deadline: deadline, callbackUrl: callbackUrl, unordered: unordered, flowType: flowType, flowDescription: flowDescription, customShowMap: customShowMap, customerData: customerData, needSignReview: needSignReview, approverVerifyType: approverVerifyType, signBeanTag: signBeanTag, ccInfos: ccInfos, ccNotifyType: ccNotifyType, autoSignScene: autoSignScene, operator: `operator`), region: region, logger: logger, on: eventLoop)
     }
@@ -168,6 +199,15 @@ extension Essbasic {
     /// 通过文件创建签署流程
     ///
     /// 接口（ChannelCreateFlowByFiles）用于通过文件创建签署流程。此接口静默签能力不可直接使用，请联系客户经理申请使用
+    @inlinable
+    public func channelCreateFlowByFiles(agent: Agent? = nil, flowName: String? = nil, flowApprovers: [FlowApproverInfo]? = nil, fileIds: [String]? = nil, components: [Component]? = nil, deadline: Int64? = nil, callbackUrl: String? = nil, unordered: Bool? = nil, flowType: String? = nil, flowDescription: String? = nil, customShowMap: String? = nil, customerData: String? = nil, needSignReview: Bool? = nil, approverVerifyType: String? = nil, signBeanTag: Int64? = nil, ccInfos: [CcInfo]? = nil, ccNotifyType: Int64? = nil, autoSignScene: String? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> ChannelCreateFlowByFilesResponse {
+        try await self.channelCreateFlowByFiles(.init(agent: agent, flowName: flowName, flowApprovers: flowApprovers, fileIds: fileIds, components: components, deadline: deadline, callbackUrl: callbackUrl, unordered: unordered, flowType: flowType, flowDescription: flowDescription, customShowMap: customShowMap, customerData: customerData, needSignReview: needSignReview, approverVerifyType: approverVerifyType, signBeanTag: signBeanTag, ccInfos: ccInfos, ccNotifyType: ccNotifyType, autoSignScene: autoSignScene), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 通过文件创建签署流程
+    ///
+    /// 接口（ChannelCreateFlowByFiles）用于通过文件创建签署流程。此接口静默签能力不可直接使用，请联系客户经理申请使用
+    @available(*, deprecated, renamed: "channelCreateFlowByFiles(agent:flowName:flowApprovers:fileIds:components:deadline:callbackUrl:unordered:flowType:flowDescription:customShowMap:customerData:needSignReview:approverVerifyType:signBeanTag:ccInfos:ccNotifyType:autoSignScene:region:logger:on:)", message: "'operator' is deprecated. Setting this parameter has no effect.")
     @inlinable
     public func channelCreateFlowByFiles(agent: Agent? = nil, flowName: String? = nil, flowApprovers: [FlowApproverInfo]? = nil, fileIds: [String]? = nil, components: [Component]? = nil, deadline: Int64? = nil, callbackUrl: String? = nil, unordered: Bool? = nil, flowType: String? = nil, flowDescription: String? = nil, customShowMap: String? = nil, customerData: String? = nil, needSignReview: Bool? = nil, approverVerifyType: String? = nil, signBeanTag: Int64? = nil, ccInfos: [CcInfo]? = nil, ccNotifyType: Int64? = nil, autoSignScene: String? = nil, operator: UserInfo? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> ChannelCreateFlowByFilesResponse {
         try await self.channelCreateFlowByFiles(.init(agent: agent, flowName: flowName, flowApprovers: flowApprovers, fileIds: fileIds, components: components, deadline: deadline, callbackUrl: callbackUrl, unordered: unordered, flowType: flowType, flowDescription: flowDescription, customShowMap: customShowMap, customerData: customerData, needSignReview: needSignReview, approverVerifyType: approverVerifyType, signBeanTag: signBeanTag, ccInfos: ccInfos, ccNotifyType: ccNotifyType, autoSignScene: autoSignScene, operator: `operator`), region: region, logger: logger, on: eventLoop)

--- a/Sources/Teco/Essbasic/V20210526/actions/ChannelCreateFlowGroupByFiles.swift
+++ b/Sources/Teco/Essbasic/V20210526/actions/ChannelCreateFlowGroupByFiles.swift
@@ -37,14 +37,22 @@ extension Essbasic {
         public let approverVerifyType: String?
 
         /// 操作者的信息，此参数不用传
-        public let `operator`: UserInfo?
+        @available(*, deprecated)
+        public let `operator`: UserInfo? = nil
 
+        public init(flowFileInfos: [FlowFileInfo], flowGroupName: String, agent: Agent? = nil, approverVerifyType: String? = nil) {
+            self.flowFileInfos = flowFileInfos
+            self.flowGroupName = flowGroupName
+            self.agent = agent
+            self.approverVerifyType = approverVerifyType
+        }
+
+        @available(*, deprecated, renamed: "init(flowFileInfos:flowGroupName:agent:approverVerifyType:)", message: "'operator' is deprecated in 'ChannelCreateFlowGroupByFilesRequest'. Setting this parameter has no effect.")
         public init(flowFileInfos: [FlowFileInfo], flowGroupName: String, agent: Agent? = nil, approverVerifyType: String? = nil, operator: UserInfo? = nil) {
             self.flowFileInfos = flowFileInfos
             self.flowGroupName = flowGroupName
             self.agent = agent
             self.approverVerifyType = approverVerifyType
-            self.operator = `operator`
         }
 
         enum CodingKeys: String, CodingKey {
@@ -96,6 +104,15 @@ extension Essbasic {
     ///
     /// 接口（ChannelCreateFlowGroupByFiles）用于通过多文件创建合同组签署流程。
     @inlinable
+    public func channelCreateFlowGroupByFiles(flowFileInfos: [FlowFileInfo], flowGroupName: String, agent: Agent? = nil, approverVerifyType: String? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<ChannelCreateFlowGroupByFilesResponse> {
+        self.channelCreateFlowGroupByFiles(.init(flowFileInfos: flowFileInfos, flowGroupName: flowGroupName, agent: agent, approverVerifyType: approverVerifyType), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 通过多文件创建合同组签署流程
+    ///
+    /// 接口（ChannelCreateFlowGroupByFiles）用于通过多文件创建合同组签署流程。
+    @available(*, deprecated, renamed: "channelCreateFlowGroupByFiles(flowFileInfos:flowGroupName:agent:approverVerifyType:region:logger:on:)", message: "'operator' is deprecated. Setting this parameter has no effect.")
+    @inlinable
     public func channelCreateFlowGroupByFiles(flowFileInfos: [FlowFileInfo], flowGroupName: String, agent: Agent? = nil, approverVerifyType: String? = nil, operator: UserInfo? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<ChannelCreateFlowGroupByFilesResponse> {
         self.channelCreateFlowGroupByFiles(.init(flowFileInfos: flowFileInfos, flowGroupName: flowGroupName, agent: agent, approverVerifyType: approverVerifyType, operator: `operator`), region: region, logger: logger, on: eventLoop)
     }
@@ -103,6 +120,15 @@ extension Essbasic {
     /// 通过多文件创建合同组签署流程
     ///
     /// 接口（ChannelCreateFlowGroupByFiles）用于通过多文件创建合同组签署流程。
+    @inlinable
+    public func channelCreateFlowGroupByFiles(flowFileInfos: [FlowFileInfo], flowGroupName: String, agent: Agent? = nil, approverVerifyType: String? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> ChannelCreateFlowGroupByFilesResponse {
+        try await self.channelCreateFlowGroupByFiles(.init(flowFileInfos: flowFileInfos, flowGroupName: flowGroupName, agent: agent, approverVerifyType: approverVerifyType), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 通过多文件创建合同组签署流程
+    ///
+    /// 接口（ChannelCreateFlowGroupByFiles）用于通过多文件创建合同组签署流程。
+    @available(*, deprecated, renamed: "channelCreateFlowGroupByFiles(flowFileInfos:flowGroupName:agent:approverVerifyType:region:logger:on:)", message: "'operator' is deprecated. Setting this parameter has no effect.")
     @inlinable
     public func channelCreateFlowGroupByFiles(flowFileInfos: [FlowFileInfo], flowGroupName: String, agent: Agent? = nil, approverVerifyType: String? = nil, operator: UserInfo? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> ChannelCreateFlowGroupByFilesResponse {
         try await self.channelCreateFlowGroupByFiles(.init(flowFileInfos: flowFileInfos, flowGroupName: flowGroupName, agent: agent, approverVerifyType: approverVerifyType, operator: `operator`), region: region, logger: logger, on: eventLoop)

--- a/Sources/Teco/Essbasic/V20210526/actions/ChannelCreateFlowSignUrl.swift
+++ b/Sources/Teco/Essbasic/V20210526/actions/ChannelCreateFlowSignUrl.swift
@@ -31,20 +31,28 @@ extension Essbasic {
         public let flowApproverInfos: [FlowApproverInfo]
 
         /// 用户信息，暂未开放
-        public let `operator`: UserInfo?
+        @available(*, deprecated)
+        public let `operator`: UserInfo? = nil
 
         /// 机构信息，暂未开放
-        public let organization: OrganizationInfo?
+        @available(*, deprecated)
+        public let organization: OrganizationInfo? = nil
 
         /// 签署完之后的H5页面的跳转链接，此链接支持http://和https://，最大长度1000个字符。
         public let jumpUrl: String?
 
+        public init(agent: Agent, flowId: String, flowApproverInfos: [FlowApproverInfo], jumpUrl: String? = nil) {
+            self.agent = agent
+            self.flowId = flowId
+            self.flowApproverInfos = flowApproverInfos
+            self.jumpUrl = jumpUrl
+        }
+
+        @available(*, deprecated, renamed: "init(agent:flowId:flowApproverInfos:jumpUrl:)", message: "'operator' and 'organization' are deprecated in 'ChannelCreateFlowSignUrlRequest'. Setting these parameters has no effect.")
         public init(agent: Agent, flowId: String, flowApproverInfos: [FlowApproverInfo], operator: UserInfo? = nil, organization: OrganizationInfo? = nil, jumpUrl: String? = nil) {
             self.agent = agent
             self.flowId = flowId
             self.flowApproverInfos = flowApproverInfos
-            self.operator = `operator`
-            self.organization = organization
             self.jumpUrl = jumpUrl
         }
 
@@ -104,6 +112,19 @@ extension Essbasic {
     /// 注意：该接口可生成签署链接的C端签署人必须仅有手写签名和时间类型的签署控件<br/>
     /// 注意：该接口返回的签署链接是用于APP集成的场景，支持APP打开或浏览器直接打开，不支持微信小程序嵌入。微信小程序请使用小程序跳转或半屏弹窗的方式<br/>
     @inlinable
+    public func channelCreateFlowSignUrl(agent: Agent, flowId: String, flowApproverInfos: [FlowApproverInfo], jumpUrl: String? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<ChannelCreateFlowSignUrlResponse> {
+        self.channelCreateFlowSignUrl(.init(agent: agent, flowId: flowId, flowApproverInfos: flowApproverInfos, jumpUrl: jumpUrl), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 获取个人签署H5页面
+    ///
+    /// 创建个人签署H5签署链接，请联系客户经理申请使用<br/>
+    /// 该接口用于发起合同后，生成C端签署人的签署链接<br/>
+    /// 注意：该接口目前签署人类型仅支持个人签署方（PERSON）<br/>
+    /// 注意：该接口可生成签署链接的C端签署人必须仅有手写签名和时间类型的签署控件<br/>
+    /// 注意：该接口返回的签署链接是用于APP集成的场景，支持APP打开或浏览器直接打开，不支持微信小程序嵌入。微信小程序请使用小程序跳转或半屏弹窗的方式<br/>
+    @available(*, deprecated, renamed: "channelCreateFlowSignUrl(agent:flowId:flowApproverInfos:jumpUrl:region:logger:on:)", message: "'operator' and 'organization' are deprecated. Setting these parameters has no effect.")
+    @inlinable
     public func channelCreateFlowSignUrl(agent: Agent, flowId: String, flowApproverInfos: [FlowApproverInfo], operator: UserInfo? = nil, organization: OrganizationInfo? = nil, jumpUrl: String? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<ChannelCreateFlowSignUrlResponse> {
         self.channelCreateFlowSignUrl(.init(agent: agent, flowId: flowId, flowApproverInfos: flowApproverInfos, operator: `operator`, organization: organization, jumpUrl: jumpUrl), region: region, logger: logger, on: eventLoop)
     }
@@ -115,6 +136,19 @@ extension Essbasic {
     /// 注意：该接口目前签署人类型仅支持个人签署方（PERSON）<br/>
     /// 注意：该接口可生成签署链接的C端签署人必须仅有手写签名和时间类型的签署控件<br/>
     /// 注意：该接口返回的签署链接是用于APP集成的场景，支持APP打开或浏览器直接打开，不支持微信小程序嵌入。微信小程序请使用小程序跳转或半屏弹窗的方式<br/>
+    @inlinable
+    public func channelCreateFlowSignUrl(agent: Agent, flowId: String, flowApproverInfos: [FlowApproverInfo], jumpUrl: String? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> ChannelCreateFlowSignUrlResponse {
+        try await self.channelCreateFlowSignUrl(.init(agent: agent, flowId: flowId, flowApproverInfos: flowApproverInfos, jumpUrl: jumpUrl), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 获取个人签署H5页面
+    ///
+    /// 创建个人签署H5签署链接，请联系客户经理申请使用<br/>
+    /// 该接口用于发起合同后，生成C端签署人的签署链接<br/>
+    /// 注意：该接口目前签署人类型仅支持个人签署方（PERSON）<br/>
+    /// 注意：该接口可生成签署链接的C端签署人必须仅有手写签名和时间类型的签署控件<br/>
+    /// 注意：该接口返回的签署链接是用于APP集成的场景，支持APP打开或浏览器直接打开，不支持微信小程序嵌入。微信小程序请使用小程序跳转或半屏弹窗的方式<br/>
+    @available(*, deprecated, renamed: "channelCreateFlowSignUrl(agent:flowId:flowApproverInfos:jumpUrl:region:logger:on:)", message: "'operator' and 'organization' are deprecated. Setting these parameters has no effect.")
     @inlinable
     public func channelCreateFlowSignUrl(agent: Agent, flowId: String, flowApproverInfos: [FlowApproverInfo], operator: UserInfo? = nil, organization: OrganizationInfo? = nil, jumpUrl: String? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> ChannelCreateFlowSignUrlResponse {
         try await self.channelCreateFlowSignUrl(.init(agent: agent, flowId: flowId, flowApproverInfos: flowApproverInfos, operator: `operator`, organization: organization, jumpUrl: jumpUrl), region: region, logger: logger, on: eventLoop)

--- a/Sources/Teco/Essbasic/V20210526/actions/ChannelCreateMultiFlowSignQRCode.swift
+++ b/Sources/Teco/Essbasic/V20210526/actions/ChannelCreateMultiFlowSignQRCode.swift
@@ -52,11 +52,25 @@ extension Essbasic {
         public let callbackUrl: String?
 
         /// 限制二维码用户条件（已弃用）
-        public let approverRestrictions: ApproverRestriction?
+        @available(*, deprecated)
+        public let approverRestrictions: ApproverRestriction? = nil
 
         /// 暂未开放
-        public let `operator`: UserInfo?
+        @available(*, deprecated)
+        public let `operator`: UserInfo? = nil
 
+        public init(agent: Agent, templateId: String, flowName: String, maxFlowNum: Int64? = nil, flowEffectiveDay: Int64? = nil, qrEffectiveDay: Int64? = nil, restrictions: [ApproverRestriction]? = nil, callbackUrl: String? = nil) {
+            self.agent = agent
+            self.templateId = templateId
+            self.flowName = flowName
+            self.maxFlowNum = maxFlowNum
+            self.flowEffectiveDay = flowEffectiveDay
+            self.qrEffectiveDay = qrEffectiveDay
+            self.restrictions = restrictions
+            self.callbackUrl = callbackUrl
+        }
+
+        @available(*, deprecated, renamed: "init(agent:templateId:flowName:maxFlowNum:flowEffectiveDay:qrEffectiveDay:restrictions:callbackUrl:)", message: "'approverRestrictions' and 'operator' are deprecated in 'ChannelCreateMultiFlowSignQRCodeRequest'. Setting these parameters has no effect.")
         public init(agent: Agent, templateId: String, flowName: String, maxFlowNum: Int64? = nil, flowEffectiveDay: Int64? = nil, qrEffectiveDay: Int64? = nil, restrictions: [ApproverRestriction]? = nil, callbackUrl: String? = nil, approverRestrictions: ApproverRestriction? = nil, operator: UserInfo? = nil) {
             self.agent = agent
             self.templateId = templateId
@@ -66,8 +80,6 @@ extension Essbasic {
             self.qrEffectiveDay = qrEffectiveDay
             self.restrictions = restrictions
             self.callbackUrl = callbackUrl
-            self.approverRestrictions = approverRestrictions
-            self.operator = `operator`
         }
 
         enum CodingKeys: String, CodingKey {
@@ -146,6 +158,23 @@ extension Essbasic {
     /// - B端企业的签署方式是静默签署
     /// - B端企业是非首位签署
     @inlinable
+    public func channelCreateMultiFlowSignQRCode(agent: Agent, templateId: String, flowName: String, maxFlowNum: Int64? = nil, flowEffectiveDay: Int64? = nil, qrEffectiveDay: Int64? = nil, restrictions: [ApproverRestriction]? = nil, callbackUrl: String? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<ChannelCreateMultiFlowSignQRCodeResponse> {
+        self.channelCreateMultiFlowSignQRCode(.init(agent: agent, templateId: templateId, flowName: flowName, maxFlowNum: maxFlowNum, flowEffectiveDay: flowEffectiveDay, qrEffectiveDay: qrEffectiveDay, restrictions: restrictions, callbackUrl: callbackUrl), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 创建一码多扫签署流程二维码
+    ///
+    /// 此接口（ChannelCreateMultiFlowSignQRCode）用于创建一码多扫流程签署二维码。 适用场景：无需填写签署人信息，可通过模板id生成签署二维码，签署人可通过扫描二维码补充签署信息进行实名签署。常用于提前不知道签署人的身份信息场景，例如：劳务工招工、大批量员工入职等场景。
+    ///
+    /// **本接口适用于发起方没有填写控件的 B2C或者单C模板**
+    ///
+    /// **若是B2C模板,还要满足以下任意一个条件**
+    ///
+    /// - 模板中配置的签署顺序是无序
+    /// - B端企业的签署方式是静默签署
+    /// - B端企业是非首位签署
+    @available(*, deprecated, renamed: "channelCreateMultiFlowSignQRCode(agent:templateId:flowName:maxFlowNum:flowEffectiveDay:qrEffectiveDay:restrictions:callbackUrl:region:logger:on:)", message: "'approverRestrictions' and 'operator' are deprecated. Setting these parameters has no effect.")
+    @inlinable
     public func channelCreateMultiFlowSignQRCode(agent: Agent, templateId: String, flowName: String, maxFlowNum: Int64? = nil, flowEffectiveDay: Int64? = nil, qrEffectiveDay: Int64? = nil, restrictions: [ApproverRestriction]? = nil, callbackUrl: String? = nil, approverRestrictions: ApproverRestriction? = nil, operator: UserInfo? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<ChannelCreateMultiFlowSignQRCodeResponse> {
         self.channelCreateMultiFlowSignQRCode(.init(agent: agent, templateId: templateId, flowName: flowName, maxFlowNum: maxFlowNum, flowEffectiveDay: flowEffectiveDay, qrEffectiveDay: qrEffectiveDay, restrictions: restrictions, callbackUrl: callbackUrl, approverRestrictions: approverRestrictions, operator: `operator`), region: region, logger: logger, on: eventLoop)
     }
@@ -161,6 +190,23 @@ extension Essbasic {
     /// - 模板中配置的签署顺序是无序
     /// - B端企业的签署方式是静默签署
     /// - B端企业是非首位签署
+    @inlinable
+    public func channelCreateMultiFlowSignQRCode(agent: Agent, templateId: String, flowName: String, maxFlowNum: Int64? = nil, flowEffectiveDay: Int64? = nil, qrEffectiveDay: Int64? = nil, restrictions: [ApproverRestriction]? = nil, callbackUrl: String? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> ChannelCreateMultiFlowSignQRCodeResponse {
+        try await self.channelCreateMultiFlowSignQRCode(.init(agent: agent, templateId: templateId, flowName: flowName, maxFlowNum: maxFlowNum, flowEffectiveDay: flowEffectiveDay, qrEffectiveDay: qrEffectiveDay, restrictions: restrictions, callbackUrl: callbackUrl), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 创建一码多扫签署流程二维码
+    ///
+    /// 此接口（ChannelCreateMultiFlowSignQRCode）用于创建一码多扫流程签署二维码。 适用场景：无需填写签署人信息，可通过模板id生成签署二维码，签署人可通过扫描二维码补充签署信息进行实名签署。常用于提前不知道签署人的身份信息场景，例如：劳务工招工、大批量员工入职等场景。
+    ///
+    /// **本接口适用于发起方没有填写控件的 B2C或者单C模板**
+    ///
+    /// **若是B2C模板,还要满足以下任意一个条件**
+    ///
+    /// - 模板中配置的签署顺序是无序
+    /// - B端企业的签署方式是静默签署
+    /// - B端企业是非首位签署
+    @available(*, deprecated, renamed: "channelCreateMultiFlowSignQRCode(agent:templateId:flowName:maxFlowNum:flowEffectiveDay:qrEffectiveDay:restrictions:callbackUrl:region:logger:on:)", message: "'approverRestrictions' and 'operator' are deprecated. Setting these parameters has no effect.")
     @inlinable
     public func channelCreateMultiFlowSignQRCode(agent: Agent, templateId: String, flowName: String, maxFlowNum: Int64? = nil, flowEffectiveDay: Int64? = nil, qrEffectiveDay: Int64? = nil, restrictions: [ApproverRestriction]? = nil, callbackUrl: String? = nil, approverRestrictions: ApproverRestriction? = nil, operator: UserInfo? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> ChannelCreateMultiFlowSignQRCodeResponse {
         try await self.channelCreateMultiFlowSignQRCode(.init(agent: agent, templateId: templateId, flowName: flowName, maxFlowNum: maxFlowNum, flowEffectiveDay: flowEffectiveDay, qrEffectiveDay: qrEffectiveDay, restrictions: restrictions, callbackUrl: callbackUrl, approverRestrictions: approverRestrictions, operator: `operator`), region: region, logger: logger, on: eventLoop)

--- a/Sources/Teco/Essbasic/V20210526/actions/ChannelCreateOrganizationModifyQrCode.swift
+++ b/Sources/Teco/Essbasic/V20210526/actions/ChannelCreateOrganizationModifyQrCode.swift
@@ -36,10 +36,10 @@ extension Essbasic {
     /// ChannelCreateOrganizationModifyQrCode返回参数结构体
     public struct ChannelCreateOrganizationModifyQrCodeResponse: TCResponseModel {
         /// 二维码下载链接
-        public let qrCodeUrl: String
+        public let qrCodeUrl: String?
 
         /// 二维码失效时间 UNIX 时间戳 精确到秒
-        public let expiredTime: Int64
+        public let expiredTime: Int64?
 
         /// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
         public let requestId: String

--- a/Sources/Teco/Essbasic/V20210526/actions/ChannelCreatePrepareFlow.swift
+++ b/Sources/Teco/Essbasic/V20210526/actions/ChannelCreatePrepareFlow.swift
@@ -43,14 +43,28 @@ extension Essbasic {
         public let flowId: String?
 
         /// 该参数不可用，请通过获取 web 可嵌入接口获取合同流程预览 URL
-        public let needPreview: Bool?
+        @available(*, deprecated)
+        public let needPreview: Bool? = nil
 
         /// 企业机构信息，不用传
-        public let organization: OrganizationInfo?
+        @available(*, deprecated)
+        public let organization: OrganizationInfo? = nil
 
         /// 操作人（用户）信息，不用传
-        public let `operator`: UserInfo?
+        @available(*, deprecated)
+        public let `operator`: UserInfo? = nil
 
+        public init(resourceId: String, resourceType: Int64, flowInfo: BaseFlowInfo, agent: Agent? = nil, flowOption: CreateFlowOption? = nil, flowApproverList: [CommonFlowApprover]? = nil, flowId: String? = nil) {
+            self.resourceId = resourceId
+            self.resourceType = resourceType
+            self.flowInfo = flowInfo
+            self.agent = agent
+            self.flowOption = flowOption
+            self.flowApproverList = flowApproverList
+            self.flowId = flowId
+        }
+
+        @available(*, deprecated, renamed: "init(resourceId:resourceType:flowInfo:agent:flowOption:flowApproverList:flowId:)", message: "'needPreview', 'organization' and 'operator' are deprecated in 'ChannelCreatePrepareFlowRequest'. Setting these parameters has no effect.")
         public init(resourceId: String, resourceType: Int64, flowInfo: BaseFlowInfo, agent: Agent? = nil, flowOption: CreateFlowOption? = nil, flowApproverList: [CommonFlowApprover]? = nil, flowId: String? = nil, needPreview: Bool? = nil, organization: OrganizationInfo? = nil, operator: UserInfo? = nil) {
             self.resourceId = resourceId
             self.resourceType = resourceType
@@ -59,9 +73,6 @@ extension Essbasic {
             self.flowOption = flowOption
             self.flowApproverList = flowApproverList
             self.flowId = flowId
-            self.needPreview = needPreview
-            self.organization = organization
-            self.operator = `operator`
         }
 
         enum CodingKeys: String, CodingKey {
@@ -128,6 +139,19 @@ extension Essbasic {
     /// 合同发起后，填写及签署流程与现有操作流程一致
     /// 注意：目前仅支持模板发起
     @inlinable
+    public func channelCreatePrepareFlow(resourceId: String, resourceType: Int64, flowInfo: BaseFlowInfo, agent: Agent? = nil, flowOption: CreateFlowOption? = nil, flowApproverList: [CommonFlowApprover]? = nil, flowId: String? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<ChannelCreatePrepareFlowResponse> {
+        self.channelCreatePrepareFlow(.init(resourceId: resourceId, resourceType: resourceType, flowInfo: flowInfo, agent: agent, flowOption: flowOption, flowApproverList: flowApproverList, flowId: flowId), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 获取模板发起合同web页面
+    ///
+    /// 创建预发起合同
+    /// 通过此接口指定：合同，签署人，填写控件信息，生成预创建合同链接，点击后跳转到web页面完成合同创建并发起
+    /// 可指定合同信息不可更改，签署人信息不可更改
+    /// 合同发起后，填写及签署流程与现有操作流程一致
+    /// 注意：目前仅支持模板发起
+    @available(*, deprecated, renamed: "channelCreatePrepareFlow(resourceId:resourceType:flowInfo:agent:flowOption:flowApproverList:flowId:region:logger:on:)", message: "'needPreview', 'organization' and 'operator' are deprecated. Setting these parameters has no effect.")
+    @inlinable
     public func channelCreatePrepareFlow(resourceId: String, resourceType: Int64, flowInfo: BaseFlowInfo, agent: Agent? = nil, flowOption: CreateFlowOption? = nil, flowApproverList: [CommonFlowApprover]? = nil, flowId: String? = nil, needPreview: Bool? = nil, organization: OrganizationInfo? = nil, operator: UserInfo? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<ChannelCreatePrepareFlowResponse> {
         self.channelCreatePrepareFlow(.init(resourceId: resourceId, resourceType: resourceType, flowInfo: flowInfo, agent: agent, flowOption: flowOption, flowApproverList: flowApproverList, flowId: flowId, needPreview: needPreview, organization: organization, operator: `operator`), region: region, logger: logger, on: eventLoop)
     }
@@ -139,6 +163,19 @@ extension Essbasic {
     /// 可指定合同信息不可更改，签署人信息不可更改
     /// 合同发起后，填写及签署流程与现有操作流程一致
     /// 注意：目前仅支持模板发起
+    @inlinable
+    public func channelCreatePrepareFlow(resourceId: String, resourceType: Int64, flowInfo: BaseFlowInfo, agent: Agent? = nil, flowOption: CreateFlowOption? = nil, flowApproverList: [CommonFlowApprover]? = nil, flowId: String? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> ChannelCreatePrepareFlowResponse {
+        try await self.channelCreatePrepareFlow(.init(resourceId: resourceId, resourceType: resourceType, flowInfo: flowInfo, agent: agent, flowOption: flowOption, flowApproverList: flowApproverList, flowId: flowId), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 获取模板发起合同web页面
+    ///
+    /// 创建预发起合同
+    /// 通过此接口指定：合同，签署人，填写控件信息，生成预创建合同链接，点击后跳转到web页面完成合同创建并发起
+    /// 可指定合同信息不可更改，签署人信息不可更改
+    /// 合同发起后，填写及签署流程与现有操作流程一致
+    /// 注意：目前仅支持模板发起
+    @available(*, deprecated, renamed: "channelCreatePrepareFlow(resourceId:resourceType:flowInfo:agent:flowOption:flowApproverList:flowId:region:logger:on:)", message: "'needPreview', 'organization' and 'operator' are deprecated. Setting these parameters has no effect.")
     @inlinable
     public func channelCreatePrepareFlow(resourceId: String, resourceType: Int64, flowInfo: BaseFlowInfo, agent: Agent? = nil, flowOption: CreateFlowOption? = nil, flowApproverList: [CommonFlowApprover]? = nil, flowId: String? = nil, needPreview: Bool? = nil, organization: OrganizationInfo? = nil, operator: UserInfo? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> ChannelCreatePrepareFlowResponse {
         try await self.channelCreatePrepareFlow(.init(resourceId: resourceId, resourceType: resourceType, flowInfo: flowInfo, agent: agent, flowOption: flowOption, flowApproverList: flowApproverList, flowId: flowId, needPreview: needPreview, organization: organization, operator: `operator`), region: region, logger: logger, on: eventLoop)

--- a/Sources/Teco/Essbasic/V20210526/actions/ChannelCreateReleaseFlow.swift
+++ b/Sources/Teco/Essbasic/V20210526/actions/ChannelCreateReleaseFlow.swift
@@ -37,22 +37,32 @@ extension Essbasic {
         public let callbackUrl: String?
 
         /// 暂未开放
-        public let organization: OrganizationInfo?
+        @available(*, deprecated)
+        public let organization: OrganizationInfo? = nil
 
         /// 暂未开放
-        public let `operator`: UserInfo?
+        @available(*, deprecated)
+        public let `operator`: UserInfo? = nil
 
         /// 签署流程的签署截止时间。 值为unix时间戳,精确到秒,不传默认为当前时间七天后
         public let deadline: Int64?
 
+        public init(agent: Agent, needRelievedFlowId: String, reliveInfo: RelieveInfo, releasedApprovers: [ReleasedApprover]? = nil, callbackUrl: String? = nil, deadline: Int64? = nil) {
+            self.agent = agent
+            self.needRelievedFlowId = needRelievedFlowId
+            self.reliveInfo = reliveInfo
+            self.releasedApprovers = releasedApprovers
+            self.callbackUrl = callbackUrl
+            self.deadline = deadline
+        }
+
+        @available(*, deprecated, renamed: "init(agent:needRelievedFlowId:reliveInfo:releasedApprovers:callbackUrl:deadline:)", message: "'organization' and 'operator' are deprecated in 'ChannelCreateReleaseFlowRequest'. Setting these parameters has no effect.")
         public init(agent: Agent, needRelievedFlowId: String, reliveInfo: RelieveInfo, releasedApprovers: [ReleasedApprover]? = nil, callbackUrl: String? = nil, organization: OrganizationInfo? = nil, operator: UserInfo? = nil, deadline: Int64? = nil) {
             self.agent = agent
             self.needRelievedFlowId = needRelievedFlowId
             self.reliveInfo = reliveInfo
             self.releasedApprovers = releasedApprovers
             self.callbackUrl = callbackUrl
-            self.organization = organization
-            self.operator = `operator`
             self.deadline = deadline
         }
 
@@ -105,6 +115,16 @@ extension Essbasic {
     /// 发起解除协议，主要应用场景为：基于一份已经签署的合同，进行解除操作。
     /// 合同发起人必须在电子签已经进行实名。
     @inlinable
+    public func channelCreateReleaseFlow(agent: Agent, needRelievedFlowId: String, reliveInfo: RelieveInfo, releasedApprovers: [ReleasedApprover]? = nil, callbackUrl: String? = nil, deadline: Int64? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<ChannelCreateReleaseFlowResponse> {
+        self.channelCreateReleaseFlow(.init(agent: agent, needRelievedFlowId: needRelievedFlowId, reliveInfo: reliveInfo, releasedApprovers: releasedApprovers, callbackUrl: callbackUrl, deadline: deadline), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 发起解除协议
+    ///
+    /// 发起解除协议，主要应用场景为：基于一份已经签署的合同，进行解除操作。
+    /// 合同发起人必须在电子签已经进行实名。
+    @available(*, deprecated, renamed: "channelCreateReleaseFlow(agent:needRelievedFlowId:reliveInfo:releasedApprovers:callbackUrl:deadline:region:logger:on:)", message: "'organization' and 'operator' are deprecated. Setting these parameters has no effect.")
+    @inlinable
     public func channelCreateReleaseFlow(agent: Agent, needRelievedFlowId: String, reliveInfo: RelieveInfo, releasedApprovers: [ReleasedApprover]? = nil, callbackUrl: String? = nil, organization: OrganizationInfo? = nil, operator: UserInfo? = nil, deadline: Int64? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<ChannelCreateReleaseFlowResponse> {
         self.channelCreateReleaseFlow(.init(agent: agent, needRelievedFlowId: needRelievedFlowId, reliveInfo: reliveInfo, releasedApprovers: releasedApprovers, callbackUrl: callbackUrl, organization: organization, operator: `operator`, deadline: deadline), region: region, logger: logger, on: eventLoop)
     }
@@ -113,6 +133,16 @@ extension Essbasic {
     ///
     /// 发起解除协议，主要应用场景为：基于一份已经签署的合同，进行解除操作。
     /// 合同发起人必须在电子签已经进行实名。
+    @inlinable
+    public func channelCreateReleaseFlow(agent: Agent, needRelievedFlowId: String, reliveInfo: RelieveInfo, releasedApprovers: [ReleasedApprover]? = nil, callbackUrl: String? = nil, deadline: Int64? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> ChannelCreateReleaseFlowResponse {
+        try await self.channelCreateReleaseFlow(.init(agent: agent, needRelievedFlowId: needRelievedFlowId, reliveInfo: reliveInfo, releasedApprovers: releasedApprovers, callbackUrl: callbackUrl, deadline: deadline), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 发起解除协议
+    ///
+    /// 发起解除协议，主要应用场景为：基于一份已经签署的合同，进行解除操作。
+    /// 合同发起人必须在电子签已经进行实名。
+    @available(*, deprecated, renamed: "channelCreateReleaseFlow(agent:needRelievedFlowId:reliveInfo:releasedApprovers:callbackUrl:deadline:region:logger:on:)", message: "'organization' and 'operator' are deprecated. Setting these parameters has no effect.")
     @inlinable
     public func channelCreateReleaseFlow(agent: Agent, needRelievedFlowId: String, reliveInfo: RelieveInfo, releasedApprovers: [ReleasedApprover]? = nil, callbackUrl: String? = nil, organization: OrganizationInfo? = nil, operator: UserInfo? = nil, deadline: Int64? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> ChannelCreateReleaseFlowResponse {
         try await self.channelCreateReleaseFlow(.init(agent: agent, needRelievedFlowId: needRelievedFlowId, reliveInfo: reliveInfo, releasedApprovers: releasedApprovers, callbackUrl: callbackUrl, organization: organization, operator: `operator`, deadline: deadline), region: region, logger: logger, on: eventLoop)

--- a/Sources/Teco/Essbasic/V20210526/actions/ChannelCreateSealPolicy.swift
+++ b/Sources/Teco/Essbasic/V20210526/actions/ChannelCreateSealPolicy.swift
@@ -32,17 +32,24 @@ extension Essbasic {
         public let userIds: [String]
 
         /// 操作人（用户）信息，不用传
-        public let `operator`: UserInfo?
+        @available(*, deprecated)
+        public let `operator`: UserInfo? = nil
 
         /// 企业机构信息，不用传
-        public let organization: OrganizationInfo?
+        @available(*, deprecated)
+        public let organization: OrganizationInfo? = nil
 
+        public init(agent: Agent, sealId: String, userIds: [String]) {
+            self.agent = agent
+            self.sealId = sealId
+            self.userIds = userIds
+        }
+
+        @available(*, deprecated, renamed: "init(agent:sealId:userIds:)", message: "'operator' and 'organization' are deprecated in 'ChannelCreateSealPolicyRequest'. Setting these parameters has no effect.")
         public init(agent: Agent, sealId: String, userIds: [String], operator: UserInfo? = nil, organization: OrganizationInfo? = nil) {
             self.agent = agent
             self.sealId = sealId
             self.userIds = userIds
-            self.operator = `operator`
-            self.organization = organization
         }
 
         enum CodingKeys: String, CodingKey {
@@ -89,6 +96,15 @@ extension Essbasic {
     ///
     /// 将指定印章授权给第三方平台子客企业下的某些员工
     @inlinable
+    public func channelCreateSealPolicy(agent: Agent, sealId: String, userIds: [String], region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<ChannelCreateSealPolicyResponse> {
+        self.channelCreateSealPolicy(.init(agent: agent, sealId: sealId, userIds: userIds), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 创建印章授权
+    ///
+    /// 将指定印章授权给第三方平台子客企业下的某些员工
+    @available(*, deprecated, renamed: "channelCreateSealPolicy(agent:sealId:userIds:region:logger:on:)", message: "'operator' and 'organization' are deprecated. Setting these parameters has no effect.")
+    @inlinable
     public func channelCreateSealPolicy(agent: Agent, sealId: String, userIds: [String], operator: UserInfo? = nil, organization: OrganizationInfo? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<ChannelCreateSealPolicyResponse> {
         self.channelCreateSealPolicy(.init(agent: agent, sealId: sealId, userIds: userIds, operator: `operator`, organization: organization), region: region, logger: logger, on: eventLoop)
     }
@@ -96,6 +112,15 @@ extension Essbasic {
     /// 创建印章授权
     ///
     /// 将指定印章授权给第三方平台子客企业下的某些员工
+    @inlinable
+    public func channelCreateSealPolicy(agent: Agent, sealId: String, userIds: [String], region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> ChannelCreateSealPolicyResponse {
+        try await self.channelCreateSealPolicy(.init(agent: agent, sealId: sealId, userIds: userIds), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 创建印章授权
+    ///
+    /// 将指定印章授权给第三方平台子客企业下的某些员工
+    @available(*, deprecated, renamed: "channelCreateSealPolicy(agent:sealId:userIds:region:logger:on:)", message: "'operator' and 'organization' are deprecated. Setting these parameters has no effect.")
     @inlinable
     public func channelCreateSealPolicy(agent: Agent, sealId: String, userIds: [String], operator: UserInfo? = nil, organization: OrganizationInfo? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> ChannelCreateSealPolicyResponse {
         try await self.channelCreateSealPolicy(.init(agent: agent, sealId: sealId, userIds: userIds, operator: `operator`, organization: organization), region: region, logger: logger, on: eventLoop)

--- a/Sources/Teco/Essbasic/V20210526/actions/ChannelCreateUserRoles.swift
+++ b/Sources/Teco/Essbasic/V20210526/actions/ChannelCreateUserRoles.swift
@@ -34,14 +34,22 @@ extension Essbasic {
         public let openIds: [String]?
 
         /// 操作者信息
-        public let `operator`: UserInfo?
+        @available(*, deprecated)
+        public let `operator`: UserInfo? = nil
 
+        public init(agent: Agent, roleIds: [String], userIds: [String]? = nil, openIds: [String]? = nil) {
+            self.agent = agent
+            self.roleIds = roleIds
+            self.userIds = userIds
+            self.openIds = openIds
+        }
+
+        @available(*, deprecated, renamed: "init(agent:roleIds:userIds:openIds:)", message: "'operator' is deprecated in 'ChannelCreateUserRolesRequest'. Setting this parameter has no effect.")
         public init(agent: Agent, roleIds: [String], userIds: [String]? = nil, openIds: [String]? = nil, operator: UserInfo? = nil) {
             self.agent = agent
             self.roleIds = roleIds
             self.userIds = userIds
             self.openIds = openIds
-            self.operator = `operator`
         }
 
         enum CodingKeys: String, CodingKey {
@@ -87,6 +95,15 @@ extension Essbasic {
     ///
     /// 通过此接口，绑定员工角色，支持以电子签userId、客户系统userId两种方式调用。
     @inlinable
+    public func channelCreateUserRoles(agent: Agent, roleIds: [String], userIds: [String]? = nil, openIds: [String]? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<ChannelCreateUserRolesResponse> {
+        self.channelCreateUserRoles(.init(agent: agent, roleIds: roleIds, userIds: userIds, openIds: openIds), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 绑定员工角色
+    ///
+    /// 通过此接口，绑定员工角色，支持以电子签userId、客户系统userId两种方式调用。
+    @available(*, deprecated, renamed: "channelCreateUserRoles(agent:roleIds:userIds:openIds:region:logger:on:)", message: "'operator' is deprecated. Setting this parameter has no effect.")
+    @inlinable
     public func channelCreateUserRoles(agent: Agent, roleIds: [String], userIds: [String]? = nil, openIds: [String]? = nil, operator: UserInfo? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<ChannelCreateUserRolesResponse> {
         self.channelCreateUserRoles(.init(agent: agent, roleIds: roleIds, userIds: userIds, openIds: openIds, operator: `operator`), region: region, logger: logger, on: eventLoop)
     }
@@ -94,6 +111,15 @@ extension Essbasic {
     /// 绑定员工角色
     ///
     /// 通过此接口，绑定员工角色，支持以电子签userId、客户系统userId两种方式调用。
+    @inlinable
+    public func channelCreateUserRoles(agent: Agent, roleIds: [String], userIds: [String]? = nil, openIds: [String]? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> ChannelCreateUserRolesResponse {
+        try await self.channelCreateUserRoles(.init(agent: agent, roleIds: roleIds, userIds: userIds, openIds: openIds), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 绑定员工角色
+    ///
+    /// 通过此接口，绑定员工角色，支持以电子签userId、客户系统userId两种方式调用。
+    @available(*, deprecated, renamed: "channelCreateUserRoles(agent:roleIds:userIds:openIds:region:logger:on:)", message: "'operator' is deprecated. Setting this parameter has no effect.")
     @inlinable
     public func channelCreateUserRoles(agent: Agent, roleIds: [String], userIds: [String]? = nil, openIds: [String]? = nil, operator: UserInfo? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> ChannelCreateUserRolesResponse {
         try await self.channelCreateUserRoles(.init(agent: agent, roleIds: roleIds, userIds: userIds, openIds: openIds, operator: `operator`), region: region, logger: logger, on: eventLoop)

--- a/Sources/Teco/Essbasic/V20210526/actions/ChannelDeleteRoleUsers.swift
+++ b/Sources/Teco/Essbasic/V20210526/actions/ChannelDeleteRoleUsers.swift
@@ -31,16 +31,24 @@ extension Essbasic {
         public let userIds: [String]?
 
         /// 操作人信息
-        public let `operator`: UserInfo?
+        @available(*, deprecated)
+        public let `operator`: UserInfo? = nil
 
         /// 客户系统用户ID列表，与UserIds参数二选一,优先UserIds参数
         public let openIds: [String]?
 
+        public init(agent: Agent, roleId: String, userIds: [String]? = nil, openIds: [String]? = nil) {
+            self.agent = agent
+            self.roleId = roleId
+            self.userIds = userIds
+            self.openIds = openIds
+        }
+
+        @available(*, deprecated, renamed: "init(agent:roleId:userIds:openIds:)", message: "'operator' is deprecated in 'ChannelDeleteRoleUsersRequest'. Setting this parameter has no effect.")
         public init(agent: Agent, roleId: String, userIds: [String]? = nil, operator: UserInfo? = nil, openIds: [String]? = nil) {
             self.agent = agent
             self.roleId = roleId
             self.userIds = userIds
-            self.operator = `operator`
             self.openIds = openIds
         }
 
@@ -87,6 +95,15 @@ extension Essbasic {
     ///
     /// 通过此接口，删除员工绑定的角色，支持以电子签userId、客户系统userId两种方式调用。
     @inlinable
+    public func channelDeleteRoleUsers(agent: Agent, roleId: String, userIds: [String]? = nil, openIds: [String]? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<ChannelDeleteRoleUsersResponse> {
+        self.channelDeleteRoleUsers(.init(agent: agent, roleId: roleId, userIds: userIds, openIds: openIds), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 删除员工绑定角色
+    ///
+    /// 通过此接口，删除员工绑定的角色，支持以电子签userId、客户系统userId两种方式调用。
+    @available(*, deprecated, renamed: "channelDeleteRoleUsers(agent:roleId:userIds:openIds:region:logger:on:)", message: "'operator' is deprecated. Setting this parameter has no effect.")
+    @inlinable
     public func channelDeleteRoleUsers(agent: Agent, roleId: String, userIds: [String]? = nil, operator: UserInfo? = nil, openIds: [String]? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<ChannelDeleteRoleUsersResponse> {
         self.channelDeleteRoleUsers(.init(agent: agent, roleId: roleId, userIds: userIds, operator: `operator`, openIds: openIds), region: region, logger: logger, on: eventLoop)
     }
@@ -94,6 +111,15 @@ extension Essbasic {
     /// 删除员工绑定角色
     ///
     /// 通过此接口，删除员工绑定的角色，支持以电子签userId、客户系统userId两种方式调用。
+    @inlinable
+    public func channelDeleteRoleUsers(agent: Agent, roleId: String, userIds: [String]? = nil, openIds: [String]? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> ChannelDeleteRoleUsersResponse {
+        try await self.channelDeleteRoleUsers(.init(agent: agent, roleId: roleId, userIds: userIds, openIds: openIds), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 删除员工绑定角色
+    ///
+    /// 通过此接口，删除员工绑定的角色，支持以电子签userId、客户系统userId两种方式调用。
+    @available(*, deprecated, renamed: "channelDeleteRoleUsers(agent:roleId:userIds:openIds:region:logger:on:)", message: "'operator' is deprecated. Setting this parameter has no effect.")
     @inlinable
     public func channelDeleteRoleUsers(agent: Agent, roleId: String, userIds: [String]? = nil, operator: UserInfo? = nil, openIds: [String]? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> ChannelDeleteRoleUsersResponse {
         try await self.channelDeleteRoleUsers(.init(agent: agent, roleId: roleId, userIds: userIds, operator: `operator`, openIds: openIds), region: region, logger: logger, on: eventLoop)

--- a/Sources/Teco/Essbasic/V20210526/actions/ChannelDeleteSealPolicies.swift
+++ b/Sources/Teco/Essbasic/V20210526/actions/ChannelDeleteSealPolicies.swift
@@ -32,17 +32,24 @@ extension Essbasic {
         public let userIds: [String]
 
         /// 组织机构信息，不用传
-        public let organization: OrganizationInfo?
+        @available(*, deprecated)
+        public let organization: OrganizationInfo? = nil
 
         /// 操作人（用户）信息，不用传
-        public let `operator`: UserInfo?
+        @available(*, deprecated)
+        public let `operator`: UserInfo? = nil
 
+        public init(agent: Agent, sealId: String, userIds: [String]) {
+            self.agent = agent
+            self.sealId = sealId
+            self.userIds = userIds
+        }
+
+        @available(*, deprecated, renamed: "init(agent:sealId:userIds:)", message: "'organization' and 'operator' are deprecated in 'ChannelDeleteSealPoliciesRequest'. Setting these parameters has no effect.")
         public init(agent: Agent, sealId: String, userIds: [String], organization: OrganizationInfo? = nil, operator: UserInfo? = nil) {
             self.agent = agent
             self.sealId = sealId
             self.userIds = userIds
-            self.organization = organization
-            self.operator = `operator`
         }
 
         enum CodingKeys: String, CodingKey {
@@ -84,6 +91,15 @@ extension Essbasic {
     ///
     /// 删除指定印章下多个授权信息
     @inlinable @discardableResult
+    public func channelDeleteSealPolicies(agent: Agent, sealId: String, userIds: [String], region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<ChannelDeleteSealPoliciesResponse> {
+        self.channelDeleteSealPolicies(.init(agent: agent, sealId: sealId, userIds: userIds), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 删除印章授权
+    ///
+    /// 删除指定印章下多个授权信息
+    @available(*, deprecated, renamed: "channelDeleteSealPolicies(agent:sealId:userIds:region:logger:on:)", message: "'organization' and 'operator' are deprecated. Setting these parameters has no effect.")
+    @inlinable @discardableResult
     public func channelDeleteSealPolicies(agent: Agent, sealId: String, userIds: [String], organization: OrganizationInfo? = nil, operator: UserInfo? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<ChannelDeleteSealPoliciesResponse> {
         self.channelDeleteSealPolicies(.init(agent: agent, sealId: sealId, userIds: userIds, organization: organization, operator: `operator`), region: region, logger: logger, on: eventLoop)
     }
@@ -91,6 +107,15 @@ extension Essbasic {
     /// 删除印章授权
     ///
     /// 删除指定印章下多个授权信息
+    @inlinable @discardableResult
+    public func channelDeleteSealPolicies(agent: Agent, sealId: String, userIds: [String], region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> ChannelDeleteSealPoliciesResponse {
+        try await self.channelDeleteSealPolicies(.init(agent: agent, sealId: sealId, userIds: userIds), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 删除印章授权
+    ///
+    /// 删除指定印章下多个授权信息
+    @available(*, deprecated, renamed: "channelDeleteSealPolicies(agent:sealId:userIds:region:logger:on:)", message: "'organization' and 'operator' are deprecated. Setting these parameters has no effect.")
     @inlinable @discardableResult
     public func channelDeleteSealPolicies(agent: Agent, sealId: String, userIds: [String], organization: OrganizationInfo? = nil, operator: UserInfo? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> ChannelDeleteSealPoliciesResponse {
         try await self.channelDeleteSealPolicies(.init(agent: agent, sealId: sealId, userIds: userIds, organization: organization, operator: `operator`), region: region, logger: logger, on: eventLoop)

--- a/Sources/Teco/Essbasic/V20210526/actions/ChannelDescribeEmployees.swift
+++ b/Sources/Teco/Essbasic/V20210526/actions/ChannelDescribeEmployees.swift
@@ -37,14 +37,22 @@ extension Essbasic {
         public let offset: Int64?
 
         /// 暂未开放
-        public let `operator`: UserInfo?
+        @available(*, deprecated)
+        public let `operator`: UserInfo? = nil
 
+        public init(limit: Int64, agent: Agent? = nil, filters: [Filter]? = nil, offset: Int64? = nil) {
+            self.limit = limit
+            self.agent = agent
+            self.filters = filters
+            self.offset = offset
+        }
+
+        @available(*, deprecated, renamed: "init(limit:agent:filters:offset:)", message: "'operator' is deprecated in 'ChannelDescribeEmployeesRequest'. Setting this parameter has no effect.")
         public init(limit: Int64, agent: Agent? = nil, filters: [Filter]? = nil, offset: Int64? = nil, operator: UserInfo? = nil) {
             self.limit = limit
             self.agent = agent
             self.filters = filters
             self.offset = offset
-            self.operator = `operator`
         }
 
         enum CodingKeys: String, CodingKey {
@@ -60,7 +68,7 @@ extension Essbasic {
             guard !response.getItems().isEmpty else {
                 return nil
             }
-            return ChannelDescribeEmployeesRequest(limit: self.limit, agent: self.agent, filters: self.filters, offset: (self.offset ?? 0) + response.limit, operator: self.operator)
+            return ChannelDescribeEmployeesRequest(limit: self.limit, agent: self.agent, filters: self.filters, offset: (self.offset ?? 0) + response.limit)
         }
     }
 
@@ -122,6 +130,15 @@ extension Essbasic {
     ///
     /// 查询企业员工列表
     @inlinable
+    public func channelDescribeEmployees(limit: Int64, agent: Agent? = nil, filters: [Filter]? = nil, offset: Int64? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<ChannelDescribeEmployeesResponse> {
+        self.channelDescribeEmployees(.init(limit: limit, agent: agent, filters: filters, offset: offset), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 查询企业员工
+    ///
+    /// 查询企业员工列表
+    @available(*, deprecated, renamed: "channelDescribeEmployees(limit:agent:filters:offset:region:logger:on:)", message: "'operator' is deprecated. Setting this parameter has no effect.")
+    @inlinable
     public func channelDescribeEmployees(limit: Int64, agent: Agent? = nil, filters: [Filter]? = nil, offset: Int64? = nil, operator: UserInfo? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<ChannelDescribeEmployeesResponse> {
         self.channelDescribeEmployees(.init(limit: limit, agent: agent, filters: filters, offset: offset, operator: `operator`), region: region, logger: logger, on: eventLoop)
     }
@@ -129,6 +146,15 @@ extension Essbasic {
     /// 查询企业员工
     ///
     /// 查询企业员工列表
+    @inlinable
+    public func channelDescribeEmployees(limit: Int64, agent: Agent? = nil, filters: [Filter]? = nil, offset: Int64? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> ChannelDescribeEmployeesResponse {
+        try await self.channelDescribeEmployees(.init(limit: limit, agent: agent, filters: filters, offset: offset), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 查询企业员工
+    ///
+    /// 查询企业员工列表
+    @available(*, deprecated, renamed: "channelDescribeEmployees(limit:agent:filters:offset:region:logger:on:)", message: "'operator' is deprecated. Setting this parameter has no effect.")
     @inlinable
     public func channelDescribeEmployees(limit: Int64, agent: Agent? = nil, filters: [Filter]? = nil, offset: Int64? = nil, operator: UserInfo? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> ChannelDescribeEmployeesResponse {
         try await self.channelDescribeEmployees(.init(limit: limit, agent: agent, filters: filters, offset: offset, operator: `operator`), region: region, logger: logger, on: eventLoop)

--- a/Sources/Teco/Essbasic/V20210526/actions/ChannelDescribeRoles.swift
+++ b/Sources/Teco/Essbasic/V20210526/actions/ChannelDescribeRoles.swift
@@ -37,14 +37,22 @@ extension Essbasic {
         public let filters: [Filter]?
 
         /// 操作人信息
-        public let `operator`: UserInfo?
+        @available(*, deprecated)
+        public let `operator`: UserInfo? = nil
 
+        public init(agent: Agent, offset: UInt64, limit: String, filters: [Filter]? = nil) {
+            self.agent = agent
+            self.offset = offset
+            self.limit = limit
+            self.filters = filters
+        }
+
+        @available(*, deprecated, renamed: "init(agent:offset:limit:filters:)", message: "'operator' is deprecated in 'ChannelDescribeRolesRequest'. Setting this parameter has no effect.")
         public init(agent: Agent, offset: UInt64, limit: String, filters: [Filter]? = nil, operator: UserInfo? = nil) {
             self.agent = agent
             self.offset = offset
             self.limit = limit
             self.filters = filters
-            self.operator = `operator`
         }
 
         enum CodingKeys: String, CodingKey {
@@ -60,7 +68,7 @@ extension Essbasic {
             guard !response.getItems().isEmpty else {
                 return nil
             }
-            return ChannelDescribeRolesRequest(agent: self.agent, offset: self.offset + response.limit, limit: self.limit, filters: self.filters, operator: self.operator)
+            return ChannelDescribeRolesRequest(agent: self.agent, offset: self.offset + response.limit, limit: self.limit, filters: self.filters)
         }
     }
 
@@ -121,6 +129,15 @@ extension Essbasic {
     ///
     /// 查询角色列表，支持根据类型和状态过滤角色列表
     @inlinable
+    public func channelDescribeRoles(agent: Agent, offset: UInt64, limit: String, filters: [Filter]? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<ChannelDescribeRolesResponse> {
+        self.channelDescribeRoles(.init(agent: agent, offset: offset, limit: limit, filters: filters), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 查询角色列表
+    ///
+    /// 查询角色列表，支持根据类型和状态过滤角色列表
+    @available(*, deprecated, renamed: "channelDescribeRoles(agent:offset:limit:filters:region:logger:on:)", message: "'operator' is deprecated. Setting this parameter has no effect.")
+    @inlinable
     public func channelDescribeRoles(agent: Agent, offset: UInt64, limit: String, filters: [Filter]? = nil, operator: UserInfo? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<ChannelDescribeRolesResponse> {
         self.channelDescribeRoles(.init(agent: agent, offset: offset, limit: limit, filters: filters, operator: `operator`), region: region, logger: logger, on: eventLoop)
     }
@@ -128,6 +145,15 @@ extension Essbasic {
     /// 查询角色列表
     ///
     /// 查询角色列表，支持根据类型和状态过滤角色列表
+    @inlinable
+    public func channelDescribeRoles(agent: Agent, offset: UInt64, limit: String, filters: [Filter]? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> ChannelDescribeRolesResponse {
+        try await self.channelDescribeRoles(.init(agent: agent, offset: offset, limit: limit, filters: filters), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 查询角色列表
+    ///
+    /// 查询角色列表，支持根据类型和状态过滤角色列表
+    @available(*, deprecated, renamed: "channelDescribeRoles(agent:offset:limit:filters:region:logger:on:)", message: "'operator' is deprecated. Setting this parameter has no effect.")
     @inlinable
     public func channelDescribeRoles(agent: Agent, offset: UInt64, limit: String, filters: [Filter]? = nil, operator: UserInfo? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> ChannelDescribeRolesResponse {
         try await self.channelDescribeRoles(.init(agent: agent, offset: offset, limit: limit, filters: filters, operator: `operator`), region: region, logger: logger, on: eventLoop)

--- a/Sources/Teco/Essbasic/V20210526/actions/ChannelGetTaskResultApi.swift
+++ b/Sources/Teco/Essbasic/V20210526/actions/ChannelGetTaskResultApi.swift
@@ -28,16 +28,22 @@ extension Essbasic {
         public let taskId: String
 
         /// 操作者的信息，不用传
-        public let `operator`: UserInfo?
+        @available(*, deprecated)
+        public let `operator`: UserInfo? = nil
 
         /// 暂未开放
-        public let organization: OrganizationInfo?
+        @available(*, deprecated)
+        public let organization: OrganizationInfo? = nil
 
+        public init(agent: Agent, taskId: String) {
+            self.agent = agent
+            self.taskId = taskId
+        }
+
+        @available(*, deprecated, renamed: "init(agent:taskId:)", message: "'operator' and 'organization' are deprecated in 'ChannelGetTaskResultApiRequest'. Setting these parameters has no effect.")
         public init(agent: Agent, taskId: String, operator: UserInfo? = nil, organization: OrganizationInfo? = nil) {
             self.agent = agent
             self.taskId = taskId
-            self.operator = `operator`
-            self.organization = organization
         }
 
         enum CodingKeys: String, CodingKey {
@@ -77,6 +83,7 @@ extension Essbasic {
         /// 预览文件Url，有效期30分钟
         /// 当前字段返回为空，发起的时候，将ResourceId 放入发起即可
         /// 注意：此字段可能返回 null，表示取不到有效值。
+        @available(*, deprecated)
         public let previewUrl: String?
 
         /// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
@@ -115,6 +122,16 @@ extension Essbasic {
     /// 查询转换任务的状态。转换任务Id通过发起转换任务接口（ChannelCreateConvertTaskApi）获取。
     /// 注意：大文件转换所需的时间可能会比较长。
     @inlinable
+    public func channelGetTaskResultApi(agent: Agent, taskId: String, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<ChannelGetTaskResultApiResponse> {
+        self.channelGetTaskResultApi(.init(agent: agent, taskId: taskId), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 查询转换任务状态
+    ///
+    /// 查询转换任务的状态。转换任务Id通过发起转换任务接口（ChannelCreateConvertTaskApi）获取。
+    /// 注意：大文件转换所需的时间可能会比较长。
+    @available(*, deprecated, renamed: "channelGetTaskResultApi(agent:taskId:region:logger:on:)", message: "'operator' and 'organization' are deprecated. Setting these parameters has no effect.")
+    @inlinable
     public func channelGetTaskResultApi(agent: Agent, taskId: String, operator: UserInfo? = nil, organization: OrganizationInfo? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<ChannelGetTaskResultApiResponse> {
         self.channelGetTaskResultApi(.init(agent: agent, taskId: taskId, operator: `operator`, organization: organization), region: region, logger: logger, on: eventLoop)
     }
@@ -123,6 +140,16 @@ extension Essbasic {
     ///
     /// 查询转换任务的状态。转换任务Id通过发起转换任务接口（ChannelCreateConvertTaskApi）获取。
     /// 注意：大文件转换所需的时间可能会比较长。
+    @inlinable
+    public func channelGetTaskResultApi(agent: Agent, taskId: String, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> ChannelGetTaskResultApiResponse {
+        try await self.channelGetTaskResultApi(.init(agent: agent, taskId: taskId), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 查询转换任务状态
+    ///
+    /// 查询转换任务的状态。转换任务Id通过发起转换任务接口（ChannelCreateConvertTaskApi）获取。
+    /// 注意：大文件转换所需的时间可能会比较长。
+    @available(*, deprecated, renamed: "channelGetTaskResultApi(agent:taskId:region:logger:on:)", message: "'operator' and 'organization' are deprecated. Setting these parameters has no effect.")
     @inlinable
     public func channelGetTaskResultApi(agent: Agent, taskId: String, operator: UserInfo? = nil, organization: OrganizationInfo? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> ChannelGetTaskResultApiResponse {
         try await self.channelGetTaskResultApi(.init(agent: agent, taskId: taskId, operator: `operator`, organization: organization), region: region, logger: logger, on: eventLoop)

--- a/Sources/Teco/Essbasic/V20210526/actions/ChannelUpdateSealStatus.swift
+++ b/Sources/Teco/Essbasic/V20210526/actions/ChannelUpdateSealStatus.swift
@@ -34,14 +34,22 @@ extension Essbasic {
         public let reason: String?
 
         /// 操作者的信息
-        public let `operator`: UserInfo?
+        @available(*, deprecated)
+        public let `operator`: UserInfo? = nil
 
+        public init(agent: Agent, status: String, sealId: String, reason: String? = nil) {
+            self.agent = agent
+            self.status = status
+            self.sealId = sealId
+            self.reason = reason
+        }
+
+        @available(*, deprecated, renamed: "init(agent:status:sealId:reason:)", message: "'operator' is deprecated in 'ChannelUpdateSealStatusRequest'. Setting this parameter has no effect.")
         public init(agent: Agent, status: String, sealId: String, reason: String? = nil, operator: UserInfo? = nil) {
             self.agent = agent
             self.status = status
             self.sealId = sealId
             self.reason = reason
-            self.operator = `operator`
         }
 
         enum CodingKeys: String, CodingKey {
@@ -83,6 +91,15 @@ extension Essbasic {
     ///
     /// 本接口（ChannelUpdateSealStatus）用于第三方应用平台为子客企业更新印章状态
     @inlinable @discardableResult
+    public func channelUpdateSealStatus(agent: Agent, status: String, sealId: String, reason: String? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<ChannelUpdateSealStatusResponse> {
+        self.channelUpdateSealStatus(.init(agent: agent, status: status, sealId: sealId, reason: reason), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 更新印章状态
+    ///
+    /// 本接口（ChannelUpdateSealStatus）用于第三方应用平台为子客企业更新印章状态
+    @available(*, deprecated, renamed: "channelUpdateSealStatus(agent:status:sealId:reason:region:logger:on:)", message: "'operator' is deprecated. Setting this parameter has no effect.")
+    @inlinable @discardableResult
     public func channelUpdateSealStatus(agent: Agent, status: String, sealId: String, reason: String? = nil, operator: UserInfo? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<ChannelUpdateSealStatusResponse> {
         self.channelUpdateSealStatus(.init(agent: agent, status: status, sealId: sealId, reason: reason, operator: `operator`), region: region, logger: logger, on: eventLoop)
     }
@@ -90,6 +107,15 @@ extension Essbasic {
     /// 更新印章状态
     ///
     /// 本接口（ChannelUpdateSealStatus）用于第三方应用平台为子客企业更新印章状态
+    @inlinable @discardableResult
+    public func channelUpdateSealStatus(agent: Agent, status: String, sealId: String, reason: String? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> ChannelUpdateSealStatusResponse {
+        try await self.channelUpdateSealStatus(.init(agent: agent, status: status, sealId: sealId, reason: reason), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 更新印章状态
+    ///
+    /// 本接口（ChannelUpdateSealStatus）用于第三方应用平台为子客企业更新印章状态
+    @available(*, deprecated, renamed: "channelUpdateSealStatus(agent:status:sealId:reason:region:logger:on:)", message: "'operator' is deprecated. Setting this parameter has no effect.")
     @inlinable @discardableResult
     public func channelUpdateSealStatus(agent: Agent, status: String, sealId: String, reason: String? = nil, operator: UserInfo? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> ChannelUpdateSealStatusResponse {
         try await self.channelUpdateSealStatus(.init(agent: agent, status: status, sealId: sealId, reason: reason, operator: `operator`), region: region, logger: logger, on: eventLoop)

--- a/Sources/Teco/Essbasic/V20210526/actions/ChannelVerifyPdf.swift
+++ b/Sources/Teco/Essbasic/V20210526/actions/ChannelVerifyPdf.swift
@@ -28,12 +28,18 @@ extension Essbasic {
         public let agent: Agent?
 
         /// 暂未开放
-        public let `operator`: UserInfo?
+        @available(*, deprecated)
+        public let `operator`: UserInfo? = nil
 
+        public init(flowId: String, agent: Agent? = nil) {
+            self.flowId = flowId
+            self.agent = agent
+        }
+
+        @available(*, deprecated, renamed: "init(flowId:agent:)", message: "'operator' is deprecated in 'ChannelVerifyPdfRequest'. Setting this parameter has no effect.")
         public init(flowId: String, agent: Agent? = nil, operator: UserInfo? = nil) {
             self.flowId = flowId
             self.agent = agent
-            self.operator = `operator`
         }
 
         enum CodingKeys: String, CodingKey {
@@ -81,6 +87,15 @@ extension Essbasic {
     ///
     /// 对流程的合同文件进行验证，判断文件是否合法。
     @inlinable
+    public func channelVerifyPdf(flowId: String, agent: Agent? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<ChannelVerifyPdfResponse> {
+        self.channelVerifyPdf(.init(flowId: flowId, agent: agent), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 流程文件验签
+    ///
+    /// 对流程的合同文件进行验证，判断文件是否合法。
+    @available(*, deprecated, renamed: "channelVerifyPdf(flowId:agent:region:logger:on:)", message: "'operator' is deprecated. Setting this parameter has no effect.")
+    @inlinable
     public func channelVerifyPdf(flowId: String, agent: Agent? = nil, operator: UserInfo? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<ChannelVerifyPdfResponse> {
         self.channelVerifyPdf(.init(flowId: flowId, agent: agent, operator: `operator`), region: region, logger: logger, on: eventLoop)
     }
@@ -88,6 +103,15 @@ extension Essbasic {
     /// 流程文件验签
     ///
     /// 对流程的合同文件进行验证，判断文件是否合法。
+    @inlinable
+    public func channelVerifyPdf(flowId: String, agent: Agent? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> ChannelVerifyPdfResponse {
+        try await self.channelVerifyPdf(.init(flowId: flowId, agent: agent), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 流程文件验签
+    ///
+    /// 对流程的合同文件进行验证，判断文件是否合法。
+    @available(*, deprecated, renamed: "channelVerifyPdf(flowId:agent:region:logger:on:)", message: "'operator' is deprecated. Setting this parameter has no effect.")
     @inlinable
     public func channelVerifyPdf(flowId: String, agent: Agent? = nil, operator: UserInfo? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> ChannelVerifyPdfResponse {
         try await self.channelVerifyPdf(.init(flowId: flowId, agent: agent, operator: `operator`), region: region, logger: logger, on: eventLoop)

--- a/Sources/Teco/Essbasic/V20210526/actions/CreateChannelFlowEvidenceReport.swift
+++ b/Sources/Teco/Essbasic/V20210526/actions/CreateChannelFlowEvidenceReport.swift
@@ -28,12 +28,18 @@ extension Essbasic {
         public let flowId: String
 
         /// 暂未开放
-        public let `operator`: UserInfo?
+        @available(*, deprecated)
+        public let `operator`: UserInfo? = nil
 
+        public init(agent: Agent, flowId: String) {
+            self.agent = agent
+            self.flowId = flowId
+        }
+
+        @available(*, deprecated, renamed: "init(agent:flowId:)", message: "'operator' is deprecated in 'CreateChannelFlowEvidenceReportRequest'. Setting this parameter has no effect.")
         public init(agent: Agent, flowId: String, operator: UserInfo? = nil) {
             self.agent = agent
             self.flowId = flowId
-            self.operator = `operator`
         }
 
         enum CodingKeys: String, CodingKey {
@@ -95,6 +101,16 @@ extension Essbasic {
     /// 创建出证报告，返回报告 ID。需要配合出证套餐才能调用。
     /// 出证需要一定时间，建议调用创建出证24小时之后再通过DescribeChannelFlowEvidenceReport进行查询。
     @inlinable
+    public func createChannelFlowEvidenceReport(agent: Agent, flowId: String, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<CreateChannelFlowEvidenceReportResponse> {
+        self.createChannelFlowEvidenceReport(.init(agent: agent, flowId: flowId), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 创建并返回出证报告
+    ///
+    /// 创建出证报告，返回报告 ID。需要配合出证套餐才能调用。
+    /// 出证需要一定时间，建议调用创建出证24小时之后再通过DescribeChannelFlowEvidenceReport进行查询。
+    @available(*, deprecated, renamed: "createChannelFlowEvidenceReport(agent:flowId:region:logger:on:)", message: "'operator' is deprecated. Setting this parameter has no effect.")
+    @inlinable
     public func createChannelFlowEvidenceReport(agent: Agent, flowId: String, operator: UserInfo? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<CreateChannelFlowEvidenceReportResponse> {
         self.createChannelFlowEvidenceReport(.init(agent: agent, flowId: flowId, operator: `operator`), region: region, logger: logger, on: eventLoop)
     }
@@ -103,6 +119,16 @@ extension Essbasic {
     ///
     /// 创建出证报告，返回报告 ID。需要配合出证套餐才能调用。
     /// 出证需要一定时间，建议调用创建出证24小时之后再通过DescribeChannelFlowEvidenceReport进行查询。
+    @inlinable
+    public func createChannelFlowEvidenceReport(agent: Agent, flowId: String, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> CreateChannelFlowEvidenceReportResponse {
+        try await self.createChannelFlowEvidenceReport(.init(agent: agent, flowId: flowId), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 创建并返回出证报告
+    ///
+    /// 创建出证报告，返回报告 ID。需要配合出证套餐才能调用。
+    /// 出证需要一定时间，建议调用创建出证24小时之后再通过DescribeChannelFlowEvidenceReport进行查询。
+    @available(*, deprecated, renamed: "createChannelFlowEvidenceReport(agent:flowId:region:logger:on:)", message: "'operator' is deprecated. Setting this parameter has no effect.")
     @inlinable
     public func createChannelFlowEvidenceReport(agent: Agent, flowId: String, operator: UserInfo? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> CreateChannelFlowEvidenceReportResponse {
         try await self.createChannelFlowEvidenceReport(.init(agent: agent, flowId: flowId, operator: `operator`), region: region, logger: logger, on: eventLoop)

--- a/Sources/Teco/Essbasic/V20210526/actions/CreateConsoleLoginUrl.swift
+++ b/Sources/Teco/Essbasic/V20210526/actions/CreateConsoleLoginUrl.swift
@@ -53,8 +53,23 @@ extension Essbasic {
         public let authorizationTypes: [Int64]?
 
         /// 暂未开放
-        public let `operator`: UserInfo?
+        @available(*, deprecated)
+        public let `operator`: UserInfo? = nil
 
+        public init(agent: Agent, proxyOrganizationName: String, proxyOperatorName: String? = nil, module: String? = nil, moduleId: String? = nil, uniformSocialCreditCode: String? = nil, menuStatus: String? = nil, endpoint: String? = nil, autoJumpBackEvent: String? = nil, authorizationTypes: [Int64]? = nil) {
+            self.agent = agent
+            self.proxyOrganizationName = proxyOrganizationName
+            self.proxyOperatorName = proxyOperatorName
+            self.module = module
+            self.moduleId = moduleId
+            self.uniformSocialCreditCode = uniformSocialCreditCode
+            self.menuStatus = menuStatus
+            self.endpoint = endpoint
+            self.autoJumpBackEvent = autoJumpBackEvent
+            self.authorizationTypes = authorizationTypes
+        }
+
+        @available(*, deprecated, renamed: "init(agent:proxyOrganizationName:proxyOperatorName:module:moduleId:uniformSocialCreditCode:menuStatus:endpoint:autoJumpBackEvent:authorizationTypes:)", message: "'operator' is deprecated in 'CreateConsoleLoginUrlRequest'. Setting this parameter has no effect.")
         public init(agent: Agent, proxyOrganizationName: String, proxyOperatorName: String? = nil, module: String? = nil, moduleId: String? = nil, uniformSocialCreditCode: String? = nil, menuStatus: String? = nil, endpoint: String? = nil, autoJumpBackEvent: String? = nil, authorizationTypes: [Int64]? = nil, operator: UserInfo? = nil) {
             self.agent = agent
             self.proxyOrganizationName = proxyOrganizationName
@@ -66,7 +81,6 @@ extension Essbasic {
             self.endpoint = endpoint
             self.autoJumpBackEvent = autoJumpBackEvent
             self.authorizationTypes = authorizationTypes
-            self.operator = `operator`
         }
 
         enum CodingKeys: String, CodingKey {
@@ -140,6 +154,18 @@ extension Essbasic {
     /// 若子客企业已激活，使用了新的经办人OpenId进入，则会进入经办人的实名流程。
     /// 若子客企业、经办人均已完成认证，则会直接进入子客Web控制台。
     @inlinable
+    public func createConsoleLoginUrl(agent: Agent, proxyOrganizationName: String, proxyOperatorName: String? = nil, module: String? = nil, moduleId: String? = nil, uniformSocialCreditCode: String? = nil, menuStatus: String? = nil, endpoint: String? = nil, autoJumpBackEvent: String? = nil, authorizationTypes: [Int64]? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<CreateConsoleLoginUrlResponse> {
+        self.createConsoleLoginUrl(.init(agent: agent, proxyOrganizationName: proxyOrganizationName, proxyOperatorName: proxyOperatorName, module: module, moduleId: moduleId, uniformSocialCreditCode: uniformSocialCreditCode, menuStatus: menuStatus, endpoint: endpoint, autoJumpBackEvent: autoJumpBackEvent, authorizationTypes: authorizationTypes), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 生成控制台、移动端链接
+    ///
+    /// 此接口（CreateConsoleLoginUrl）用于创建第三方平台子客企业控制台Web/移动登录链接。登录链接是子客控制台的唯一入口。
+    /// 若子客企业未激活，会进入企业激活流程，首次参与激活流程的经办人会成为超管。（若企业激活过程中填写信息有误，需要重置激活流程，可以换一个经办人OpenId获取新的链接进入。）
+    /// 若子客企业已激活，使用了新的经办人OpenId进入，则会进入经办人的实名流程。
+    /// 若子客企业、经办人均已完成认证，则会直接进入子客Web控制台。
+    @available(*, deprecated, renamed: "createConsoleLoginUrl(agent:proxyOrganizationName:proxyOperatorName:module:moduleId:uniformSocialCreditCode:menuStatus:endpoint:autoJumpBackEvent:authorizationTypes:region:logger:on:)", message: "'operator' is deprecated. Setting this parameter has no effect.")
+    @inlinable
     public func createConsoleLoginUrl(agent: Agent, proxyOrganizationName: String, proxyOperatorName: String? = nil, module: String? = nil, moduleId: String? = nil, uniformSocialCreditCode: String? = nil, menuStatus: String? = nil, endpoint: String? = nil, autoJumpBackEvent: String? = nil, authorizationTypes: [Int64]? = nil, operator: UserInfo? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<CreateConsoleLoginUrlResponse> {
         self.createConsoleLoginUrl(.init(agent: agent, proxyOrganizationName: proxyOrganizationName, proxyOperatorName: proxyOperatorName, module: module, moduleId: moduleId, uniformSocialCreditCode: uniformSocialCreditCode, menuStatus: menuStatus, endpoint: endpoint, autoJumpBackEvent: autoJumpBackEvent, authorizationTypes: authorizationTypes, operator: `operator`), region: region, logger: logger, on: eventLoop)
     }
@@ -150,6 +176,18 @@ extension Essbasic {
     /// 若子客企业未激活，会进入企业激活流程，首次参与激活流程的经办人会成为超管。（若企业激活过程中填写信息有误，需要重置激活流程，可以换一个经办人OpenId获取新的链接进入。）
     /// 若子客企业已激活，使用了新的经办人OpenId进入，则会进入经办人的实名流程。
     /// 若子客企业、经办人均已完成认证，则会直接进入子客Web控制台。
+    @inlinable
+    public func createConsoleLoginUrl(agent: Agent, proxyOrganizationName: String, proxyOperatorName: String? = nil, module: String? = nil, moduleId: String? = nil, uniformSocialCreditCode: String? = nil, menuStatus: String? = nil, endpoint: String? = nil, autoJumpBackEvent: String? = nil, authorizationTypes: [Int64]? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> CreateConsoleLoginUrlResponse {
+        try await self.createConsoleLoginUrl(.init(agent: agent, proxyOrganizationName: proxyOrganizationName, proxyOperatorName: proxyOperatorName, module: module, moduleId: moduleId, uniformSocialCreditCode: uniformSocialCreditCode, menuStatus: menuStatus, endpoint: endpoint, autoJumpBackEvent: autoJumpBackEvent, authorizationTypes: authorizationTypes), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 生成控制台、移动端链接
+    ///
+    /// 此接口（CreateConsoleLoginUrl）用于创建第三方平台子客企业控制台Web/移动登录链接。登录链接是子客控制台的唯一入口。
+    /// 若子客企业未激活，会进入企业激活流程，首次参与激活流程的经办人会成为超管。（若企业激活过程中填写信息有误，需要重置激活流程，可以换一个经办人OpenId获取新的链接进入。）
+    /// 若子客企业已激活，使用了新的经办人OpenId进入，则会进入经办人的实名流程。
+    /// 若子客企业、经办人均已完成认证，则会直接进入子客Web控制台。
+    @available(*, deprecated, renamed: "createConsoleLoginUrl(agent:proxyOrganizationName:proxyOperatorName:module:moduleId:uniformSocialCreditCode:menuStatus:endpoint:autoJumpBackEvent:authorizationTypes:region:logger:on:)", message: "'operator' is deprecated. Setting this parameter has no effect.")
     @inlinable
     public func createConsoleLoginUrl(agent: Agent, proxyOrganizationName: String, proxyOperatorName: String? = nil, module: String? = nil, moduleId: String? = nil, uniformSocialCreditCode: String? = nil, menuStatus: String? = nil, endpoint: String? = nil, autoJumpBackEvent: String? = nil, authorizationTypes: [Int64]? = nil, operator: UserInfo? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> CreateConsoleLoginUrlResponse {
         try await self.createConsoleLoginUrl(.init(agent: agent, proxyOrganizationName: proxyOrganizationName, proxyOperatorName: proxyOperatorName, module: module, moduleId: moduleId, uniformSocialCreditCode: uniformSocialCreditCode, menuStatus: menuStatus, endpoint: endpoint, autoJumpBackEvent: autoJumpBackEvent, authorizationTypes: authorizationTypes, operator: `operator`), region: region, logger: logger, on: eventLoop)

--- a/Sources/Teco/Essbasic/V20210526/actions/CreateFlowsByTemplates.swift
+++ b/Sources/Teco/Essbasic/V20210526/actions/CreateFlowsByTemplates.swift
@@ -36,14 +36,22 @@ extension Essbasic {
         public let previewType: Int64?
 
         /// 操作者的信息，不用传
-        public let `operator`: UserInfo?
+        @available(*, deprecated)
+        public let `operator`: UserInfo? = nil
 
+        public init(agent: Agent, flowInfos: [FlowInfo], needPreview: Bool? = nil, previewType: Int64? = nil) {
+            self.agent = agent
+            self.flowInfos = flowInfos
+            self.needPreview = needPreview
+            self.previewType = previewType
+        }
+
+        @available(*, deprecated, renamed: "init(agent:flowInfos:needPreview:previewType:)", message: "'operator' is deprecated in 'CreateFlowsByTemplatesRequest'. Setting this parameter has no effect.")
         public init(agent: Agent, flowInfos: [FlowInfo], needPreview: Bool? = nil, previewType: Int64? = nil, operator: UserInfo? = nil) {
             self.agent = agent
             self.flowInfos = flowInfos
             self.needPreview = needPreview
             self.previewType = previewType
-            self.operator = `operator`
         }
 
         enum CodingKeys: String, CodingKey {
@@ -113,6 +121,17 @@ extension Essbasic {
     /// 如若在模板中配置了动态表格, 上传的附件必须为A4大小
     /// 合同发起人必须在电子签已经进行实名。
     @inlinable
+    public func createFlowsByTemplates(agent: Agent, flowInfos: [FlowInfo], needPreview: Bool? = nil, previewType: Int64? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<CreateFlowsByTemplatesResponse> {
+        self.createFlowsByTemplates(.init(agent: agent, flowInfos: flowInfos, needPreview: needPreview, previewType: previewType), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 使用模板创建签署流程
+    ///
+    /// 接口（CreateFlowsByTemplates）用于使用模板批量创建签署流程。当前可批量发起合同（签署流程）数量为1-20个。
+    /// 如若在模板中配置了动态表格, 上传的附件必须为A4大小
+    /// 合同发起人必须在电子签已经进行实名。
+    @available(*, deprecated, renamed: "createFlowsByTemplates(agent:flowInfos:needPreview:previewType:region:logger:on:)", message: "'operator' is deprecated. Setting this parameter has no effect.")
+    @inlinable
     public func createFlowsByTemplates(agent: Agent, flowInfos: [FlowInfo], needPreview: Bool? = nil, previewType: Int64? = nil, operator: UserInfo? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<CreateFlowsByTemplatesResponse> {
         self.createFlowsByTemplates(.init(agent: agent, flowInfos: flowInfos, needPreview: needPreview, previewType: previewType, operator: `operator`), region: region, logger: logger, on: eventLoop)
     }
@@ -122,6 +141,17 @@ extension Essbasic {
     /// 接口（CreateFlowsByTemplates）用于使用模板批量创建签署流程。当前可批量发起合同（签署流程）数量为1-20个。
     /// 如若在模板中配置了动态表格, 上传的附件必须为A4大小
     /// 合同发起人必须在电子签已经进行实名。
+    @inlinable
+    public func createFlowsByTemplates(agent: Agent, flowInfos: [FlowInfo], needPreview: Bool? = nil, previewType: Int64? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> CreateFlowsByTemplatesResponse {
+        try await self.createFlowsByTemplates(.init(agent: agent, flowInfos: flowInfos, needPreview: needPreview, previewType: previewType), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 使用模板创建签署流程
+    ///
+    /// 接口（CreateFlowsByTemplates）用于使用模板批量创建签署流程。当前可批量发起合同（签署流程）数量为1-20个。
+    /// 如若在模板中配置了动态表格, 上传的附件必须为A4大小
+    /// 合同发起人必须在电子签已经进行实名。
+    @available(*, deprecated, renamed: "createFlowsByTemplates(agent:flowInfos:needPreview:previewType:region:logger:on:)", message: "'operator' is deprecated. Setting this parameter has no effect.")
     @inlinable
     public func createFlowsByTemplates(agent: Agent, flowInfos: [FlowInfo], needPreview: Bool? = nil, previewType: Int64? = nil, operator: UserInfo? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> CreateFlowsByTemplatesResponse {
         try await self.createFlowsByTemplates(.init(agent: agent, flowInfos: flowInfos, needPreview: needPreview, previewType: previewType, operator: `operator`), region: region, logger: logger, on: eventLoop)

--- a/Sources/Teco/Essbasic/V20210526/actions/CreateSealByImage.swift
+++ b/Sources/Teco/Essbasic/V20210526/actions/CreateSealByImage.swift
@@ -31,13 +31,20 @@ extension Essbasic {
         public let sealImage: String
 
         /// 操作者的信息
-        public let `operator`: UserInfo?
+        @available(*, deprecated)
+        public let `operator`: UserInfo? = nil
 
+        public init(agent: Agent, sealName: String, sealImage: String) {
+            self.agent = agent
+            self.sealName = sealName
+            self.sealImage = sealImage
+        }
+
+        @available(*, deprecated, renamed: "init(agent:sealName:sealImage:)", message: "'operator' is deprecated in 'CreateSealByImageRequest'. Setting this parameter has no effect.")
         public init(agent: Agent, sealName: String, sealImage: String, operator: UserInfo? = nil) {
             self.agent = agent
             self.sealName = sealName
             self.sealImage = sealImage
-            self.operator = `operator`
         }
 
         enum CodingKeys: String, CodingKey {
@@ -82,6 +89,15 @@ extension Essbasic {
     ///
     /// 通过图片为子客企业代创建印章，图片最大5MB
     @inlinable
+    public func createSealByImage(agent: Agent, sealName: String, sealImage: String, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<CreateSealByImageResponse> {
+        self.createSealByImage(.init(agent: agent, sealName: sealName, sealImage: sealImage), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 通过图片为子客企业代创建印章
+    ///
+    /// 通过图片为子客企业代创建印章，图片最大5MB
+    @available(*, deprecated, renamed: "createSealByImage(agent:sealName:sealImage:region:logger:on:)", message: "'operator' is deprecated. Setting this parameter has no effect.")
+    @inlinable
     public func createSealByImage(agent: Agent, sealName: String, sealImage: String, operator: UserInfo? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<CreateSealByImageResponse> {
         self.createSealByImage(.init(agent: agent, sealName: sealName, sealImage: sealImage, operator: `operator`), region: region, logger: logger, on: eventLoop)
     }
@@ -89,6 +105,15 @@ extension Essbasic {
     /// 通过图片为子客企业代创建印章
     ///
     /// 通过图片为子客企业代创建印章，图片最大5MB
+    @inlinable
+    public func createSealByImage(agent: Agent, sealName: String, sealImage: String, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> CreateSealByImageResponse {
+        try await self.createSealByImage(.init(agent: agent, sealName: sealName, sealImage: sealImage), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 通过图片为子客企业代创建印章
+    ///
+    /// 通过图片为子客企业代创建印章，图片最大5MB
+    @available(*, deprecated, renamed: "createSealByImage(agent:sealName:sealImage:region:logger:on:)", message: "'operator' is deprecated. Setting this parameter has no effect.")
     @inlinable
     public func createSealByImage(agent: Agent, sealName: String, sealImage: String, operator: UserInfo? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> CreateSealByImageResponse {
         try await self.createSealByImage(.init(agent: agent, sealName: sealName, sealImage: sealImage, operator: `operator`), region: region, logger: logger, on: eventLoop)

--- a/Sources/Teco/Essbasic/V20210526/actions/CreateSignUrls.swift
+++ b/Sources/Teco/Essbasic/V20210526/actions/CreateSignUrls.swift
@@ -64,7 +64,8 @@ extension Essbasic {
         public let jumpUrl: String?
 
         /// 暂未开放
-        public let `operator`: UserInfo?
+        @available(*, deprecated)
+        public let `operator`: UserInfo? = nil
 
         /// 生成的签署链接在签署过程隐藏的按钮列表, 可以设置隐藏的按钮列表如下
         ///
@@ -74,6 +75,23 @@ extension Essbasic {
         /// 3:签署成功页的查看详情按钮
         public let hides: [Int64]?
 
+        public init(agent: Agent, flowIds: [String]? = nil, flowGroupId: String? = nil, endpoint: String? = nil, generateType: String? = nil, organizationName: String? = nil, name: String? = nil, mobile: String? = nil, organizationOpenId: String? = nil, openId: String? = nil, autoJumpBack: Bool? = nil, jumpUrl: String? = nil, hides: [Int64]? = nil) {
+            self.agent = agent
+            self.flowIds = flowIds
+            self.flowGroupId = flowGroupId
+            self.endpoint = endpoint
+            self.generateType = generateType
+            self.organizationName = organizationName
+            self.name = name
+            self.mobile = mobile
+            self.organizationOpenId = organizationOpenId
+            self.openId = openId
+            self.autoJumpBack = autoJumpBack
+            self.jumpUrl = jumpUrl
+            self.hides = hides
+        }
+
+        @available(*, deprecated, renamed: "init(agent:flowIds:flowGroupId:endpoint:generateType:organizationName:name:mobile:organizationOpenId:openId:autoJumpBack:jumpUrl:hides:)", message: "'operator' is deprecated in 'CreateSignUrlsRequest'. Setting this parameter has no effect.")
         public init(agent: Agent, flowIds: [String]? = nil, flowGroupId: String? = nil, endpoint: String? = nil, generateType: String? = nil, organizationName: String? = nil, name: String? = nil, mobile: String? = nil, organizationOpenId: String? = nil, openId: String? = nil, autoJumpBack: Bool? = nil, jumpUrl: String? = nil, operator: UserInfo? = nil, hides: [Int64]? = nil) {
             self.agent = agent
             self.flowIds = flowIds
@@ -87,7 +105,6 @@ extension Essbasic {
             self.openId = openId
             self.autoJumpBack = autoJumpBack
             self.jumpUrl = jumpUrl
-            self.operator = `operator`
             self.hides = hides
         }
 
@@ -213,6 +230,37 @@ extension Essbasic {
     /// 其中小程序的原始Id，请联系<对接技术人员>获取，或者查看小程序信息自助获取。
     /// 使用CreateSignUrls，设置EndPoint为APP，得到path。
     @inlinable
+    public func createSignUrls(agent: Agent, flowIds: [String]? = nil, flowGroupId: String? = nil, endpoint: String? = nil, generateType: String? = nil, organizationName: String? = nil, name: String? = nil, mobile: String? = nil, organizationOpenId: String? = nil, openId: String? = nil, autoJumpBack: Bool? = nil, jumpUrl: String? = nil, hides: [Int64]? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<CreateSignUrlsResponse> {
+        self.createSignUrls(.init(agent: agent, flowIds: flowIds, flowGroupId: flowGroupId, endpoint: endpoint, generateType: generateType, organizationName: organizationName, name: name, mobile: mobile, organizationOpenId: organizationOpenId, openId: openId, autoJumpBack: autoJumpBack, jumpUrl: jumpUrl, hides: hides), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 获取跳转小程序查看或签署链接
+    ///
+    /// 创建跳转小程序查看或签署的链接。
+    ///
+    /// 跳转小程序的几种方式：主要是设置不同的EndPoint
+    /// 1. 通过链接Url直接跳转到小程序，不需要返回
+    /// 设置EndPoint为WEIXINAPP，得到链接打开即可。（与短信提醒用户签署形式一样）。
+    ///
+    /// 2. 通过链接Url打开H5引导页-->点击跳转到小程序-->签署完退出小程序-->回到H5引导页-->跳转到指定JumpUrl
+    /// 设置EndPoint为CHANNEL，指定JumpUrl，得到链接打开即可。
+    ///
+    /// 3. 客户App直接跳转到小程序-->小程序签署完成-->返回App
+    /// 跳转到小程序的实现，参考官方文档
+    /// https://developers.weixin.qq.com/miniprogram/dev/framework/open-ability/launchApp.html
+    /// 其中小程序的原始Id，请联系<对接技术人员>获取，或者查看小程序信息自助获取。
+    /// 使用CreateSignUrls，设置EndPoint为APP，得到path。
+    ///
+    /// 4. 客户小程序直接跳到电子签小程序-->签署完成退出电子签小程序-->回到客户小程序
+    /// 跳转到小程序的实现，参考官方文档（分为全屏、半屏两种方式）
+    /// 全屏方式：
+    /// （https://developers.weixin.qq.com/miniprogram/dev/api/navigate/wx.navigateToMiniProgram.html）
+    /// 半屏方式：
+    /// （https://developers.weixin.qq.com/miniprogram/dev/framework/open-ability/openEmbeddedMiniProgram.html）
+    /// 其中小程序的原始Id，请联系<对接技术人员>获取，或者查看小程序信息自助获取。
+    /// 使用CreateSignUrls，设置EndPoint为APP，得到path。
+    @available(*, deprecated, renamed: "createSignUrls(agent:flowIds:flowGroupId:endpoint:generateType:organizationName:name:mobile:organizationOpenId:openId:autoJumpBack:jumpUrl:hides:region:logger:on:)", message: "'operator' is deprecated. Setting this parameter has no effect.")
+    @inlinable
     public func createSignUrls(agent: Agent, flowIds: [String]? = nil, flowGroupId: String? = nil, endpoint: String? = nil, generateType: String? = nil, organizationName: String? = nil, name: String? = nil, mobile: String? = nil, organizationOpenId: String? = nil, openId: String? = nil, autoJumpBack: Bool? = nil, jumpUrl: String? = nil, operator: UserInfo? = nil, hides: [Int64]? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<CreateSignUrlsResponse> {
         self.createSignUrls(.init(agent: agent, flowIds: flowIds, flowGroupId: flowGroupId, endpoint: endpoint, generateType: generateType, organizationName: organizationName, name: name, mobile: mobile, organizationOpenId: organizationOpenId, openId: openId, autoJumpBack: autoJumpBack, jumpUrl: jumpUrl, operator: `operator`, hides: hides), region: region, logger: logger, on: eventLoop)
     }
@@ -242,6 +290,37 @@ extension Essbasic {
     /// （https://developers.weixin.qq.com/miniprogram/dev/framework/open-ability/openEmbeddedMiniProgram.html）
     /// 其中小程序的原始Id，请联系<对接技术人员>获取，或者查看小程序信息自助获取。
     /// 使用CreateSignUrls，设置EndPoint为APP，得到path。
+    @inlinable
+    public func createSignUrls(agent: Agent, flowIds: [String]? = nil, flowGroupId: String? = nil, endpoint: String? = nil, generateType: String? = nil, organizationName: String? = nil, name: String? = nil, mobile: String? = nil, organizationOpenId: String? = nil, openId: String? = nil, autoJumpBack: Bool? = nil, jumpUrl: String? = nil, hides: [Int64]? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> CreateSignUrlsResponse {
+        try await self.createSignUrls(.init(agent: agent, flowIds: flowIds, flowGroupId: flowGroupId, endpoint: endpoint, generateType: generateType, organizationName: organizationName, name: name, mobile: mobile, organizationOpenId: organizationOpenId, openId: openId, autoJumpBack: autoJumpBack, jumpUrl: jumpUrl, hides: hides), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 获取跳转小程序查看或签署链接
+    ///
+    /// 创建跳转小程序查看或签署的链接。
+    ///
+    /// 跳转小程序的几种方式：主要是设置不同的EndPoint
+    /// 1. 通过链接Url直接跳转到小程序，不需要返回
+    /// 设置EndPoint为WEIXINAPP，得到链接打开即可。（与短信提醒用户签署形式一样）。
+    ///
+    /// 2. 通过链接Url打开H5引导页-->点击跳转到小程序-->签署完退出小程序-->回到H5引导页-->跳转到指定JumpUrl
+    /// 设置EndPoint为CHANNEL，指定JumpUrl，得到链接打开即可。
+    ///
+    /// 3. 客户App直接跳转到小程序-->小程序签署完成-->返回App
+    /// 跳转到小程序的实现，参考官方文档
+    /// https://developers.weixin.qq.com/miniprogram/dev/framework/open-ability/launchApp.html
+    /// 其中小程序的原始Id，请联系<对接技术人员>获取，或者查看小程序信息自助获取。
+    /// 使用CreateSignUrls，设置EndPoint为APP，得到path。
+    ///
+    /// 4. 客户小程序直接跳到电子签小程序-->签署完成退出电子签小程序-->回到客户小程序
+    /// 跳转到小程序的实现，参考官方文档（分为全屏、半屏两种方式）
+    /// 全屏方式：
+    /// （https://developers.weixin.qq.com/miniprogram/dev/api/navigate/wx.navigateToMiniProgram.html）
+    /// 半屏方式：
+    /// （https://developers.weixin.qq.com/miniprogram/dev/framework/open-ability/openEmbeddedMiniProgram.html）
+    /// 其中小程序的原始Id，请联系<对接技术人员>获取，或者查看小程序信息自助获取。
+    /// 使用CreateSignUrls，设置EndPoint为APP，得到path。
+    @available(*, deprecated, renamed: "createSignUrls(agent:flowIds:flowGroupId:endpoint:generateType:organizationName:name:mobile:organizationOpenId:openId:autoJumpBack:jumpUrl:hides:region:logger:on:)", message: "'operator' is deprecated. Setting this parameter has no effect.")
     @inlinable
     public func createSignUrls(agent: Agent, flowIds: [String]? = nil, flowGroupId: String? = nil, endpoint: String? = nil, generateType: String? = nil, organizationName: String? = nil, name: String? = nil, mobile: String? = nil, organizationOpenId: String? = nil, openId: String? = nil, autoJumpBack: Bool? = nil, jumpUrl: String? = nil, operator: UserInfo? = nil, hides: [Int64]? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> CreateSignUrlsResponse {
         try await self.createSignUrls(.init(agent: agent, flowIds: flowIds, flowGroupId: flowGroupId, endpoint: endpoint, generateType: generateType, organizationName: organizationName, name: name, mobile: mobile, organizationOpenId: organizationOpenId, openId: openId, autoJumpBack: autoJumpBack, jumpUrl: jumpUrl, operator: `operator`, hides: hides), region: region, logger: logger, on: eventLoop)

--- a/Sources/Teco/Essbasic/V20210526/actions/DescribeChannelFlowEvidenceReport.swift
+++ b/Sources/Teco/Essbasic/V20210526/actions/DescribeChannelFlowEvidenceReport.swift
@@ -28,12 +28,18 @@ extension Essbasic {
         public let reportId: String
 
         /// 暂未开放
-        public let `operator`: UserInfo?
+        @available(*, deprecated)
+        public let `operator`: UserInfo? = nil
 
+        public init(agent: Agent, reportId: String) {
+            self.agent = agent
+            self.reportId = reportId
+        }
+
+        @available(*, deprecated, renamed: "init(agent:reportId:)", message: "'operator' is deprecated in 'DescribeChannelFlowEvidenceReportRequest'. Setting this parameter has no effect.")
         public init(agent: Agent, reportId: String, operator: UserInfo? = nil) {
             self.agent = agent
             self.reportId = reportId
-            self.operator = `operator`
         }
 
         enum CodingKeys: String, CodingKey {
@@ -86,6 +92,15 @@ extension Essbasic {
     ///
     /// 查询出证报告，返回报告 URL。
     @inlinable
+    public func describeChannelFlowEvidenceReport(agent: Agent, reportId: String, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<DescribeChannelFlowEvidenceReportResponse> {
+        self.describeChannelFlowEvidenceReport(.init(agent: agent, reportId: reportId), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 查询出证报告
+    ///
+    /// 查询出证报告，返回报告 URL。
+    @available(*, deprecated, renamed: "describeChannelFlowEvidenceReport(agent:reportId:region:logger:on:)", message: "'operator' is deprecated. Setting this parameter has no effect.")
+    @inlinable
     public func describeChannelFlowEvidenceReport(agent: Agent, reportId: String, operator: UserInfo? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<DescribeChannelFlowEvidenceReportResponse> {
         self.describeChannelFlowEvidenceReport(.init(agent: agent, reportId: reportId, operator: `operator`), region: region, logger: logger, on: eventLoop)
     }
@@ -93,6 +108,15 @@ extension Essbasic {
     /// 查询出证报告
     ///
     /// 查询出证报告，返回报告 URL。
+    @inlinable
+    public func describeChannelFlowEvidenceReport(agent: Agent, reportId: String, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> DescribeChannelFlowEvidenceReportResponse {
+        try await self.describeChannelFlowEvidenceReport(.init(agent: agent, reportId: reportId), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 查询出证报告
+    ///
+    /// 查询出证报告，返回报告 URL。
+    @available(*, deprecated, renamed: "describeChannelFlowEvidenceReport(agent:reportId:region:logger:on:)", message: "'operator' is deprecated. Setting this parameter has no effect.")
     @inlinable
     public func describeChannelFlowEvidenceReport(agent: Agent, reportId: String, operator: UserInfo? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> DescribeChannelFlowEvidenceReportResponse {
         try await self.describeChannelFlowEvidenceReport(.init(agent: agent, reportId: reportId, operator: `operator`), region: region, logger: logger, on: eventLoop)

--- a/Sources/Teco/Essbasic/V20210526/actions/DescribeFlowDetailInfo.swift
+++ b/Sources/Teco/Essbasic/V20210526/actions/DescribeFlowDetailInfo.swift
@@ -33,13 +33,20 @@ extension Essbasic {
         public let flowGroupId: String?
 
         /// 暂未开放
-        public let `operator`: UserInfo?
+        @available(*, deprecated)
+        public let `operator`: UserInfo? = nil
 
+        public init(agent: Agent, flowIds: [String]? = nil, flowGroupId: String? = nil) {
+            self.agent = agent
+            self.flowIds = flowIds
+            self.flowGroupId = flowGroupId
+        }
+
+        @available(*, deprecated, renamed: "init(agent:flowIds:flowGroupId:)", message: "'operator' is deprecated in 'DescribeFlowDetailInfoRequest'. Setting this parameter has no effect.")
         public init(agent: Agent, flowIds: [String]? = nil, flowGroupId: String? = nil, operator: UserInfo? = nil) {
             self.agent = agent
             self.flowIds = flowIds
             self.flowGroupId = flowGroupId
-            self.operator = `operator`
         }
 
         enum CodingKeys: String, CodingKey {
@@ -103,6 +110,15 @@ extension Essbasic {
     ///
     /// 此接口（DescribeFlowDetailInfo）用于查询合同(签署流程)的详细信息。
     @inlinable
+    public func describeFlowDetailInfo(agent: Agent, flowIds: [String]? = nil, flowGroupId: String? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<DescribeFlowDetailInfoResponse> {
+        self.describeFlowDetailInfo(.init(agent: agent, flowIds: flowIds, flowGroupId: flowGroupId), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 查询合同(签署流程)的详细信息
+    ///
+    /// 此接口（DescribeFlowDetailInfo）用于查询合同(签署流程)的详细信息。
+    @available(*, deprecated, renamed: "describeFlowDetailInfo(agent:flowIds:flowGroupId:region:logger:on:)", message: "'operator' is deprecated. Setting this parameter has no effect.")
+    @inlinable
     public func describeFlowDetailInfo(agent: Agent, flowIds: [String]? = nil, flowGroupId: String? = nil, operator: UserInfo? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<DescribeFlowDetailInfoResponse> {
         self.describeFlowDetailInfo(.init(agent: agent, flowIds: flowIds, flowGroupId: flowGroupId, operator: `operator`), region: region, logger: logger, on: eventLoop)
     }
@@ -110,6 +126,15 @@ extension Essbasic {
     /// 查询合同(签署流程)的详细信息
     ///
     /// 此接口（DescribeFlowDetailInfo）用于查询合同(签署流程)的详细信息。
+    @inlinable
+    public func describeFlowDetailInfo(agent: Agent, flowIds: [String]? = nil, flowGroupId: String? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> DescribeFlowDetailInfoResponse {
+        try await self.describeFlowDetailInfo(.init(agent: agent, flowIds: flowIds, flowGroupId: flowGroupId), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 查询合同(签署流程)的详细信息
+    ///
+    /// 此接口（DescribeFlowDetailInfo）用于查询合同(签署流程)的详细信息。
+    @available(*, deprecated, renamed: "describeFlowDetailInfo(agent:flowIds:flowGroupId:region:logger:on:)", message: "'operator' is deprecated. Setting this parameter has no effect.")
     @inlinable
     public func describeFlowDetailInfo(agent: Agent, flowIds: [String]? = nil, flowGroupId: String? = nil, operator: UserInfo? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> DescribeFlowDetailInfoResponse {
         try await self.describeFlowDetailInfo(.init(agent: agent, flowIds: flowIds, flowGroupId: flowGroupId, operator: `operator`), region: region, logger: logger, on: eventLoop)

--- a/Sources/Teco/Essbasic/V20210526/actions/DescribeResourceUrlsByFlows.swift
+++ b/Sources/Teco/Essbasic/V20210526/actions/DescribeResourceUrlsByFlows.swift
@@ -29,12 +29,18 @@ extension Essbasic {
         public let flowIds: [String]?
 
         /// 操作者的信息，不用传
-        public let `operator`: UserInfo?
+        @available(*, deprecated)
+        public let `operator`: UserInfo? = nil
 
+        public init(agent: Agent, flowIds: [String]? = nil) {
+            self.agent = agent
+            self.flowIds = flowIds
+        }
+
+        @available(*, deprecated, renamed: "init(agent:flowIds:)", message: "'operator' is deprecated in 'DescribeResourceUrlsByFlowsRequest'. Setting this parameter has no effect.")
         public init(agent: Agent, flowIds: [String]? = nil, operator: UserInfo? = nil) {
             self.agent = agent
             self.flowIds = flowIds
-            self.operator = `operator`
         }
 
         enum CodingKeys: String, CodingKey {
@@ -86,6 +92,16 @@ extension Essbasic {
     /// 根据签署流程信息批量获取资源下载链接，可以下载签署中、签署完的合同，需合作企业先进行授权。
     /// 此接口直接返回下载的资源的url，与接口GetDownloadFlowUrl跳转到控制台的下载方式不同。
     @inlinable
+    public func describeResourceUrlsByFlows(agent: Agent, flowIds: [String]? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<DescribeResourceUrlsByFlowsResponse> {
+        self.describeResourceUrlsByFlows(.init(agent: agent, flowIds: flowIds), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 根据签署流程信息批量获取资源下载链接
+    ///
+    /// 根据签署流程信息批量获取资源下载链接，可以下载签署中、签署完的合同，需合作企业先进行授权。
+    /// 此接口直接返回下载的资源的url，与接口GetDownloadFlowUrl跳转到控制台的下载方式不同。
+    @available(*, deprecated, renamed: "describeResourceUrlsByFlows(agent:flowIds:region:logger:on:)", message: "'operator' is deprecated. Setting this parameter has no effect.")
+    @inlinable
     public func describeResourceUrlsByFlows(agent: Agent, flowIds: [String]? = nil, operator: UserInfo? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<DescribeResourceUrlsByFlowsResponse> {
         self.describeResourceUrlsByFlows(.init(agent: agent, flowIds: flowIds, operator: `operator`), region: region, logger: logger, on: eventLoop)
     }
@@ -94,6 +110,16 @@ extension Essbasic {
     ///
     /// 根据签署流程信息批量获取资源下载链接，可以下载签署中、签署完的合同，需合作企业先进行授权。
     /// 此接口直接返回下载的资源的url，与接口GetDownloadFlowUrl跳转到控制台的下载方式不同。
+    @inlinable
+    public func describeResourceUrlsByFlows(agent: Agent, flowIds: [String]? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> DescribeResourceUrlsByFlowsResponse {
+        try await self.describeResourceUrlsByFlows(.init(agent: agent, flowIds: flowIds), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 根据签署流程信息批量获取资源下载链接
+    ///
+    /// 根据签署流程信息批量获取资源下载链接，可以下载签署中、签署完的合同，需合作企业先进行授权。
+    /// 此接口直接返回下载的资源的url，与接口GetDownloadFlowUrl跳转到控制台的下载方式不同。
+    @available(*, deprecated, renamed: "describeResourceUrlsByFlows(agent:flowIds:region:logger:on:)", message: "'operator' is deprecated. Setting this parameter has no effect.")
     @inlinable
     public func describeResourceUrlsByFlows(agent: Agent, flowIds: [String]? = nil, operator: UserInfo? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> DescribeResourceUrlsByFlowsResponse {
         try await self.describeResourceUrlsByFlows(.init(agent: agent, flowIds: flowIds, operator: `operator`), region: region, logger: logger, on: eventLoop)

--- a/Sources/Teco/Essbasic/V20210526/actions/DescribeTemplates.swift
+++ b/Sources/Teco/Essbasic/V20210526/actions/DescribeTemplates.swift
@@ -63,8 +63,23 @@ extension Essbasic {
         public let channelTemplateId: String?
 
         /// 操作者的信息
-        public let `operator`: UserInfo?
+        @available(*, deprecated)
+        public let `operator`: UserInfo? = nil
 
+        public init(agent: Agent, templateId: String? = nil, contentType: Int64? = nil, limit: UInt64? = nil, offset: UInt64? = nil, queryAllComponents: Bool? = nil, templateName: String? = nil, withPreviewUrl: Bool? = nil, withPdfUrl: Bool? = nil, channelTemplateId: String? = nil) {
+            self.agent = agent
+            self.templateId = templateId
+            self.contentType = contentType
+            self.limit = limit
+            self.offset = offset
+            self.queryAllComponents = queryAllComponents
+            self.templateName = templateName
+            self.withPreviewUrl = withPreviewUrl
+            self.withPdfUrl = withPdfUrl
+            self.channelTemplateId = channelTemplateId
+        }
+
+        @available(*, deprecated, renamed: "init(agent:templateId:contentType:limit:offset:queryAllComponents:templateName:withPreviewUrl:withPdfUrl:channelTemplateId:)", message: "'operator' is deprecated in 'DescribeTemplatesRequest'. Setting this parameter has no effect.")
         public init(agent: Agent, templateId: String? = nil, contentType: Int64? = nil, limit: UInt64? = nil, offset: UInt64? = nil, queryAllComponents: Bool? = nil, templateName: String? = nil, withPreviewUrl: Bool? = nil, withPdfUrl: Bool? = nil, channelTemplateId: String? = nil, operator: UserInfo? = nil) {
             self.agent = agent
             self.templateId = templateId
@@ -76,7 +91,6 @@ extension Essbasic {
             self.withPreviewUrl = withPreviewUrl
             self.withPdfUrl = withPdfUrl
             self.channelTemplateId = channelTemplateId
-            self.operator = `operator`
         }
 
         enum CodingKeys: String, CodingKey {
@@ -98,7 +112,7 @@ extension Essbasic {
             guard !response.getItems().isEmpty else {
                 return nil
             }
-            return DescribeTemplatesRequest(agent: self.agent, templateId: self.templateId, contentType: self.contentType, limit: self.limit, offset: (self.offset ?? 0) + response.limit, queryAllComponents: self.queryAllComponents, templateName: self.templateName, withPreviewUrl: self.withPreviewUrl, withPdfUrl: self.withPdfUrl, channelTemplateId: self.channelTemplateId, operator: self.operator)
+            return DescribeTemplatesRequest(agent: self.agent, templateId: self.templateId, contentType: self.contentType, limit: self.limit, offset: (self.offset ?? 0) + response.limit, queryAllComponents: self.queryAllComponents, templateName: self.templateName, withPreviewUrl: self.withPreviewUrl, withPdfUrl: self.withPdfUrl, channelTemplateId: self.channelTemplateId)
         }
     }
 
@@ -188,6 +202,25 @@ extension Essbasic {
     /// >- 签署控件 SignComponents
     /// >- 生成模板的文件基础信息 FileInfos
     @inlinable
+    public func describeTemplates(agent: Agent, templateId: String? = nil, contentType: Int64? = nil, limit: UInt64? = nil, offset: UInt64? = nil, queryAllComponents: Bool? = nil, templateName: String? = nil, withPreviewUrl: Bool? = nil, withPdfUrl: Bool? = nil, channelTemplateId: String? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<DescribeTemplatesResponse> {
+        self.describeTemplates(.init(agent: agent, templateId: templateId, contentType: contentType, limit: limit, offset: offset, queryAllComponents: queryAllComponents, templateName: templateName, withPreviewUrl: withPreviewUrl, withPdfUrl: withPdfUrl, channelTemplateId: channelTemplateId), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 查询模板信息列表
+    ///
+    /// 通过此接口（DescribeTemplates）查询该第三方平台子客企业在电子签拥有的有效模板，不包括第三方平台模板。
+    ///
+    /// > **适用场景**
+    /// >
+    /// >  该接口常用来配合“使用模板创建签署流程”接口作为前置的接口使用。
+    /// >  一个模板通常会包含以下结构信息
+    /// >- 模板基本信息
+    /// >- 发起方参与信息Promoter、签署参与方 Recipients，后者会在模板发起合同时用于指定参与方
+    /// >- 填写控件 Components
+    /// >- 签署控件 SignComponents
+    /// >- 生成模板的文件基础信息 FileInfos
+    @available(*, deprecated, renamed: "describeTemplates(agent:templateId:contentType:limit:offset:queryAllComponents:templateName:withPreviewUrl:withPdfUrl:channelTemplateId:region:logger:on:)", message: "'operator' is deprecated. Setting this parameter has no effect.")
+    @inlinable
     public func describeTemplates(agent: Agent, templateId: String? = nil, contentType: Int64? = nil, limit: UInt64? = nil, offset: UInt64? = nil, queryAllComponents: Bool? = nil, templateName: String? = nil, withPreviewUrl: Bool? = nil, withPdfUrl: Bool? = nil, channelTemplateId: String? = nil, operator: UserInfo? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<DescribeTemplatesResponse> {
         self.describeTemplates(.init(agent: agent, templateId: templateId, contentType: contentType, limit: limit, offset: offset, queryAllComponents: queryAllComponents, templateName: templateName, withPreviewUrl: withPreviewUrl, withPdfUrl: withPdfUrl, channelTemplateId: channelTemplateId, operator: `operator`), region: region, logger: logger, on: eventLoop)
     }
@@ -205,6 +238,25 @@ extension Essbasic {
     /// >- 填写控件 Components
     /// >- 签署控件 SignComponents
     /// >- 生成模板的文件基础信息 FileInfos
+    @inlinable
+    public func describeTemplates(agent: Agent, templateId: String? = nil, contentType: Int64? = nil, limit: UInt64? = nil, offset: UInt64? = nil, queryAllComponents: Bool? = nil, templateName: String? = nil, withPreviewUrl: Bool? = nil, withPdfUrl: Bool? = nil, channelTemplateId: String? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> DescribeTemplatesResponse {
+        try await self.describeTemplates(.init(agent: agent, templateId: templateId, contentType: contentType, limit: limit, offset: offset, queryAllComponents: queryAllComponents, templateName: templateName, withPreviewUrl: withPreviewUrl, withPdfUrl: withPdfUrl, channelTemplateId: channelTemplateId), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 查询模板信息列表
+    ///
+    /// 通过此接口（DescribeTemplates）查询该第三方平台子客企业在电子签拥有的有效模板，不包括第三方平台模板。
+    ///
+    /// > **适用场景**
+    /// >
+    /// >  该接口常用来配合“使用模板创建签署流程”接口作为前置的接口使用。
+    /// >  一个模板通常会包含以下结构信息
+    /// >- 模板基本信息
+    /// >- 发起方参与信息Promoter、签署参与方 Recipients，后者会在模板发起合同时用于指定参与方
+    /// >- 填写控件 Components
+    /// >- 签署控件 SignComponents
+    /// >- 生成模板的文件基础信息 FileInfos
+    @available(*, deprecated, renamed: "describeTemplates(agent:templateId:contentType:limit:offset:queryAllComponents:templateName:withPreviewUrl:withPdfUrl:channelTemplateId:region:logger:on:)", message: "'operator' is deprecated. Setting this parameter has no effect.")
     @inlinable
     public func describeTemplates(agent: Agent, templateId: String? = nil, contentType: Int64? = nil, limit: UInt64? = nil, offset: UInt64? = nil, queryAllComponents: Bool? = nil, templateName: String? = nil, withPreviewUrl: Bool? = nil, withPdfUrl: Bool? = nil, channelTemplateId: String? = nil, operator: UserInfo? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> DescribeTemplatesResponse {
         try await self.describeTemplates(.init(agent: agent, templateId: templateId, contentType: contentType, limit: limit, offset: offset, queryAllComponents: queryAllComponents, templateName: templateName, withPreviewUrl: withPreviewUrl, withPdfUrl: withPdfUrl, channelTemplateId: channelTemplateId, operator: `operator`), region: region, logger: logger, on: eventLoop)

--- a/Sources/Teco/Essbasic/V20210526/actions/DescribeUsage.swift
+++ b/Sources/Teco/Essbasic/V20210526/actions/DescribeUsage.swift
@@ -52,8 +52,19 @@ extension Essbasic {
         public let offset: UInt64?
 
         /// 暂未开放
-        public let `operator`: UserInfo?
+        @available(*, deprecated)
+        public let `operator`: UserInfo? = nil
 
+        public init(agent: Agent, startDate: Date, endDate: Date, needAggregate: Bool? = nil, limit: UInt64? = nil, offset: UInt64? = nil) {
+            self.agent = agent
+            self._startDate = .init(wrappedValue: startDate)
+            self._endDate = .init(wrappedValue: endDate)
+            self.needAggregate = needAggregate
+            self.limit = limit
+            self.offset = offset
+        }
+
+        @available(*, deprecated, renamed: "init(agent:startDate:endDate:needAggregate:limit:offset:)", message: "'operator' is deprecated in 'DescribeUsageRequest'. Setting this parameter has no effect.")
         public init(agent: Agent, startDate: Date, endDate: Date, needAggregate: Bool? = nil, limit: UInt64? = nil, offset: UInt64? = nil, operator: UserInfo? = nil) {
             self.agent = agent
             self._startDate = .init(wrappedValue: startDate)
@@ -61,7 +72,6 @@ extension Essbasic {
             self.needAggregate = needAggregate
             self.limit = limit
             self.offset = offset
-            self.operator = `operator`
         }
 
         enum CodingKeys: String, CodingKey {
@@ -79,7 +89,7 @@ extension Essbasic {
             guard !response.getItems().isEmpty else {
                 return nil
             }
-            return DescribeUsageRequest(agent: self.agent, startDate: self.startDate, endDate: self.endDate, needAggregate: self.needAggregate, limit: self.limit, offset: (self.offset ?? 0) + .init(response.getItems().count), operator: self.operator)
+            return DescribeUsageRequest(agent: self.agent, startDate: self.startDate, endDate: self.endDate, needAggregate: self.needAggregate, limit: self.limit, offset: (self.offset ?? 0) + .init(response.getItems().count))
         }
     }
 
@@ -135,6 +145,16 @@ extension Essbasic {
     /// 此接口（DescribeUsage）用于获取第三方平台所有合作企业流量消耗情况。
     ///  注: 此接口每日限频2次，若要扩大限制次数,请提前与客服经理或邮件至e-contract@tencent.com进行联系。
     @inlinable
+    public func describeUsage(agent: Agent, startDate: Date, endDate: Date, needAggregate: Bool? = nil, limit: UInt64? = nil, offset: UInt64? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<DescribeUsageResponse> {
+        self.describeUsage(.init(agent: agent, startDate: startDate, endDate: endDate, needAggregate: needAggregate, limit: limit, offset: offset), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 合同用量查询
+    ///
+    /// 此接口（DescribeUsage）用于获取第三方平台所有合作企业流量消耗情况。
+    ///  注: 此接口每日限频2次，若要扩大限制次数,请提前与客服经理或邮件至e-contract@tencent.com进行联系。
+    @available(*, deprecated, renamed: "describeUsage(agent:startDate:endDate:needAggregate:limit:offset:region:logger:on:)", message: "'operator' is deprecated. Setting this parameter has no effect.")
+    @inlinable
     public func describeUsage(agent: Agent, startDate: Date, endDate: Date, needAggregate: Bool? = nil, limit: UInt64? = nil, offset: UInt64? = nil, operator: UserInfo? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<DescribeUsageResponse> {
         self.describeUsage(.init(agent: agent, startDate: startDate, endDate: endDate, needAggregate: needAggregate, limit: limit, offset: offset, operator: `operator`), region: region, logger: logger, on: eventLoop)
     }
@@ -143,6 +163,16 @@ extension Essbasic {
     ///
     /// 此接口（DescribeUsage）用于获取第三方平台所有合作企业流量消耗情况。
     ///  注: 此接口每日限频2次，若要扩大限制次数,请提前与客服经理或邮件至e-contract@tencent.com进行联系。
+    @inlinable
+    public func describeUsage(agent: Agent, startDate: Date, endDate: Date, needAggregate: Bool? = nil, limit: UInt64? = nil, offset: UInt64? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> DescribeUsageResponse {
+        try await self.describeUsage(.init(agent: agent, startDate: startDate, endDate: endDate, needAggregate: needAggregate, limit: limit, offset: offset), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 合同用量查询
+    ///
+    /// 此接口（DescribeUsage）用于获取第三方平台所有合作企业流量消耗情况。
+    ///  注: 此接口每日限频2次，若要扩大限制次数,请提前与客服经理或邮件至e-contract@tencent.com进行联系。
+    @available(*, deprecated, renamed: "describeUsage(agent:startDate:endDate:needAggregate:limit:offset:region:logger:on:)", message: "'operator' is deprecated. Setting this parameter has no effect.")
     @inlinable
     public func describeUsage(agent: Agent, startDate: Date, endDate: Date, needAggregate: Bool? = nil, limit: UInt64? = nil, offset: UInt64? = nil, operator: UserInfo? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> DescribeUsageResponse {
         try await self.describeUsage(.init(agent: agent, startDate: startDate, endDate: endDate, needAggregate: needAggregate, limit: limit, offset: offset, operator: `operator`), region: region, logger: logger, on: eventLoop)

--- a/Sources/Teco/Essbasic/V20210526/actions/GetDownloadFlowUrl.swift
+++ b/Sources/Teco/Essbasic/V20210526/actions/GetDownloadFlowUrl.swift
@@ -28,12 +28,18 @@ extension Essbasic {
         public let downLoadFlows: [DownloadFlowInfo]?
 
         /// 操作者的信息，不用传
-        public let `operator`: UserInfo?
+        @available(*, deprecated)
+        public let `operator`: UserInfo? = nil
 
+        public init(agent: Agent, downLoadFlows: [DownloadFlowInfo]? = nil) {
+            self.agent = agent
+            self.downLoadFlows = downLoadFlows
+        }
+
+        @available(*, deprecated, renamed: "init(agent:downLoadFlows:)", message: "'operator' is deprecated in 'GetDownloadFlowUrlRequest'. Setting this parameter has no effect.")
         public init(agent: Agent, downLoadFlows: [DownloadFlowInfo]? = nil, operator: UserInfo? = nil) {
             self.agent = agent
             self.downLoadFlows = downLoadFlows
-            self.operator = `operator`
         }
 
         enum CodingKeys: String, CodingKey {
@@ -83,6 +89,17 @@ extension Essbasic {
     /// 当前接口限制最多合同（流程）50个.
     /// 返回的链接只能使用一次
     @inlinable
+    public func getDownloadFlowUrl(agent: Agent, downLoadFlows: [DownloadFlowInfo]? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<GetDownloadFlowUrlResponse> {
+        self.getDownloadFlowUrl(.init(agent: agent, downLoadFlows: downLoadFlows), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 获取合同（流程）批量下载链接
+    ///
+    /// 此接口（GetDownloadFlowUrl）用于创建电子签批量下载地址，让合作企业进入控制台直接下载，支持客户合同（流程）按照自定义文件夹形式 分类下载。
+    /// 当前接口限制最多合同（流程）50个.
+    /// 返回的链接只能使用一次
+    @available(*, deprecated, renamed: "getDownloadFlowUrl(agent:downLoadFlows:region:logger:on:)", message: "'operator' is deprecated. Setting this parameter has no effect.")
+    @inlinable
     public func getDownloadFlowUrl(agent: Agent, downLoadFlows: [DownloadFlowInfo]? = nil, operator: UserInfo? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<GetDownloadFlowUrlResponse> {
         self.getDownloadFlowUrl(.init(agent: agent, downLoadFlows: downLoadFlows, operator: `operator`), region: region, logger: logger, on: eventLoop)
     }
@@ -92,6 +109,17 @@ extension Essbasic {
     /// 此接口（GetDownloadFlowUrl）用于创建电子签批量下载地址，让合作企业进入控制台直接下载，支持客户合同（流程）按照自定义文件夹形式 分类下载。
     /// 当前接口限制最多合同（流程）50个.
     /// 返回的链接只能使用一次
+    @inlinable
+    public func getDownloadFlowUrl(agent: Agent, downLoadFlows: [DownloadFlowInfo]? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> GetDownloadFlowUrlResponse {
+        try await self.getDownloadFlowUrl(.init(agent: agent, downLoadFlows: downLoadFlows), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 获取合同（流程）批量下载链接
+    ///
+    /// 此接口（GetDownloadFlowUrl）用于创建电子签批量下载地址，让合作企业进入控制台直接下载，支持客户合同（流程）按照自定义文件夹形式 分类下载。
+    /// 当前接口限制最多合同（流程）50个.
+    /// 返回的链接只能使用一次
+    @available(*, deprecated, renamed: "getDownloadFlowUrl(agent:downLoadFlows:region:logger:on:)", message: "'operator' is deprecated. Setting this parameter has no effect.")
     @inlinable
     public func getDownloadFlowUrl(agent: Agent, downLoadFlows: [DownloadFlowInfo]? = nil, operator: UserInfo? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> GetDownloadFlowUrlResponse {
         try await self.getDownloadFlowUrl(.init(agent: agent, downLoadFlows: downLoadFlows, operator: `operator`), region: region, logger: logger, on: eventLoop)

--- a/Sources/Teco/Essbasic/V20210526/actions/OperateChannelTemplate.swift
+++ b/Sources/Teco/Essbasic/V20210526/actions/OperateChannelTemplate.swift
@@ -51,8 +51,19 @@ extension Essbasic {
         public let available: Int64?
 
         /// 暂未开放
-        public let `operator`: UserInfo?
+        @available(*, deprecated)
+        public let `operator`: UserInfo? = nil
 
+        public init(agent: Agent, operateType: String, templateId: String, proxyOrganizationOpenIds: String? = nil, authTag: String? = nil, available: Int64? = nil) {
+            self.agent = agent
+            self.operateType = operateType
+            self.templateId = templateId
+            self.proxyOrganizationOpenIds = proxyOrganizationOpenIds
+            self.authTag = authTag
+            self.available = available
+        }
+
+        @available(*, deprecated, renamed: "init(agent:operateType:templateId:proxyOrganizationOpenIds:authTag:available:)", message: "'operator' is deprecated in 'OperateChannelTemplateRequest'. Setting this parameter has no effect.")
         public init(agent: Agent, operateType: String, templateId: String, proxyOrganizationOpenIds: String? = nil, authTag: String? = nil, available: Int64? = nil, operator: UserInfo? = nil) {
             self.agent = agent
             self.operateType = operateType
@@ -60,7 +71,6 @@ extension Essbasic {
             self.proxyOrganizationOpenIds = proxyOrganizationOpenIds
             self.authTag = authTag
             self.available = available
-            self.operator = `operator`
         }
 
         enum CodingKeys: String, CodingKey {
@@ -187,6 +197,31 @@ extension Essbasic {
     /// > - 对于自动领取的模板，由于已经下发，更改授权不会影响。
     /// > - 如果要同步删除子客自有模板库中的模板，请使用OperateType=UPDATE+Available参数处理。
     @inlinable
+    public func operateChannelTemplate(agent: Agent, operateType: String, templateId: String, proxyOrganizationOpenIds: String? = nil, authTag: String? = nil, available: Int64? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<OperateChannelTemplateResponse> {
+        self.operateChannelTemplate(.init(agent: agent, operateType: operateType, templateId: templateId, proxyOrganizationOpenIds: proxyOrganizationOpenIds, authTag: authTag, available: available), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 操作第三方应用平台企业模板
+    ///
+    /// 此接口（OperateChannelTemplate）用于针对第三方应用平台模板库中的模板对子客企业可见性的查询和设置。
+    ///
+    /// > **使用场景**
+    /// >
+    /// >  1：查询 OperateType=SELECT
+    /// > - 查询第三方应用平台模板库的可见性以及授权的子客列表。
+    /// >
+    /// >  2：修改部分子客授权 OperateType=UPDATE
+    /// > - 对子客企业进行模板库中模板可见性的进行修改操作。
+    /// >- 当模板未发布时，可以修改可见性AuthTag（part/all），当模板发布后，不可做此修改
+    /// > - 若模板已发布且可见性AuthTag是part，可以通过ProxyOrganizationOpenIds增加子客的授权范围。如果是自动领取的模板，增加授权范围后会自动下发。
+    /// >
+    /// >  3：取消部分子客授权 OperateType=DELETE
+    /// > - 对子客企业进行模板库中模板可见性的进行删除操作。
+    /// > - 主要对于手动领取的模板，去除授权后子客在在模板库中看不到，就无法再领取了。但是已经领取过成为自有模板的不会同步删除。
+    /// > - 对于自动领取的模板，由于已经下发，更改授权不会影响。
+    /// > - 如果要同步删除子客自有模板库中的模板，请使用OperateType=UPDATE+Available参数处理。
+    @available(*, deprecated, renamed: "operateChannelTemplate(agent:operateType:templateId:proxyOrganizationOpenIds:authTag:available:region:logger:on:)", message: "'operator' is deprecated. Setting this parameter has no effect.")
+    @inlinable
     public func operateChannelTemplate(agent: Agent, operateType: String, templateId: String, proxyOrganizationOpenIds: String? = nil, authTag: String? = nil, available: Int64? = nil, operator: UserInfo? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<OperateChannelTemplateResponse> {
         self.operateChannelTemplate(.init(agent: agent, operateType: operateType, templateId: templateId, proxyOrganizationOpenIds: proxyOrganizationOpenIds, authTag: authTag, available: available, operator: `operator`), region: region, logger: logger, on: eventLoop)
     }
@@ -210,6 +245,31 @@ extension Essbasic {
     /// > - 主要对于手动领取的模板，去除授权后子客在在模板库中看不到，就无法再领取了。但是已经领取过成为自有模板的不会同步删除。
     /// > - 对于自动领取的模板，由于已经下发，更改授权不会影响。
     /// > - 如果要同步删除子客自有模板库中的模板，请使用OperateType=UPDATE+Available参数处理。
+    @inlinable
+    public func operateChannelTemplate(agent: Agent, operateType: String, templateId: String, proxyOrganizationOpenIds: String? = nil, authTag: String? = nil, available: Int64? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> OperateChannelTemplateResponse {
+        try await self.operateChannelTemplate(.init(agent: agent, operateType: operateType, templateId: templateId, proxyOrganizationOpenIds: proxyOrganizationOpenIds, authTag: authTag, available: available), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 操作第三方应用平台企业模板
+    ///
+    /// 此接口（OperateChannelTemplate）用于针对第三方应用平台模板库中的模板对子客企业可见性的查询和设置。
+    ///
+    /// > **使用场景**
+    /// >
+    /// >  1：查询 OperateType=SELECT
+    /// > - 查询第三方应用平台模板库的可见性以及授权的子客列表。
+    /// >
+    /// >  2：修改部分子客授权 OperateType=UPDATE
+    /// > - 对子客企业进行模板库中模板可见性的进行修改操作。
+    /// >- 当模板未发布时，可以修改可见性AuthTag（part/all），当模板发布后，不可做此修改
+    /// > - 若模板已发布且可见性AuthTag是part，可以通过ProxyOrganizationOpenIds增加子客的授权范围。如果是自动领取的模板，增加授权范围后会自动下发。
+    /// >
+    /// >  3：取消部分子客授权 OperateType=DELETE
+    /// > - 对子客企业进行模板库中模板可见性的进行删除操作。
+    /// > - 主要对于手动领取的模板，去除授权后子客在在模板库中看不到，就无法再领取了。但是已经领取过成为自有模板的不会同步删除。
+    /// > - 对于自动领取的模板，由于已经下发，更改授权不会影响。
+    /// > - 如果要同步删除子客自有模板库中的模板，请使用OperateType=UPDATE+Available参数处理。
+    @available(*, deprecated, renamed: "operateChannelTemplate(agent:operateType:templateId:proxyOrganizationOpenIds:authTag:available:region:logger:on:)", message: "'operator' is deprecated. Setting this parameter has no effect.")
     @inlinable
     public func operateChannelTemplate(agent: Agent, operateType: String, templateId: String, proxyOrganizationOpenIds: String? = nil, authTag: String? = nil, available: Int64? = nil, operator: UserInfo? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> OperateChannelTemplateResponse {
         try await self.operateChannelTemplate(.init(agent: agent, operateType: operateType, templateId: templateId, proxyOrganizationOpenIds: proxyOrganizationOpenIds, authTag: authTag, available: available, operator: `operator`), region: region, logger: logger, on: eventLoop)

--- a/Sources/Teco/Essbasic/V20210526/actions/PrepareFlows.swift
+++ b/Sources/Teco/Essbasic/V20210526/actions/PrepareFlows.swift
@@ -31,13 +31,20 @@ extension Essbasic {
         public let jumpUrl: String
 
         /// 暂未开放
-        public let `operator`: UserInfo?
+        @available(*, deprecated)
+        public let `operator`: UserInfo? = nil
 
+        public init(agent: Agent, flowInfos: [FlowInfo], jumpUrl: String) {
+            self.agent = agent
+            self.flowInfos = flowInfos
+            self.jumpUrl = jumpUrl
+        }
+
+        @available(*, deprecated, renamed: "init(agent:flowInfos:jumpUrl:)", message: "'operator' is deprecated in 'PrepareFlowsRequest'. Setting this parameter has no effect.")
         public init(agent: Agent, flowInfos: [FlowInfo], jumpUrl: String, operator: UserInfo? = nil) {
             self.agent = agent
             self.flowInfos = flowInfos
             self.jumpUrl = jumpUrl
-            self.operator = `operator`
         }
 
         enum CodingKeys: String, CodingKey {
@@ -88,6 +95,17 @@ extension Essbasic {
     /// 用户通过该接口进入签署流程发起的确认页面，进行发起信息二次确认， 如果确认则进行正常发起。
     /// 目前该接口只支持B2C，不建议使用，将会废弃。
     @inlinable
+    public func prepareFlows(agent: Agent, flowInfos: [FlowInfo], jumpUrl: String, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<PrepareFlowsResponse> {
+        self.prepareFlows(.init(agent: agent, flowInfos: flowInfos, jumpUrl: jumpUrl), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 准备待发起文件
+    ///
+    /// 该接口 (PrepareFlows) 用于创建待发起文件
+    /// 用户通过该接口进入签署流程发起的确认页面，进行发起信息二次确认， 如果确认则进行正常发起。
+    /// 目前该接口只支持B2C，不建议使用，将会废弃。
+    @available(*, deprecated, renamed: "prepareFlows(agent:flowInfos:jumpUrl:region:logger:on:)", message: "'operator' is deprecated. Setting this parameter has no effect.")
+    @inlinable
     public func prepareFlows(agent: Agent, flowInfos: [FlowInfo], jumpUrl: String, operator: UserInfo? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<PrepareFlowsResponse> {
         self.prepareFlows(.init(agent: agent, flowInfos: flowInfos, jumpUrl: jumpUrl, operator: `operator`), region: region, logger: logger, on: eventLoop)
     }
@@ -97,6 +115,17 @@ extension Essbasic {
     /// 该接口 (PrepareFlows) 用于创建待发起文件
     /// 用户通过该接口进入签署流程发起的确认页面，进行发起信息二次确认， 如果确认则进行正常发起。
     /// 目前该接口只支持B2C，不建议使用，将会废弃。
+    @inlinable
+    public func prepareFlows(agent: Agent, flowInfos: [FlowInfo], jumpUrl: String, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> PrepareFlowsResponse {
+        try await self.prepareFlows(.init(agent: agent, flowInfos: flowInfos, jumpUrl: jumpUrl), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 准备待发起文件
+    ///
+    /// 该接口 (PrepareFlows) 用于创建待发起文件
+    /// 用户通过该接口进入签署流程发起的确认页面，进行发起信息二次确认， 如果确认则进行正常发起。
+    /// 目前该接口只支持B2C，不建议使用，将会废弃。
+    @available(*, deprecated, renamed: "prepareFlows(agent:flowInfos:jumpUrl:region:logger:on:)", message: "'operator' is deprecated. Setting this parameter has no effect.")
     @inlinable
     public func prepareFlows(agent: Agent, flowInfos: [FlowInfo], jumpUrl: String, operator: UserInfo? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> PrepareFlowsResponse {
         try await self.prepareFlows(.init(agent: agent, flowInfos: flowInfos, jumpUrl: jumpUrl, operator: `operator`), region: region, logger: logger, on: eventLoop)

--- a/Sources/Teco/Essbasic/V20210526/actions/SyncProxyOrganization.swift
+++ b/Sources/Teco/Essbasic/V20210526/actions/SyncProxyOrganization.swift
@@ -38,15 +38,24 @@ extension Essbasic {
         public let proxyLegalName: String?
 
         /// 暂未开放
-        public let `operator`: UserInfo?
+        @available(*, deprecated)
+        public let `operator`: UserInfo? = nil
 
+        public init(agent: Agent, proxyOrganizationName: String, businessLicense: String? = nil, uniformSocialCreditCode: String? = nil, proxyLegalName: String? = nil) {
+            self.agent = agent
+            self.proxyOrganizationName = proxyOrganizationName
+            self.businessLicense = businessLicense
+            self.uniformSocialCreditCode = uniformSocialCreditCode
+            self.proxyLegalName = proxyLegalName
+        }
+
+        @available(*, deprecated, renamed: "init(agent:proxyOrganizationName:businessLicense:uniformSocialCreditCode:proxyLegalName:)", message: "'operator' is deprecated in 'SyncProxyOrganizationRequest'. Setting this parameter has no effect.")
         public init(agent: Agent, proxyOrganizationName: String, businessLicense: String? = nil, uniformSocialCreditCode: String? = nil, proxyLegalName: String? = nil, operator: UserInfo? = nil) {
             self.agent = agent
             self.proxyOrganizationName = proxyOrganizationName
             self.businessLicense = businessLicense
             self.uniformSocialCreditCode = uniformSocialCreditCode
             self.proxyLegalName = proxyLegalName
-            self.operator = `operator`
         }
 
         enum CodingKeys: String, CodingKey {
@@ -89,6 +98,15 @@ extension Essbasic {
     ///
     /// 此接口（SyncProxyOrganization）用于同步第三方平台子客企业信息，主要是子客企业的营业执照，便于子客企业开通过程中不用手动上传。若有需要调用此接口，需要在创建控制链接CreateConsoleLoginUrl之后即刻进行调用。
     @inlinable @discardableResult
+    public func syncProxyOrganization(agent: Agent, proxyOrganizationName: String, businessLicense: String? = nil, uniformSocialCreditCode: String? = nil, proxyLegalName: String? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<SyncProxyOrganizationResponse> {
+        self.syncProxyOrganization(.init(agent: agent, proxyOrganizationName: proxyOrganizationName, businessLicense: businessLicense, uniformSocialCreditCode: uniformSocialCreditCode, proxyLegalName: proxyLegalName), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 同步企业信息
+    ///
+    /// 此接口（SyncProxyOrganization）用于同步第三方平台子客企业信息，主要是子客企业的营业执照，便于子客企业开通过程中不用手动上传。若有需要调用此接口，需要在创建控制链接CreateConsoleLoginUrl之后即刻进行调用。
+    @available(*, deprecated, renamed: "syncProxyOrganization(agent:proxyOrganizationName:businessLicense:uniformSocialCreditCode:proxyLegalName:region:logger:on:)", message: "'operator' is deprecated. Setting this parameter has no effect.")
+    @inlinable @discardableResult
     public func syncProxyOrganization(agent: Agent, proxyOrganizationName: String, businessLicense: String? = nil, uniformSocialCreditCode: String? = nil, proxyLegalName: String? = nil, operator: UserInfo? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<SyncProxyOrganizationResponse> {
         self.syncProxyOrganization(.init(agent: agent, proxyOrganizationName: proxyOrganizationName, businessLicense: businessLicense, uniformSocialCreditCode: uniformSocialCreditCode, proxyLegalName: proxyLegalName, operator: `operator`), region: region, logger: logger, on: eventLoop)
     }
@@ -96,6 +114,15 @@ extension Essbasic {
     /// 同步企业信息
     ///
     /// 此接口（SyncProxyOrganization）用于同步第三方平台子客企业信息，主要是子客企业的营业执照，便于子客企业开通过程中不用手动上传。若有需要调用此接口，需要在创建控制链接CreateConsoleLoginUrl之后即刻进行调用。
+    @inlinable @discardableResult
+    public func syncProxyOrganization(agent: Agent, proxyOrganizationName: String, businessLicense: String? = nil, uniformSocialCreditCode: String? = nil, proxyLegalName: String? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> SyncProxyOrganizationResponse {
+        try await self.syncProxyOrganization(.init(agent: agent, proxyOrganizationName: proxyOrganizationName, businessLicense: businessLicense, uniformSocialCreditCode: uniformSocialCreditCode, proxyLegalName: proxyLegalName), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 同步企业信息
+    ///
+    /// 此接口（SyncProxyOrganization）用于同步第三方平台子客企业信息，主要是子客企业的营业执照，便于子客企业开通过程中不用手动上传。若有需要调用此接口，需要在创建控制链接CreateConsoleLoginUrl之后即刻进行调用。
+    @available(*, deprecated, renamed: "syncProxyOrganization(agent:proxyOrganizationName:businessLicense:uniformSocialCreditCode:proxyLegalName:region:logger:on:)", message: "'operator' is deprecated. Setting this parameter has no effect.")
     @inlinable @discardableResult
     public func syncProxyOrganization(agent: Agent, proxyOrganizationName: String, businessLicense: String? = nil, uniformSocialCreditCode: String? = nil, proxyLegalName: String? = nil, operator: UserInfo? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> SyncProxyOrganizationResponse {
         try await self.syncProxyOrganization(.init(agent: agent, proxyOrganizationName: proxyOrganizationName, businessLicense: businessLicense, uniformSocialCreditCode: uniformSocialCreditCode, proxyLegalName: proxyLegalName, operator: `operator`), region: region, logger: logger, on: eventLoop)

--- a/Sources/Teco/Essbasic/V20210526/actions/SyncProxyOrganizationOperators.swift
+++ b/Sources/Teco/Essbasic/V20210526/actions/SyncProxyOrganizationOperators.swift
@@ -31,13 +31,20 @@ extension Essbasic {
         public let proxyOrganizationOperators: [ProxyOrganizationOperator]
 
         /// 暂未开放
-        public let `operator`: UserInfo?
+        @available(*, deprecated)
+        public let `operator`: UserInfo? = nil
 
+        public init(agent: Agent, operatorType: String, proxyOrganizationOperators: [ProxyOrganizationOperator]) {
+            self.agent = agent
+            self.operatorType = operatorType
+            self.proxyOrganizationOperators = proxyOrganizationOperators
+        }
+
+        @available(*, deprecated, renamed: "init(agent:operatorType:proxyOrganizationOperators:)", message: "'operator' is deprecated in 'SyncProxyOrganizationOperatorsRequest'. Setting this parameter has no effect.")
         public init(agent: Agent, operatorType: String, proxyOrganizationOperators: [ProxyOrganizationOperator], operator: UserInfo? = nil) {
             self.agent = agent
             self.operatorType = operatorType
             self.proxyOrganizationOperators = proxyOrganizationOperators
-            self.operator = `operator`
         }
 
         enum CodingKeys: String, CodingKey {
@@ -93,6 +100,16 @@ extension Essbasic {
     /// 此接口（SyncProxyOrganizationOperators）用于同步 第三方平台子客企业经办人列表，主要是同步经办人的离职状态。子客Web控制台的组织架构管理，是依赖于第三方应用平台的，无法针对员工做新增/更新/离职等操作。
     /// 若经办人信息有误，或者需要修改，也可以先将之前的经办人做离职操作，然后重新使用控制台链接CreateConsoleLoginUrl让经办人重新实名。
     @inlinable
+    public func syncProxyOrganizationOperators(agent: Agent, operatorType: String, proxyOrganizationOperators: [ProxyOrganizationOperator], region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<SyncProxyOrganizationOperatorsResponse> {
+        self.syncProxyOrganizationOperators(.init(agent: agent, operatorType: operatorType, proxyOrganizationOperators: proxyOrganizationOperators), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 同步企业经办人列表
+    ///
+    /// 此接口（SyncProxyOrganizationOperators）用于同步 第三方平台子客企业经办人列表，主要是同步经办人的离职状态。子客Web控制台的组织架构管理，是依赖于第三方应用平台的，无法针对员工做新增/更新/离职等操作。
+    /// 若经办人信息有误，或者需要修改，也可以先将之前的经办人做离职操作，然后重新使用控制台链接CreateConsoleLoginUrl让经办人重新实名。
+    @available(*, deprecated, renamed: "syncProxyOrganizationOperators(agent:operatorType:proxyOrganizationOperators:region:logger:on:)", message: "'operator' is deprecated. Setting this parameter has no effect.")
+    @inlinable
     public func syncProxyOrganizationOperators(agent: Agent, operatorType: String, proxyOrganizationOperators: [ProxyOrganizationOperator], operator: UserInfo? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<SyncProxyOrganizationOperatorsResponse> {
         self.syncProxyOrganizationOperators(.init(agent: agent, operatorType: operatorType, proxyOrganizationOperators: proxyOrganizationOperators, operator: `operator`), region: region, logger: logger, on: eventLoop)
     }
@@ -101,6 +118,16 @@ extension Essbasic {
     ///
     /// 此接口（SyncProxyOrganizationOperators）用于同步 第三方平台子客企业经办人列表，主要是同步经办人的离职状态。子客Web控制台的组织架构管理，是依赖于第三方应用平台的，无法针对员工做新增/更新/离职等操作。
     /// 若经办人信息有误，或者需要修改，也可以先将之前的经办人做离职操作，然后重新使用控制台链接CreateConsoleLoginUrl让经办人重新实名。
+    @inlinable
+    public func syncProxyOrganizationOperators(agent: Agent, operatorType: String, proxyOrganizationOperators: [ProxyOrganizationOperator], region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> SyncProxyOrganizationOperatorsResponse {
+        try await self.syncProxyOrganizationOperators(.init(agent: agent, operatorType: operatorType, proxyOrganizationOperators: proxyOrganizationOperators), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 同步企业经办人列表
+    ///
+    /// 此接口（SyncProxyOrganizationOperators）用于同步 第三方平台子客企业经办人列表，主要是同步经办人的离职状态。子客Web控制台的组织架构管理，是依赖于第三方应用平台的，无法针对员工做新增/更新/离职等操作。
+    /// 若经办人信息有误，或者需要修改，也可以先将之前的经办人做离职操作，然后重新使用控制台链接CreateConsoleLoginUrl让经办人重新实名。
+    @available(*, deprecated, renamed: "syncProxyOrganizationOperators(agent:operatorType:proxyOrganizationOperators:region:logger:on:)", message: "'operator' is deprecated. Setting this parameter has no effect.")
     @inlinable
     public func syncProxyOrganizationOperators(agent: Agent, operatorType: String, proxyOrganizationOperators: [ProxyOrganizationOperator], operator: UserInfo? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> SyncProxyOrganizationOperatorsResponse {
         try await self.syncProxyOrganizationOperators(.init(agent: agent, operatorType: operatorType, proxyOrganizationOperators: proxyOrganizationOperators, operator: `operator`), region: region, logger: logger, on: eventLoop)

--- a/Sources/Teco/Essbasic/V20210526/actions/UploadFiles.swift
+++ b/Sources/Teco/Essbasic/V20210526/actions/UploadFiles.swift
@@ -33,13 +33,20 @@ extension Essbasic {
         public let fileInfos: [UploadFile]?
 
         /// 操作者的信息
-        public let `operator`: UserInfo?
+        @available(*, deprecated)
+        public let `operator`: UserInfo? = nil
 
+        public init(agent: Agent, businessType: String, fileInfos: [UploadFile]? = nil) {
+            self.agent = agent
+            self.businessType = businessType
+            self.fileInfos = fileInfos
+        }
+
+        @available(*, deprecated, renamed: "init(agent:businessType:fileInfos:)", message: "'operator' is deprecated in 'UploadFilesRequest'. Setting this parameter has no effect.")
         public init(agent: Agent, businessType: String, fileInfos: [UploadFile]? = nil, operator: UserInfo? = nil) {
             self.agent = agent
             self.businessType = businessType
             self.fileInfos = fileInfos
-            self.operator = `operator`
         }
 
         enum CodingKeys: String, CodingKey {
@@ -107,6 +114,20 @@ extension Essbasic {
     /// HttpProfile httpProfile = new HttpProfile();
     /// httpProfile.setEndpoint("file.test.ess.tencent.cn");
     @inlinable
+    public func uploadFiles(agent: Agent, businessType: String, fileInfos: [UploadFile]? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<UploadFilesResponse> {
+        self.uploadFiles(.init(agent: agent, businessType: businessType, fileInfos: fileInfos), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 文件上传
+    ///
+    /// 此接口（UploadFiles）用于文件上传。
+    /// 其中上传的文件，图片类型(png/jpg/jpeg)大小限制为5M，其他大小限制为60M。
+    /// 调用时需要设置Domain, 正式环境为 file.ess.tencent.cn。
+    /// 代码示例：
+    /// HttpProfile httpProfile = new HttpProfile();
+    /// httpProfile.setEndpoint("file.test.ess.tencent.cn");
+    @available(*, deprecated, renamed: "uploadFiles(agent:businessType:fileInfos:region:logger:on:)", message: "'operator' is deprecated. Setting this parameter has no effect.")
+    @inlinable
     public func uploadFiles(agent: Agent, businessType: String, fileInfos: [UploadFile]? = nil, operator: UserInfo? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<UploadFilesResponse> {
         self.uploadFiles(.init(agent: agent, businessType: businessType, fileInfos: fileInfos, operator: `operator`), region: region, logger: logger, on: eventLoop)
     }
@@ -119,6 +140,20 @@ extension Essbasic {
     /// 代码示例：
     /// HttpProfile httpProfile = new HttpProfile();
     /// httpProfile.setEndpoint("file.test.ess.tencent.cn");
+    @inlinable
+    public func uploadFiles(agent: Agent, businessType: String, fileInfos: [UploadFile]? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> UploadFilesResponse {
+        try await self.uploadFiles(.init(agent: agent, businessType: businessType, fileInfos: fileInfos), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 文件上传
+    ///
+    /// 此接口（UploadFiles）用于文件上传。
+    /// 其中上传的文件，图片类型(png/jpg/jpeg)大小限制为5M，其他大小限制为60M。
+    /// 调用时需要设置Domain, 正式环境为 file.ess.tencent.cn。
+    /// 代码示例：
+    /// HttpProfile httpProfile = new HttpProfile();
+    /// httpProfile.setEndpoint("file.test.ess.tencent.cn");
+    @available(*, deprecated, renamed: "uploadFiles(agent:businessType:fileInfos:region:logger:on:)", message: "'operator' is deprecated. Setting this parameter has no effect.")
     @inlinable
     public func uploadFiles(agent: Agent, businessType: String, fileInfos: [UploadFile]? = nil, operator: UserInfo? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> UploadFilesResponse {
         try await self.uploadFiles(.init(agent: agent, businessType: businessType, fileInfos: fileInfos, operator: `operator`), region: region, logger: logger, on: eventLoop)

--- a/Sources/Teco/Essbasic/V20210526/models.swift
+++ b/Sources/Teco/Essbasic/V20210526/models.swift
@@ -34,14 +34,22 @@ extension Essbasic {
         public let proxyAppId: String?
 
         /// 内部参数，暂未开放使用
-        public let proxyOrganizationId: String?
+        @available(*, deprecated)
+        public let proxyOrganizationId: String? = nil
 
+        public init(appId: String, proxyOrganizationOpenId: String? = nil, proxyOperator: UserInfo? = nil, proxyAppId: String? = nil) {
+            self.appId = appId
+            self.proxyOrganizationOpenId = proxyOrganizationOpenId
+            self.proxyOperator = proxyOperator
+            self.proxyAppId = proxyAppId
+        }
+
+        @available(*, deprecated, renamed: "init(appId:proxyOrganizationOpenId:proxyOperator:proxyAppId:)", message: "'proxyOrganizationId' is deprecated in 'Agent'. Setting this parameter has no effect.")
         public init(appId: String, proxyOrganizationOpenId: String? = nil, proxyOperator: UserInfo? = nil, proxyAppId: String? = nil, proxyOrganizationId: String? = nil) {
             self.appId = appId
             self.proxyOrganizationOpenId = proxyOrganizationOpenId
             self.proxyOperator = proxyOperator
             self.proxyAppId = proxyAppId
-            self.proxyOrganizationId = proxyOrganizationId
         }
 
         enum CodingKeys: String, CodingKey {
@@ -299,11 +307,29 @@ extension Essbasic {
         public let isFullText: Bool?
 
         /// 通知类型：SMS（短信） NONE（不做通知）, 不传 默认SMS
-        public let notifyType: String?
+        @available(*, deprecated)
+        public let notifyType: String? = nil
 
         /// 签署人配置
         public let approverOption: CommonApproverOption?
 
+        public init(notChannelOrganization: Bool, approverType: Int64? = nil, organizationId: String? = nil, organizationOpenId: String? = nil, organizationName: String? = nil, userId: String? = nil, openId: String? = nil, approverName: String? = nil, approverMobile: String? = nil, recipientId: String? = nil, preReadTime: Int64? = nil, isFullText: Bool? = nil, approverOption: CommonApproverOption? = nil) {
+            self.notChannelOrganization = notChannelOrganization
+            self.approverType = approverType
+            self.organizationId = organizationId
+            self.organizationOpenId = organizationOpenId
+            self.organizationName = organizationName
+            self.userId = userId
+            self.openId = openId
+            self.approverName = approverName
+            self.approverMobile = approverMobile
+            self.recipientId = recipientId
+            self.preReadTime = preReadTime
+            self.isFullText = isFullText
+            self.approverOption = approverOption
+        }
+
+        @available(*, deprecated, renamed: "init(notChannelOrganization:approverType:organizationId:organizationOpenId:organizationName:userId:openId:approverName:approverMobile:recipientId:preReadTime:isFullText:approverOption:)", message: "'notifyType' is deprecated in 'CommonFlowApprover'. Setting this parameter has no effect.")
         public init(notChannelOrganization: Bool, approverType: Int64? = nil, organizationId: String? = nil, organizationOpenId: String? = nil, organizationName: String? = nil, userId: String? = nil, openId: String? = nil, approverName: String? = nil, approverMobile: String? = nil, recipientId: String? = nil, preReadTime: Int64? = nil, isFullText: Bool? = nil, notifyType: String? = nil, approverOption: CommonApproverOption? = nil) {
             self.notChannelOrganization = notChannelOrganization
             self.approverType = approverType
@@ -317,7 +343,6 @@ extension Essbasic {
             self.recipientId = recipientId
             self.preReadTime = preReadTime
             self.isFullText = isFullText
-            self.notifyType = notifyType
             self.approverOption = approverOption
         }
 
@@ -942,7 +967,8 @@ extension Essbasic {
         public let deadline: Int64?
 
         /// 签署完回调url，最大长度1000个字符
-        public let callbackUrl: String?
+        @available(*, deprecated)
+        public let callbackUrl: String? = nil
 
         /// 使用PDF文件直接发起合同时，签署人指定的签署控件；<br/>使用模板发起合同时，指定本企业印章签署控件的印章ID: <br/>通过ComponentId或ComponenetName指定签署控件，ComponentValue为印章ID。
         public let signComponents: [Component]?
@@ -983,6 +1009,31 @@ extension Essbasic {
         /// 默认为SMS(签署方为子客时该字段不生效)
         public let notifyType: String?
 
+        public init(name: String? = nil, idCardType: String? = nil, idCardNumber: String? = nil, mobile: String? = nil, organizationName: String? = nil, notChannelOrganization: Bool? = nil, openId: String? = nil, organizationOpenId: String? = nil, approverType: String? = nil, recipientId: String? = nil, deadline: Int64? = nil, signComponents: [Component]? = nil, componentLimitType: [String]? = nil, preReadTime: Int64? = nil, jumpUrl: String? = nil, approverOption: ApproverOption? = nil, approverNeedSignReview: Bool? = nil, approverVerifyTypes: [Int64]? = nil, approverSignTypes: [Int64]? = nil, signId: String? = nil, notifyType: String? = nil) {
+            self.name = name
+            self.idCardType = idCardType
+            self.idCardNumber = idCardNumber
+            self.mobile = mobile
+            self.organizationName = organizationName
+            self.notChannelOrganization = notChannelOrganization
+            self.openId = openId
+            self.organizationOpenId = organizationOpenId
+            self.approverType = approverType
+            self.recipientId = recipientId
+            self.deadline = deadline
+            self.signComponents = signComponents
+            self.componentLimitType = componentLimitType
+            self.preReadTime = preReadTime
+            self.jumpUrl = jumpUrl
+            self.approverOption = approverOption
+            self.approverNeedSignReview = approverNeedSignReview
+            self.approverVerifyTypes = approverVerifyTypes
+            self.approverSignTypes = approverSignTypes
+            self.signId = signId
+            self.notifyType = notifyType
+        }
+
+        @available(*, deprecated, renamed: "init(name:idCardType:idCardNumber:mobile:organizationName:notChannelOrganization:openId:organizationOpenId:approverType:recipientId:deadline:signComponents:componentLimitType:preReadTime:jumpUrl:approverOption:approverNeedSignReview:approverVerifyTypes:approverSignTypes:signId:notifyType:)", message: "'callbackUrl' is deprecated in 'FlowApproverInfo'. Setting this parameter has no effect.")
         public init(name: String? = nil, idCardType: String? = nil, idCardNumber: String? = nil, mobile: String? = nil, organizationName: String? = nil, notChannelOrganization: Bool? = nil, openId: String? = nil, organizationOpenId: String? = nil, approverType: String? = nil, recipientId: String? = nil, deadline: Int64? = nil, callbackUrl: String? = nil, signComponents: [Component]? = nil, componentLimitType: [String]? = nil, preReadTime: Int64? = nil, jumpUrl: String? = nil, approverOption: ApproverOption? = nil, approverNeedSignReview: Bool? = nil, approverVerifyTypes: [Int64]? = nil, approverSignTypes: [Int64]? = nil, signId: String? = nil, notifyType: String? = nil) {
             self.name = name
             self.idCardType = idCardType
@@ -995,7 +1046,6 @@ extension Essbasic {
             self.approverType = approverType
             self.recipientId = recipientId
             self.deadline = deadline
-            self.callbackUrl = callbackUrl
             self.signComponents = signComponents
             self.componentLimitType = componentLimitType
             self.preReadTime = preReadTime
@@ -1501,17 +1551,24 @@ extension Essbasic {
         public let channel: String?
 
         /// 用户真实的IP
-        public let clientIp: String?
+        @available(*, deprecated)
+        public let clientIp: String? = nil
 
         /// 机构的代理IP
-        public let proxyIp: String?
+        @available(*, deprecated)
+        public let proxyIp: String? = nil
 
+        public init(organizationOpenId: String, organizationId: String? = nil, channel: String? = nil) {
+            self.organizationOpenId = organizationOpenId
+            self.organizationId = organizationId
+            self.channel = channel
+        }
+
+        @available(*, deprecated, renamed: "init(organizationOpenId:organizationId:channel:)", message: "'clientIp' and 'proxyIp' are deprecated in 'OrganizationInfo'. Setting these parameters has no effect.")
         public init(organizationOpenId: String, organizationId: String? = nil, channel: String? = nil, clientIp: String? = nil, proxyIp: String? = nil) {
             self.organizationOpenId = organizationOpenId
             self.organizationId = organizationId
             self.channel = channel
-            self.clientIp = clientIp
-            self.proxyIp = proxyIp
         }
 
         enum CodingKeys: String, CodingKey {
@@ -1929,6 +1986,7 @@ extension Essbasic {
 
         /// 自定义用户编号
         /// 注意：此字段可能返回 null，表示取不到有效值。
+        @available(*, deprecated)
         public let customUserId: String?
 
         /// 用户姓名
@@ -2116,6 +2174,7 @@ extension Essbasic {
         public let templateType: Int64
 
         /// 是否是发起人 ,已弃用
+        @available(*, deprecated)
         public let isPromoter: Bool
 
         /// 模板的创建者信息，电子签系统用户ID
@@ -2242,23 +2301,28 @@ extension Essbasic {
         public let openId: String?
 
         /// 内部参数，暂未开放使用
-        public let channel: String?
+        @available(*, deprecated)
+        public let channel: String? = nil
 
         /// 内部参数，暂未开放使用
-        public let customUserId: String?
+        @available(*, deprecated)
+        public let customUserId: String? = nil
 
         /// 内部参数，暂未开放使用
-        public let clientIp: String?
+        @available(*, deprecated)
+        public let clientIp: String? = nil
 
         /// 内部参数，暂未开放使用
-        public let proxyIp: String?
+        @available(*, deprecated)
+        public let proxyIp: String? = nil
 
+        public init(openId: String? = nil) {
+            self.openId = openId
+        }
+
+        @available(*, deprecated, renamed: "init(openId:)", message: "'channel', 'customUserId', 'clientIp' and 'proxyIp' are deprecated in 'UserInfo'. Setting these parameters has no effect.")
         public init(openId: String? = nil, channel: String? = nil, customUserId: String? = nil, clientIp: String? = nil, proxyIp: String? = nil) {
             self.openId = openId
-            self.channel = channel
-            self.customUserId = customUserId
-            self.clientIp = clientIp
-            self.proxyIp = proxyIp
         }
 
         enum CodingKeys: String, CodingKey {

--- a/Sources/Teco/Faceid/V20180301/models.swift
+++ b/Sources/Teco/Faceid/V20180301/models.swift
@@ -436,7 +436,7 @@ extension Faceid {
         /// 注意：此字段可能返回 null，表示取不到有效值。
         public let tagList: [String]?
 
-        public init(encryptList: [String], ciphertextBlob: String, iv: String, algorithm: String? = nil, tagList: [String]? = nil) {
+        public init(encryptList: [String]? = nil, ciphertextBlob: String? = nil, iv: String? = nil, algorithm: String? = nil, tagList: [String]? = nil) {
             self.encryptList = encryptList
             self.ciphertextBlob = ciphertextBlob
             self.iv = iv

--- a/Sources/Teco/Iotvideo/V20211125/actions/DescribeCloudStorageThumbnail.swift
+++ b/Sources/Teco/Iotvideo/V20211125/actions/DescribeCloudStorageThumbnail.swift
@@ -49,7 +49,7 @@ extension Iotvideo {
         public let thumbnailURL: String
 
         /// 缩略图访问地址的过期时间
-        public let expireTime: Int64
+        public let expireTime: Int64?
 
         /// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
         public let requestId: String

--- a/Sources/Teco/Iss/V20230517/models.swift
+++ b/Sources/Teco/Iss/V20230517/models.swift
@@ -20,15 +20,15 @@ extension Iss {
     /// AI分析配置
     public struct AIConfig: TCInputModel, TCOutputModel {
         /// AI 分析类型。可选值为 Facemask(口罩识别)、Chefhat(厨师帽识别)、Smoking(抽烟检测)、Chefcloth(厨师服识别)、PhoneCall(接打电话识别)、Pet(宠物识别)、Body(人体识别)和Car(车辆车牌识别)等
-        public let detectType: String
+        public let detectType: String?
 
         /// 截图频率。可选值1～20秒
-        public let timeInterval: UInt64
+        public let timeInterval: UInt64?
 
         /// 模板生效的时间段。最多包含5组时间段
-        public let operTimeSlot: [OperTimeSlot]
+        public let operTimeSlot: [OperTimeSlot]?
 
-        public init(detectType: String, timeInterval: UInt64, operTimeSlot: [OperTimeSlot]) {
+        public init(detectType: String? = nil, timeInterval: UInt64? = nil, operTimeSlot: [OperTimeSlot]? = nil) {
             self.detectType = detectType
             self.timeInterval = timeInterval
             self.operTimeSlot = operTimeSlot
@@ -163,7 +163,7 @@ extension Iss {
     /// AI模板信息
     public struct AITemplates: TCInputModel, TCOutputModel {
         /// AI 类别。可选值 AI(AI 分析)和 Snapshot(截图)，Templates 列表中只能出现一种类型。
-        public let tag: String
+        public let tag: String?
 
         /// AI 分析配置。和"SnapshotConfig"二选一。
         public let aiConfig: AIConfig?
@@ -171,7 +171,7 @@ extension Iss {
         /// 截图配置。和"AIConfig"二选一。
         public let snapshotConfig: SnapshotConfig?
 
-        public init(tag: String, aiConfig: AIConfig? = nil, snapshotConfig: SnapshotConfig? = nil) {
+        public init(tag: String? = nil, aiConfig: AIConfig? = nil, snapshotConfig: SnapshotConfig? = nil) {
             self.tag = tag
             self.aiConfig = aiConfig
             self.snapshotConfig = snapshotConfig
@@ -941,12 +941,12 @@ extension Iss {
     /// AI分析的时间段配置
     public struct OperTimeSlot: TCInputModel, TCOutputModel {
         /// 开始时间。格式为"hh:mm:ss"，且 Start 必须小于 End
-        public let start: String
+        public let start: String?
 
         /// 结束时间。格式为"hh:mm:ss"，且 Start 必须小于 End
-        public let end: String
+        public let end: String?
 
-        public init(start: String, end: String) {
+        public init(start: String? = nil, end: String? = nil) {
             self.start = start
             self.end = end
         }
@@ -1304,12 +1304,12 @@ extension Iss {
     /// 截图配置
     public struct SnapshotConfig: TCInputModel, TCOutputModel {
         /// 截图频率。可选值1～20秒
-        public let timeInterval: UInt64
+        public let timeInterval: UInt64?
 
         /// 模板生效的时间段。最多包含5组时间段
-        public let operTimeSlot: [OperTimeSlot]
+        public let operTimeSlot: [OperTimeSlot]?
 
-        public init(timeInterval: UInt64, operTimeSlot: [OperTimeSlot]) {
+        public init(timeInterval: UInt64? = nil, operTimeSlot: [OperTimeSlot]? = nil) {
             self.timeInterval = timeInterval
             self.operTimeSlot = operTimeSlot
         }

--- a/Sources/Teco/Lcic/V20220817/actions/DescribeDocument.swift
+++ b/Sources/Teco/Lcic/V20220817/actions/DescribeDocument.swift
@@ -78,10 +78,10 @@ extension Lcic {
         public let updateTime: UInt64
 
         /// 课件页数
-        public let pages: UInt64
+        public let pages: UInt64?
 
         /// 课件预览地址
-        public let preview: String
+        public let preview: String?
 
         /// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
         public let requestId: String

--- a/Sources/Teco/Lcic/V20220817/actions/DescribeRoom.swift
+++ b/Sources/Teco/Lcic/V20220817/actions/DescribeRoom.swift
@@ -105,16 +105,16 @@ extension Lcic {
         /// 开启专注模式。
         /// 0 收看全部角色音视频(默认)
         /// 1 只看老师和助教
-        public let interactionMode: Int64
+        public let interactionMode: Int64?
 
         /// 横竖屏。0：横屏开播（默认值）; 1：竖屏开播，当前仅支持移动端的纯视频类型
-        public let videoOrientation: UInt64
+        public let videoOrientation: UInt64?
 
         /// 开启课后评分。 0：不开启(默认)  1：开启
-        public let isGradingRequiredPostClass: Int64
+        public let isGradingRequiredPostClass: Int64?
 
         /// 房间类型: 0 小班课（默认值）; 1 大班课; 2 1V1 (后续扩展)
-        public let roomType: Int64
+        public let roomType: Int64?
 
         /// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
         public let requestId: String

--- a/Sources/Teco/Mps/V20190612/models.swift
+++ b/Sources/Teco/Mps/V20190612/models.swift
@@ -7885,7 +7885,7 @@ extension Mps {
         /// 注意：此字段可能返回 null，表示取不到有效值。
         public let s3SecretKey: String?
 
-        public init(s3Bucket: String, s3Region: String, s3Object: String, s3SecretId: String? = nil, s3SecretKey: String? = nil) {
+        public init(s3Bucket: String? = nil, s3Region: String? = nil, s3Object: String? = nil, s3SecretId: String? = nil, s3SecretKey: String? = nil) {
             self.s3Bucket = s3Bucket
             self.s3Region = s3Region
             self.s3Object = s3Object

--- a/Sources/Teco/Ms/V20180408/actions/CreateCosSecKeyInstance.swift
+++ b/Sources/Teco/Ms/V20180408/actions/CreateCosSecKeyInstance.swift
@@ -59,6 +59,7 @@ extension Ms {
         public let cosKey: String
 
         /// 密钥TOCKEN信息
+        @available(*, deprecated)
         public let cosTocken: String
 
         /// 密钥可访问的文件前缀人。例如：CosPrefix=test/123/666，则该密钥只能操作test/123/666为前缀的文件，例如test/123/666/1.txt

--- a/Sources/Teco/Ocr/V20181119/actions/GeneralBasicOCR.swift
+++ b/Sources/Teco/Ocr/V20181119/actions/GeneralBasicOCR.swift
@@ -101,6 +101,7 @@ extension Ocr {
         public let language: String
 
         /// 图片旋转角度（角度制），文本的水平方向为0°；顺时针为正，逆时针为负。点击查看<a href="https://cloud.tencent.com/document/product/866/45139">如何纠正倾斜文本</a>
+        @available(*, deprecated)
         public let angel: Float
 
         /// 图片为PDF时，返回PDF的总页数，默认为0

--- a/Sources/Teco/Scf/V20180416/models.swift
+++ b/Sources/Teco/Scf/V20180416/models.swift
@@ -1298,12 +1298,15 @@ extension Scf {
         public let availableStatus: String
 
         /// 触发器最小资源ID
+        @available(*, deprecated)
         public let resourceId: String?
 
         /// 触发器和云函数绑定状态
+        @available(*, deprecated)
         public let bindStatus: String?
 
         /// 触发器类型，双向表示两侧控制台均可操作，单向表示SCF控制台单向创建
+        @available(*, deprecated)
         public let triggerAttribute: String?
 
         /// 触发器绑定的别名或版本
@@ -1454,12 +1457,15 @@ extension Scf {
         @TCTimestampEncoding public var modTime: Date
 
         /// 触发器最小资源ID
+        @available(*, deprecated)
         public let resourceId: String?
 
         /// 触发器和云函数绑定状态
+        @available(*, deprecated)
         public let bindStatus: String?
 
         /// 触发器类型，双向表示两侧控制台均可操作，单向表示SCF控制台单向创建
+        @available(*, deprecated)
         public let triggerAttribute: String?
 
         /// 客户自定义触发器描述

--- a/Sources/Teco/Sqlserver/V20180328/actions/DescribeInstanceByOrders.swift
+++ b/Sources/Teco/Sqlserver/V20180328/actions/DescribeInstanceByOrders.swift
@@ -36,7 +36,7 @@ extension Sqlserver {
     /// DescribeInstanceByOrders返回参数结构体
     public struct DescribeInstanceByOrdersResponse: TCResponseModel {
         /// 资源ID集合
-        public let dealInstance: [DealInstance]
+        public let dealInstance: [DealInstance]?
 
         /// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
         public let requestId: String

--- a/Sources/Teco/Sqlserver/V20180328/models.swift
+++ b/Sources/Teco/Sqlserver/V20180328/models.swift
@@ -1021,10 +1021,10 @@ extension Sqlserver {
     /// 订单号对应的资源ID列表
     public struct DealInstance: TCOutputModel {
         /// 实例ID
-        public let instanceId: [String]
+        public let instanceId: [String]?
 
         /// 订单号
-        public let dealName: String
+        public let dealName: String?
 
         enum CodingKeys: String, CodingKey {
             case instanceId = "InstanceId"

--- a/Sources/Teco/Tcss/V20201101/actions/CreateAssetImageRegistryScanTask.swift
+++ b/Sources/Teco/Tcss/V20201101/actions/CreateAssetImageRegistryScanTask.swift
@@ -66,7 +66,7 @@ extension Tcss {
     /// CreateAssetImageRegistryScanTask返回参数结构体
     public struct CreateAssetImageRegistryScanTaskResponse: TCResponseModel {
         /// 返回的任务ID
-        public let taskID: UInt64
+        public let taskID: UInt64?
 
         /// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
         public let requestId: String

--- a/Sources/Teco/Tcss/V20201101/actions/CreateAssetImageRegistryScanTaskOneKey.swift
+++ b/Sources/Teco/Tcss/V20201101/actions/CreateAssetImageRegistryScanTaskOneKey.swift
@@ -51,7 +51,7 @@ extension Tcss {
     /// CreateAssetImageRegistryScanTaskOneKey返回参数结构体
     public struct CreateAssetImageRegistryScanTaskOneKeyResponse: TCResponseModel {
         /// 扫描任务id
-        public let taskID: UInt64
+        public let taskID: UInt64?
 
         /// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
         public let requestId: String

--- a/Sources/Teco/Tcss/V20201101/actions/DescribeAssetImageRegistryRegistryDetail.swift
+++ b/Sources/Teco/Tcss/V20201101/actions/DescribeAssetImageRegistryRegistryDetail.swift
@@ -70,10 +70,10 @@ extension Tcss {
         public let insecure: UInt64?
 
         /// 联通性检测结果详情
-        public let connDetectDetail: [RegistryConnDetectResult]
+        public let connDetectDetail: [RegistryConnDetectResult]?
 
         /// tcr情况下instance_id
-        public let instanceID: String
+        public let instanceID: String?
 
         /// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
         public let requestId: String

--- a/Sources/Teco/Tcss/V20201101/models.swift
+++ b/Sources/Teco/Tcss/V20201101/models.swift
@@ -2267,6 +2267,7 @@ extension Tcss {
     public struct ComponentsInfo: TCOutputModel {
         /// 组件名称
         /// 注意：此字段可能返回 null，表示取不到有效值。
+        @available(*, deprecated)
         public let component: String?
 
         /// 组件版本信息

--- a/Sources/Teco/Teo/V20220901/actions/CreatePurgeTask.swift
+++ b/Sources/Teco/Teo/V20220901/actions/CreatePurgeTask.swift
@@ -40,14 +40,22 @@ extension Teo {
 
         /// 若有编码转换，仅清除编码转换后匹配的资源。
         /// 若内容含有非 ASCII 字符集的字符，请开启此开关进行编码转换（编码规则遵循 RFC3986）。
-        public let encodeUrl: Bool?
+        @available(*, deprecated)
+        public let encodeUrl: Bool? = nil
 
+        public init(zoneId: String, type: String, method: String? = nil, targets: [String]? = nil) {
+            self.zoneId = zoneId
+            self.type = type
+            self.method = method
+            self.targets = targets
+        }
+
+        @available(*, deprecated, renamed: "init(zoneId:type:method:targets:)", message: "'encodeUrl' is deprecated in 'CreatePurgeTaskRequest'. Setting this parameter has no effect.")
         public init(zoneId: String, type: String, method: String? = nil, targets: [String]? = nil, encodeUrl: Bool? = nil) {
             self.zoneId = zoneId
             self.type = type
             self.method = method
             self.targets = targets
-            self.encodeUrl = encodeUrl
         }
 
         enum CodingKeys: String, CodingKey {
@@ -104,6 +112,17 @@ extension Teo {
     ///
     /// 清除缓存任务详情请查看[清除缓存](https://cloud.tencent.com/document/product/1552/70759)。</li>
     @inlinable
+    public func createPurgeTask(zoneId: String, type: String, method: String? = nil, targets: [String]? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<CreatePurgeTaskResponse> {
+        self.createPurgeTask(.init(zoneId: zoneId, type: type, method: method, targets: targets), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 创建清除缓存任务
+    ///
+    /// 当源站资源更新，但节点缓存 TTL 未过期时，用户仍会访问到旧的资源，此时可以通过该接口实现节点资源更新。触发更新的方法有以下两种：<li>直接删除：不做任何校验，直接删除节点缓存，用户请求时触发回源拉取；</li><li>标记过期：将节点资源置为过期，用户请求时触发回源校验，即发送带有 If-None-Match 和 If-Modified-Since 头部的 HTTP 条件请求。若源站响应 200，则节点会回源拉取新的资源并更新缓存；若源站响应 304，则节点不会更新缓存；</li>
+    ///
+    /// 清除缓存任务详情请查看[清除缓存](https://cloud.tencent.com/document/product/1552/70759)。</li>
+    @available(*, deprecated, renamed: "createPurgeTask(zoneId:type:method:targets:region:logger:on:)", message: "'encodeUrl' is deprecated. Setting this parameter has no effect.")
+    @inlinable
     public func createPurgeTask(zoneId: String, type: String, method: String? = nil, targets: [String]? = nil, encodeUrl: Bool? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<CreatePurgeTaskResponse> {
         self.createPurgeTask(.init(zoneId: zoneId, type: type, method: method, targets: targets, encodeUrl: encodeUrl), region: region, logger: logger, on: eventLoop)
     }
@@ -113,6 +132,17 @@ extension Teo {
     /// 当源站资源更新，但节点缓存 TTL 未过期时，用户仍会访问到旧的资源，此时可以通过该接口实现节点资源更新。触发更新的方法有以下两种：<li>直接删除：不做任何校验，直接删除节点缓存，用户请求时触发回源拉取；</li><li>标记过期：将节点资源置为过期，用户请求时触发回源校验，即发送带有 If-None-Match 和 If-Modified-Since 头部的 HTTP 条件请求。若源站响应 200，则节点会回源拉取新的资源并更新缓存；若源站响应 304，则节点不会更新缓存；</li>
     ///
     /// 清除缓存任务详情请查看[清除缓存](https://cloud.tencent.com/document/product/1552/70759)。</li>
+    @inlinable
+    public func createPurgeTask(zoneId: String, type: String, method: String? = nil, targets: [String]? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> CreatePurgeTaskResponse {
+        try await self.createPurgeTask(.init(zoneId: zoneId, type: type, method: method, targets: targets), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 创建清除缓存任务
+    ///
+    /// 当源站资源更新，但节点缓存 TTL 未过期时，用户仍会访问到旧的资源，此时可以通过该接口实现节点资源更新。触发更新的方法有以下两种：<li>直接删除：不做任何校验，直接删除节点缓存，用户请求时触发回源拉取；</li><li>标记过期：将节点资源置为过期，用户请求时触发回源校验，即发送带有 If-None-Match 和 If-Modified-Since 头部的 HTTP 条件请求。若源站响应 200，则节点会回源拉取新的资源并更新缓存；若源站响应 304，则节点不会更新缓存；</li>
+    ///
+    /// 清除缓存任务详情请查看[清除缓存](https://cloud.tencent.com/document/product/1552/70759)。</li>
+    @available(*, deprecated, renamed: "createPurgeTask(zoneId:type:method:targets:region:logger:on:)", message: "'encodeUrl' is deprecated. Setting this parameter has no effect.")
     @inlinable
     public func createPurgeTask(zoneId: String, type: String, method: String? = nil, targets: [String]? = nil, encodeUrl: Bool? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> CreatePurgeTaskResponse {
         try await self.createPurgeTask(.init(zoneId: zoneId, type: type, method: method, targets: targets, encodeUrl: encodeUrl), region: region, logger: logger, on: eventLoop)

--- a/Sources/Teco/Teo/V20220901/models.swift
+++ b/Sources/Teco/Teo/V20220901/models.swift
@@ -1090,12 +1090,18 @@ extension Teo {
         /// <li>on：开启；</li>
         /// <li>off：关闭。</li>
         /// 注意：此字段可能返回 null，表示取不到有效值。
-        public let ignoreCacheControl: String?
+        @available(*, deprecated)
+        public let ignoreCacheControl: String? = nil
 
+        public init(switch: String, cacheTime: Int64? = nil) {
+            self.switch = `switch`
+            self.cacheTime = cacheTime
+        }
+
+        @available(*, deprecated, renamed: "init(switch:cacheTime:)", message: "'ignoreCacheControl' is deprecated in 'Cache'. Setting this parameter has no effect.")
         public init(switch: String, cacheTime: Int64? = nil, ignoreCacheControl: String? = nil) {
             self.switch = `switch`
             self.cacheTime = cacheTime
-            self.ignoreCacheControl = ignoreCacheControl
         }
 
         enum CodingKeys: String, CodingKey {

--- a/Sources/Teco/Tione/V20211111/actions/DescribeModelServiceHotUpdated.swift
+++ b/Sources/Teco/Tione/V20211111/actions/DescribeModelServiceHotUpdated.swift
@@ -46,7 +46,7 @@ extension Tione {
     /// DescribeModelServiceHotUpdated返回参数结构体
     public struct DescribeModelServiceHotUpdatedResponse: TCResponseModel {
         /// 模型加速标志位.Allowed 允许模型加速. Forbidden 禁止模型加速
-        public let modelTurboFlag: String
+        public let modelTurboFlag: String?
 
         /// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
         public let requestId: String

--- a/Sources/Teco/Trp/V20210515/actions/DescribeRawScanLogs.swift
+++ b/Sources/Teco/Trp/V20210515/actions/DescribeRawScanLogs.swift
@@ -72,7 +72,7 @@ extension Trp {
     /// DescribeRawScanLogs返回参数结构体
     public struct DescribeRawScanLogsResponse: TCPaginatedResponse {
         /// 原始扫码日志
-        public let scanLogs: [RawScanLog]
+        public let scanLogs: [RawScanLog]?
 
         /// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
         public let requestId: String
@@ -84,7 +84,7 @@ extension Trp {
 
         /// Extract the returned item list from the paginated response.
         public func getItems() -> [RawScanLog] {
-            self.scanLogs
+            self.scanLogs ?? []
         }
     }
 

--- a/Sources/Teco/Trp/V20210515/actions/DescribeScanLogs.swift
+++ b/Sources/Teco/Trp/V20210515/actions/DescribeScanLogs.swift
@@ -56,6 +56,7 @@ extension Trp {
     /// DescribeScanLogs返回参数结构体
     public struct DescribeScanLogsResponse: TCResponseModel {
         /// 【弃用】
+        @available(*, deprecated)
         public let products: [ScanLog]
 
         /// 条数

--- a/Sources/Teco/Trp/V20210515/models.swift
+++ b/Sources/Teco/Trp/V20210515/models.swift
@@ -785,20 +785,20 @@ extension Trp {
     /// 原始扫码日志
     public struct RawScanLog: TCOutputModel {
         /// 日志ID
-        public let logId: Int64
+        public let logId: Int64?
 
         /// 微信小程序openid
         /// 注意：此字段可能返回 null，表示取不到有效值。
         public let openid: String?
 
         /// 扫码时间
-        public let createTime: String
+        public let createTime: String?
 
         /// 溯源码
-        public let code: String
+        public let code: String?
 
         /// 企业ID
-        public let corpId: UInt64
+        public let corpId: UInt64?
 
         /// 商户ID
         /// 注意：此字段可能返回 null，表示取不到有效值。

--- a/Sources/Teco/Tse/V20201207/actions/CreateCloudNativeAPIGatewayRoute.swift
+++ b/Sources/Teco/Tse/V20201207/actions/CreateCloudNativeAPIGatewayRoute.swift
@@ -70,7 +70,8 @@ extension Tse {
         public let stripPath: Bool?
 
         /// 是否开启强制HTTPS
-        public let forceHttps: Bool?
+        @available(*, deprecated)
+        public let forceHttps: Bool? = nil
 
         /// 四层匹配的目的端口
         public let destinationPorts: [UInt64]?
@@ -78,6 +79,22 @@ extension Tse {
         /// 路由的Headers
         public let headers: [KVMapping]?
 
+        public init(gatewayId: String, serviceID: String, routeName: String? = nil, methods: [String]? = nil, hosts: [String]? = nil, paths: [String]? = nil, protocols: [String]? = nil, preserveHost: Bool? = nil, httpsRedirectStatusCode: Int64? = nil, stripPath: Bool? = nil, destinationPorts: [UInt64]? = nil, headers: [KVMapping]? = nil) {
+            self.gatewayId = gatewayId
+            self.serviceID = serviceID
+            self.routeName = routeName
+            self.methods = methods
+            self.hosts = hosts
+            self.paths = paths
+            self.protocols = protocols
+            self.preserveHost = preserveHost
+            self.httpsRedirectStatusCode = httpsRedirectStatusCode
+            self.stripPath = stripPath
+            self.destinationPorts = destinationPorts
+            self.headers = headers
+        }
+
+        @available(*, deprecated, renamed: "init(gatewayId:serviceID:routeName:methods:hosts:paths:protocols:preserveHost:httpsRedirectStatusCode:stripPath:destinationPorts:headers:)", message: "'forceHttps' is deprecated in 'CreateCloudNativeAPIGatewayRouteRequest'. Setting this parameter has no effect.")
         public init(gatewayId: String, serviceID: String, routeName: String? = nil, methods: [String]? = nil, hosts: [String]? = nil, paths: [String]? = nil, protocols: [String]? = nil, preserveHost: Bool? = nil, httpsRedirectStatusCode: Int64? = nil, stripPath: Bool? = nil, forceHttps: Bool? = nil, destinationPorts: [UInt64]? = nil, headers: [KVMapping]? = nil) {
             self.gatewayId = gatewayId
             self.serviceID = serviceID
@@ -89,7 +106,6 @@ extension Tse {
             self.preserveHost = preserveHost
             self.httpsRedirectStatusCode = httpsRedirectStatusCode
             self.stripPath = stripPath
-            self.forceHttps = forceHttps
             self.destinationPorts = destinationPorts
             self.headers = headers
         }
@@ -135,11 +151,25 @@ extension Tse {
 
     /// 创建云原生网关路由
     @inlinable @discardableResult
+    public func createCloudNativeAPIGatewayRoute(gatewayId: String, serviceID: String, routeName: String? = nil, methods: [String]? = nil, hosts: [String]? = nil, paths: [String]? = nil, protocols: [String]? = nil, preserveHost: Bool? = nil, httpsRedirectStatusCode: Int64? = nil, stripPath: Bool? = nil, destinationPorts: [UInt64]? = nil, headers: [KVMapping]? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<CreateCloudNativeAPIGatewayRouteResponse> {
+        self.createCloudNativeAPIGatewayRoute(.init(gatewayId: gatewayId, serviceID: serviceID, routeName: routeName, methods: methods, hosts: hosts, paths: paths, protocols: protocols, preserveHost: preserveHost, httpsRedirectStatusCode: httpsRedirectStatusCode, stripPath: stripPath, destinationPorts: destinationPorts, headers: headers), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 创建云原生网关路由
+    @available(*, deprecated, renamed: "createCloudNativeAPIGatewayRoute(gatewayId:serviceID:routeName:methods:hosts:paths:protocols:preserveHost:httpsRedirectStatusCode:stripPath:destinationPorts:headers:region:logger:on:)", message: "'forceHttps' is deprecated. Setting this parameter has no effect.")
+    @inlinable @discardableResult
     public func createCloudNativeAPIGatewayRoute(gatewayId: String, serviceID: String, routeName: String? = nil, methods: [String]? = nil, hosts: [String]? = nil, paths: [String]? = nil, protocols: [String]? = nil, preserveHost: Bool? = nil, httpsRedirectStatusCode: Int64? = nil, stripPath: Bool? = nil, forceHttps: Bool? = nil, destinationPorts: [UInt64]? = nil, headers: [KVMapping]? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<CreateCloudNativeAPIGatewayRouteResponse> {
         self.createCloudNativeAPIGatewayRoute(.init(gatewayId: gatewayId, serviceID: serviceID, routeName: routeName, methods: methods, hosts: hosts, paths: paths, protocols: protocols, preserveHost: preserveHost, httpsRedirectStatusCode: httpsRedirectStatusCode, stripPath: stripPath, forceHttps: forceHttps, destinationPorts: destinationPorts, headers: headers), region: region, logger: logger, on: eventLoop)
     }
 
     /// 创建云原生网关路由
+    @inlinable @discardableResult
+    public func createCloudNativeAPIGatewayRoute(gatewayId: String, serviceID: String, routeName: String? = nil, methods: [String]? = nil, hosts: [String]? = nil, paths: [String]? = nil, protocols: [String]? = nil, preserveHost: Bool? = nil, httpsRedirectStatusCode: Int64? = nil, stripPath: Bool? = nil, destinationPorts: [UInt64]? = nil, headers: [KVMapping]? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> CreateCloudNativeAPIGatewayRouteResponse {
+        try await self.createCloudNativeAPIGatewayRoute(.init(gatewayId: gatewayId, serviceID: serviceID, routeName: routeName, methods: methods, hosts: hosts, paths: paths, protocols: protocols, preserveHost: preserveHost, httpsRedirectStatusCode: httpsRedirectStatusCode, stripPath: stripPath, destinationPorts: destinationPorts, headers: headers), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 创建云原生网关路由
+    @available(*, deprecated, renamed: "createCloudNativeAPIGatewayRoute(gatewayId:serviceID:routeName:methods:hosts:paths:protocols:preserveHost:httpsRedirectStatusCode:stripPath:destinationPorts:headers:region:logger:on:)", message: "'forceHttps' is deprecated. Setting this parameter has no effect.")
     @inlinable @discardableResult
     public func createCloudNativeAPIGatewayRoute(gatewayId: String, serviceID: String, routeName: String? = nil, methods: [String]? = nil, hosts: [String]? = nil, paths: [String]? = nil, protocols: [String]? = nil, preserveHost: Bool? = nil, httpsRedirectStatusCode: Int64? = nil, stripPath: Bool? = nil, forceHttps: Bool? = nil, destinationPorts: [UInt64]? = nil, headers: [KVMapping]? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> CreateCloudNativeAPIGatewayRouteResponse {
         try await self.createCloudNativeAPIGatewayRoute(.init(gatewayId: gatewayId, serviceID: serviceID, routeName: routeName, methods: methods, hosts: hosts, paths: paths, protocols: protocols, preserveHost: preserveHost, httpsRedirectStatusCode: httpsRedirectStatusCode, stripPath: stripPath, forceHttps: forceHttps, destinationPorts: destinationPorts, headers: headers), region: region, logger: logger, on: eventLoop)

--- a/Sources/Teco/Tse/V20201207/actions/ModifyCloudNativeAPIGatewayRoute.swift
+++ b/Sources/Teco/Tse/V20201207/actions/ModifyCloudNativeAPIGatewayRoute.swift
@@ -73,7 +73,8 @@ extension Tse {
         public let stripPath: Bool?
 
         /// 是否开启强制HTTPS
-        public let forceHttps: Bool?
+        @available(*, deprecated)
+        public let forceHttps: Bool? = nil
 
         /// 四层匹配的目的端口
         public let destinationPorts: [UInt64]?
@@ -81,6 +82,23 @@ extension Tse {
         /// 路由的Headers
         public let headers: [KVMapping]?
 
+        public init(gatewayId: String, serviceID: String, routeID: String, routeName: String? = nil, methods: [String]? = nil, hosts: [String]? = nil, paths: [String]? = nil, protocols: [String]? = nil, preserveHost: Bool? = nil, httpsRedirectStatusCode: Int64? = nil, stripPath: Bool? = nil, destinationPorts: [UInt64]? = nil, headers: [KVMapping]? = nil) {
+            self.gatewayId = gatewayId
+            self.serviceID = serviceID
+            self.routeID = routeID
+            self.routeName = routeName
+            self.methods = methods
+            self.hosts = hosts
+            self.paths = paths
+            self.protocols = protocols
+            self.preserveHost = preserveHost
+            self.httpsRedirectStatusCode = httpsRedirectStatusCode
+            self.stripPath = stripPath
+            self.destinationPorts = destinationPorts
+            self.headers = headers
+        }
+
+        @available(*, deprecated, renamed: "init(gatewayId:serviceID:routeID:routeName:methods:hosts:paths:protocols:preserveHost:httpsRedirectStatusCode:stripPath:destinationPorts:headers:)", message: "'forceHttps' is deprecated in 'ModifyCloudNativeAPIGatewayRouteRequest'. Setting this parameter has no effect.")
         public init(gatewayId: String, serviceID: String, routeID: String, routeName: String? = nil, methods: [String]? = nil, hosts: [String]? = nil, paths: [String]? = nil, protocols: [String]? = nil, preserveHost: Bool? = nil, httpsRedirectStatusCode: Int64? = nil, stripPath: Bool? = nil, forceHttps: Bool? = nil, destinationPorts: [UInt64]? = nil, headers: [KVMapping]? = nil) {
             self.gatewayId = gatewayId
             self.serviceID = serviceID
@@ -93,7 +111,6 @@ extension Tse {
             self.preserveHost = preserveHost
             self.httpsRedirectStatusCode = httpsRedirectStatusCode
             self.stripPath = stripPath
-            self.forceHttps = forceHttps
             self.destinationPorts = destinationPorts
             self.headers = headers
         }
@@ -140,11 +157,25 @@ extension Tse {
 
     /// 修改云原生网关路由
     @inlinable @discardableResult
+    public func modifyCloudNativeAPIGatewayRoute(gatewayId: String, serviceID: String, routeID: String, routeName: String? = nil, methods: [String]? = nil, hosts: [String]? = nil, paths: [String]? = nil, protocols: [String]? = nil, preserveHost: Bool? = nil, httpsRedirectStatusCode: Int64? = nil, stripPath: Bool? = nil, destinationPorts: [UInt64]? = nil, headers: [KVMapping]? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<ModifyCloudNativeAPIGatewayRouteResponse> {
+        self.modifyCloudNativeAPIGatewayRoute(.init(gatewayId: gatewayId, serviceID: serviceID, routeID: routeID, routeName: routeName, methods: methods, hosts: hosts, paths: paths, protocols: protocols, preserveHost: preserveHost, httpsRedirectStatusCode: httpsRedirectStatusCode, stripPath: stripPath, destinationPorts: destinationPorts, headers: headers), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 修改云原生网关路由
+    @available(*, deprecated, renamed: "modifyCloudNativeAPIGatewayRoute(gatewayId:serviceID:routeID:routeName:methods:hosts:paths:protocols:preserveHost:httpsRedirectStatusCode:stripPath:destinationPorts:headers:region:logger:on:)", message: "'forceHttps' is deprecated. Setting this parameter has no effect.")
+    @inlinable @discardableResult
     public func modifyCloudNativeAPIGatewayRoute(gatewayId: String, serviceID: String, routeID: String, routeName: String? = nil, methods: [String]? = nil, hosts: [String]? = nil, paths: [String]? = nil, protocols: [String]? = nil, preserveHost: Bool? = nil, httpsRedirectStatusCode: Int64? = nil, stripPath: Bool? = nil, forceHttps: Bool? = nil, destinationPorts: [UInt64]? = nil, headers: [KVMapping]? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<ModifyCloudNativeAPIGatewayRouteResponse> {
         self.modifyCloudNativeAPIGatewayRoute(.init(gatewayId: gatewayId, serviceID: serviceID, routeID: routeID, routeName: routeName, methods: methods, hosts: hosts, paths: paths, protocols: protocols, preserveHost: preserveHost, httpsRedirectStatusCode: httpsRedirectStatusCode, stripPath: stripPath, forceHttps: forceHttps, destinationPorts: destinationPorts, headers: headers), region: region, logger: logger, on: eventLoop)
     }
 
     /// 修改云原生网关路由
+    @inlinable @discardableResult
+    public func modifyCloudNativeAPIGatewayRoute(gatewayId: String, serviceID: String, routeID: String, routeName: String? = nil, methods: [String]? = nil, hosts: [String]? = nil, paths: [String]? = nil, protocols: [String]? = nil, preserveHost: Bool? = nil, httpsRedirectStatusCode: Int64? = nil, stripPath: Bool? = nil, destinationPorts: [UInt64]? = nil, headers: [KVMapping]? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> ModifyCloudNativeAPIGatewayRouteResponse {
+        try await self.modifyCloudNativeAPIGatewayRoute(.init(gatewayId: gatewayId, serviceID: serviceID, routeID: routeID, routeName: routeName, methods: methods, hosts: hosts, paths: paths, protocols: protocols, preserveHost: preserveHost, httpsRedirectStatusCode: httpsRedirectStatusCode, stripPath: stripPath, destinationPorts: destinationPorts, headers: headers), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 修改云原生网关路由
+    @available(*, deprecated, renamed: "modifyCloudNativeAPIGatewayRoute(gatewayId:serviceID:routeID:routeName:methods:hosts:paths:protocols:preserveHost:httpsRedirectStatusCode:stripPath:destinationPorts:headers:region:logger:on:)", message: "'forceHttps' is deprecated. Setting this parameter has no effect.")
     @inlinable @discardableResult
     public func modifyCloudNativeAPIGatewayRoute(gatewayId: String, serviceID: String, routeID: String, routeName: String? = nil, methods: [String]? = nil, hosts: [String]? = nil, paths: [String]? = nil, protocols: [String]? = nil, preserveHost: Bool? = nil, httpsRedirectStatusCode: Int64? = nil, stripPath: Bool? = nil, forceHttps: Bool? = nil, destinationPorts: [UInt64]? = nil, headers: [KVMapping]? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> ModifyCloudNativeAPIGatewayRouteResponse {
         try await self.modifyCloudNativeAPIGatewayRoute(.init(gatewayId: gatewayId, serviceID: serviceID, routeID: routeID, routeName: routeName, methods: methods, hosts: hosts, paths: paths, protocols: protocols, preserveHost: preserveHost, httpsRedirectStatusCode: httpsRedirectStatusCode, stripPath: stripPath, forceHttps: forceHttps, destinationPorts: destinationPorts, headers: headers), region: region, logger: logger, on: eventLoop)

--- a/Sources/Teco/Vod/V20180717/models.swift
+++ b/Sources/Teco/Vod/V20180717/models.swift
@@ -8957,18 +8957,18 @@ extension Vod {
         /// 媒体文件是否无音频轨，取值范围：
         /// <li>0：否，即有音频轨；</li>
         /// <li>1：是，即无音频轨。</li>
-        public let noAudio: Int64
+        public let noAudio: Int64?
 
         /// 媒体文件是否无视频轨，取值范围：
         /// <li>0：否，即有视频轨；</li>
         /// <li>1：是，即无视频轨。</li>
-        public let noVideo: Int64
+        public let noVideo: Int64?
 
         /// 视频画面质量评分，取值范围：[0, 100]。
-        public let qualityEvaluationScore: UInt64
+        public let qualityEvaluationScore: UInt64?
 
         /// 音画质检测出的异常项列表。
-        public let qualityInspectResultSet: [QualityInspectResultItem]
+        public let qualityInspectResultSet: [QualityInspectResultItem]?
 
         enum CodingKeys: String, CodingKey {
             case noAudio = "NoAudio"

--- a/Sources/Teco/Vpc/V20170312/models.swift
+++ b/Sources/Teco/Vpc/V20170312/models.swift
@@ -151,7 +151,7 @@ extension Vpc {
         public let instanceType: String?
 
         /// 高防包ID,当EIP类型为高防EIP时，返回EIP绑定的高防包ID.
-        public let antiDDoSPackageId: String
+        public let antiDDoSPackageId: String?
 
         enum CodingKeys: String, CodingKey {
             case addressId = "AddressId"

--- a/Sources/Teco/Wedata/V20210820/actions/BatchDeleteOpsTasks.swift
+++ b/Sources/Teco/Wedata/V20210820/actions/BatchDeleteOpsTasks.swift
@@ -53,7 +53,7 @@ extension Wedata {
     /// BatchDeleteOpsTasks返回参数结构体
     public struct BatchDeleteOpsTasksResponse: TCResponseModel {
         /// 返回批量操作成功个数、失败个数、操作总数
-        public let data: BatchOperationOpsDto
+        public let data: BatchOperationOpsDto?
 
         /// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
         public let requestId: String

--- a/Sources/Teco/Wedata/V20210820/actions/CheckAlarmRegularNameExist.swift
+++ b/Sources/Teco/Wedata/V20210820/actions/CheckAlarmRegularNameExist.swift
@@ -28,7 +28,8 @@ extension Wedata {
         public let alarmRegularName: String
 
         /// 任务ID
-        public let taskId: String?
+        @available(*, deprecated)
+        public let taskId: String? = nil
 
         /// 主键ID
         public let id: String?
@@ -36,10 +37,17 @@ extension Wedata {
         /// 任务类型:201.实时,202.离线
         public let taskType: Int64?
 
+        public init(projectId: String, alarmRegularName: String, id: String? = nil, taskType: Int64? = nil) {
+            self.projectId = projectId
+            self.alarmRegularName = alarmRegularName
+            self.id = id
+            self.taskType = taskType
+        }
+
+        @available(*, deprecated, renamed: "init(projectId:alarmRegularName:id:taskType:)", message: "'taskId' is deprecated in 'CheckAlarmRegularNameExistRequest'. Setting this parameter has no effect.")
         public init(projectId: String, alarmRegularName: String, taskId: String? = nil, id: String? = nil, taskType: Int64? = nil) {
             self.projectId = projectId
             self.alarmRegularName = alarmRegularName
-            self.taskId = taskId
             self.id = id
             self.taskType = taskType
         }
@@ -81,11 +89,25 @@ extension Wedata {
 
     /// 判断告警规则重名
     @inlinable
+    public func checkAlarmRegularNameExist(projectId: String, alarmRegularName: String, id: String? = nil, taskType: Int64? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<CheckAlarmRegularNameExistResponse> {
+        self.checkAlarmRegularNameExist(.init(projectId: projectId, alarmRegularName: alarmRegularName, id: id, taskType: taskType), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 判断告警规则重名
+    @available(*, deprecated, renamed: "checkAlarmRegularNameExist(projectId:alarmRegularName:id:taskType:region:logger:on:)", message: "'taskId' is deprecated. Setting this parameter has no effect.")
+    @inlinable
     public func checkAlarmRegularNameExist(projectId: String, alarmRegularName: String, taskId: String? = nil, id: String? = nil, taskType: Int64? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<CheckAlarmRegularNameExistResponse> {
         self.checkAlarmRegularNameExist(.init(projectId: projectId, alarmRegularName: alarmRegularName, taskId: taskId, id: id, taskType: taskType), region: region, logger: logger, on: eventLoop)
     }
 
     /// 判断告警规则重名
+    @inlinable
+    public func checkAlarmRegularNameExist(projectId: String, alarmRegularName: String, id: String? = nil, taskType: Int64? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> CheckAlarmRegularNameExistResponse {
+        try await self.checkAlarmRegularNameExist(.init(projectId: projectId, alarmRegularName: alarmRegularName, id: id, taskType: taskType), region: region, logger: logger, on: eventLoop)
+    }
+
+    /// 判断告警规则重名
+    @available(*, deprecated, renamed: "checkAlarmRegularNameExist(projectId:alarmRegularName:id:taskType:region:logger:on:)", message: "'taskId' is deprecated. Setting this parameter has no effect.")
     @inlinable
     public func checkAlarmRegularNameExist(projectId: String, alarmRegularName: String, taskId: String? = nil, id: String? = nil, taskType: Int64? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> CheckAlarmRegularNameExistResponse {
         try await self.checkAlarmRegularNameExist(.init(projectId: projectId, alarmRegularName: alarmRegularName, taskId: taskId, id: id, taskType: taskType), region: region, logger: logger, on: eventLoop)

--- a/Sources/Teco/Wedata/V20210820/models.swift
+++ b/Sources/Teco/Wedata/V20210820/models.swift
@@ -2381,7 +2381,8 @@ extension Wedata {
     public struct DimensionCount: TCInputModel, TCOutputModel {
         /// 维度类型1：准确性，2：唯一性，3：完整性，4：一致性，5：及时性，6：有效性
         /// 注意：此字段可能返回 null，表示取不到有效值。
-        public let dimType: UInt64?
+        @available(*, deprecated)
+        public let dimType: UInt64? = nil
 
         /// 统计值
         /// 注意：此字段可能返回 null，表示取不到有效值。
@@ -2391,8 +2392,13 @@ extension Wedata {
         /// 注意：此字段可能返回 null，表示取不到有效值。
         public let qualityDim: UInt64?
 
+        public init(count: UInt64? = nil, qualityDim: UInt64? = nil) {
+            self.count = count
+            self.qualityDim = qualityDim
+        }
+
+        @available(*, deprecated, renamed: "init(count:qualityDim:)", message: "'dimType' is deprecated in 'DimensionCount'. Setting this parameter has no effect.")
         public init(dimType: UInt64? = nil, count: UInt64? = nil, qualityDim: UInt64? = nil) {
-            self.dimType = dimType
             self.count = count
             self.qualityDim = qualityDim
         }
@@ -8969,11 +8975,13 @@ extension Wedata {
     public struct SourceObject: TCInputModel, TCOutputModel {
         /// 源字段详细类型，int、string
         /// 注意：此字段可能返回 null，表示取不到有效值。
-        public let sourceObjectDataTypeName: String?
+        @available(*, deprecated)
+        public let sourceObjectDataTypeName: String? = nil
 
         /// 源字段名称
         /// 注意：此字段可能返回 null，表示取不到有效值。
-        public let sourceObjectValue: String?
+        @available(*, deprecated)
+        public let sourceObjectValue: String? = nil
 
         /// 源字段详细类型，int、string
         /// 注意：此字段可能返回 null，表示取不到有效值。
@@ -8987,9 +8995,14 @@ extension Wedata {
         /// 注意：此字段可能返回 null，表示取不到有效值。
         public let objectType: UInt64?
 
+        public init(objectDataTypeName: String? = nil, objectValue: String? = nil, objectType: UInt64? = nil) {
+            self.objectDataTypeName = objectDataTypeName
+            self.objectValue = objectValue
+            self.objectType = objectType
+        }
+
+        @available(*, deprecated, renamed: "init(objectDataTypeName:objectValue:objectType:)", message: "'sourceObjectDataTypeName' and 'sourceObjectValue' are deprecated in 'SourceObject'. Setting these parameters has no effect.")
         public init(sourceObjectDataTypeName: String? = nil, sourceObjectValue: String? = nil, objectDataTypeName: String? = nil, objectValue: String? = nil, objectType: UInt64? = nil) {
-            self.sourceObjectDataTypeName = sourceObjectDataTypeName
-            self.sourceObjectValue = sourceObjectValue
             self.objectDataTypeName = objectDataTypeName
             self.objectValue = objectValue
             self.objectType = objectType


### PR DESCRIPTION
Latest API models include flags to track if a member is "disabled". For backend-only models, disabled members are simply marked as deprecated; for constructible models, deprecated members are forced to default value, and the original initializer will also be marked as deprecated.

This PR also fixes a bug where some backend-only model member is falsely marked as non-optional.

Companioned by https://github.com/teco-project/teco-code-generators/pull/33.