### PR TITLE
Introduces a warning-free build test in CI workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,6 +44,13 @@ jobs:
         uses: actions/checkout@v3
       - name: Build
         run: swift build
+  build-without-warnings:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Build
+        run: swift build --build-tests -Xswiftc -warnings-as-errors
   build-with-docc:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This PR adds a CI test that treats Swift warnings as errors, helping us debug and keep this library warning-free.