### PR TITLE
Updates DocC asides to use `>` instead of `-`

### DIFF
--- a/Sources/Teco/Cdn/V20180606/actions/DescribeIpStatus.swift
+++ b/Sources/Teco/Cdn/V20180606/actions/DescribeIpStatus.swift
@@ -86,7 +86,7 @@ extension Cdn {
     ///
     /// DescribeIpStatus 用于查询域名所在加速平台的边缘节点、回源节点明细。注意事项：暂不支持查询边缘节点信息并且数据会存在一定延迟。
     ///
-    /// - Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41954)，使用  CDN 相关API 进行操作。
+    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41954)，使用  CDN 相关API 进行操作。
     @inlinable
     public func describeIpStatus(_ input: DescribeIpStatusRequest, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<DescribeIpStatusResponse> {
         self.client.execute(action: "DescribeIpStatus", region: region, serviceConfig: self.config, input: input, logger: logger, on: eventLoop)
@@ -96,7 +96,7 @@ extension Cdn {
     ///
     /// DescribeIpStatus 用于查询域名所在加速平台的边缘节点、回源节点明细。注意事项：暂不支持查询边缘节点信息并且数据会存在一定延迟。
     ///
-    /// - Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41954)，使用  CDN 相关API 进行操作。
+    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41954)，使用  CDN 相关API 进行操作。
     @inlinable
     public func describeIpStatus(_ input: DescribeIpStatusRequest, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> DescribeIpStatusResponse {
         try await self.client.execute(action: "DescribeIpStatus", region: region, serviceConfig: self.config, input: input, logger: logger, on: eventLoop).get()
@@ -106,7 +106,7 @@ extension Cdn {
     ///
     /// DescribeIpStatus 用于查询域名所在加速平台的边缘节点、回源节点明细。注意事项：暂不支持查询边缘节点信息并且数据会存在一定延迟。
     ///
-    /// - Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41954)，使用  CDN 相关API 进行操作。
+    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41954)，使用  CDN 相关API 进行操作。
     @inlinable
     public func describeIpStatus(domain: String, layer: String? = nil, area: String? = nil, segment: Bool? = nil, showIpv6: Bool? = nil, abbreviationIpv6: Bool? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<DescribeIpStatusResponse> {
         self.describeIpStatus(.init(domain: domain, layer: layer, area: area, segment: segment, showIpv6: showIpv6, abbreviationIpv6: abbreviationIpv6), region: region, logger: logger, on: eventLoop)
@@ -116,7 +116,7 @@ extension Cdn {
     ///
     /// DescribeIpStatus 用于查询域名所在加速平台的边缘节点、回源节点明细。注意事项：暂不支持查询边缘节点信息并且数据会存在一定延迟。
     ///
-    /// - Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41954)，使用  CDN 相关API 进行操作。
+    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41954)，使用  CDN 相关API 进行操作。
     @inlinable
     public func describeIpStatus(domain: String, layer: String? = nil, area: String? = nil, segment: Bool? = nil, showIpv6: Bool? = nil, abbreviationIpv6: Bool? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> DescribeIpStatusResponse {
         try await self.describeIpStatus(.init(domain: domain, layer: layer, area: area, segment: segment, showIpv6: showIpv6, abbreviationIpv6: abbreviationIpv6), region: region, logger: logger, on: eventLoop)

--- a/Sources/Teco/Cdn/V20180606/actions/DescribeIpStatus.swift
+++ b/Sources/Teco/Cdn/V20180606/actions/DescribeIpStatus.swift
@@ -86,7 +86,7 @@ extension Cdn {
     ///
     /// DescribeIpStatus 用于查询域名所在加速平台的边缘节点、回源节点明细。注意事项：暂不支持查询边缘节点信息并且数据会存在一定延迟。
     ///
-    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41954)，使用  CDN 相关API 进行操作。
+    /// > Important: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41954)，使用  CDN 相关API 进行操作。
     @inlinable
     public func describeIpStatus(_ input: DescribeIpStatusRequest, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<DescribeIpStatusResponse> {
         self.client.execute(action: "DescribeIpStatus", region: region, serviceConfig: self.config, input: input, logger: logger, on: eventLoop)
@@ -96,7 +96,7 @@ extension Cdn {
     ///
     /// DescribeIpStatus 用于查询域名所在加速平台的边缘节点、回源节点明细。注意事项：暂不支持查询边缘节点信息并且数据会存在一定延迟。
     ///
-    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41954)，使用  CDN 相关API 进行操作。
+    /// > Important: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41954)，使用  CDN 相关API 进行操作。
     @inlinable
     public func describeIpStatus(_ input: DescribeIpStatusRequest, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> DescribeIpStatusResponse {
         try await self.client.execute(action: "DescribeIpStatus", region: region, serviceConfig: self.config, input: input, logger: logger, on: eventLoop).get()
@@ -106,7 +106,7 @@ extension Cdn {
     ///
     /// DescribeIpStatus 用于查询域名所在加速平台的边缘节点、回源节点明细。注意事项：暂不支持查询边缘节点信息并且数据会存在一定延迟。
     ///
-    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41954)，使用  CDN 相关API 进行操作。
+    /// > Important: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41954)，使用  CDN 相关API 进行操作。
     @inlinable
     public func describeIpStatus(domain: String, layer: String? = nil, area: String? = nil, segment: Bool? = nil, showIpv6: Bool? = nil, abbreviationIpv6: Bool? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<DescribeIpStatusResponse> {
         self.describeIpStatus(.init(domain: domain, layer: layer, area: area, segment: segment, showIpv6: showIpv6, abbreviationIpv6: abbreviationIpv6), region: region, logger: logger, on: eventLoop)
@@ -116,7 +116,7 @@ extension Cdn {
     ///
     /// DescribeIpStatus 用于查询域名所在加速平台的边缘节点、回源节点明细。注意事项：暂不支持查询边缘节点信息并且数据会存在一定延迟。
     ///
-    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41954)，使用  CDN 相关API 进行操作。
+    /// > Important: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41954)，使用  CDN 相关API 进行操作。
     @inlinable
     public func describeIpStatus(domain: String, layer: String? = nil, area: String? = nil, segment: Bool? = nil, showIpv6: Bool? = nil, abbreviationIpv6: Bool? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> DescribeIpStatusResponse {
         try await self.describeIpStatus(.init(domain: domain, layer: layer, area: area, segment: segment, showIpv6: showIpv6, abbreviationIpv6: abbreviationIpv6), region: region, logger: logger, on: eventLoop)

--- a/Sources/Teco/Cvm/V20170312/actions/InquiryPriceModifyInstancesChargeType.swift
+++ b/Sources/Teco/Cvm/V20170312/actions/InquiryPriceModifyInstancesChargeType.swift
@@ -31,7 +31,7 @@ extension Cvm {
         public let instanceChargeType: String
 
         /// 预付费模式，即包年包月相关参数设置。通过该参数可以指定包年包月实例的购买时长、是否设置自动续费等属性。
-        /// - Note: 若指定实例的付费模式为预付费则该参数必传。
+        /// > Note: 若指定实例的付费模式为预付费则该参数必传。
         public let instanceChargePrepaid: InstanceChargePrepaid?
 
         /// 是否同时切换弹性数据云盘计费模式。取值范围：

--- a/Sources/Teco/Cvm/V20170312/actions/ModifyInstancesAttribute.swift
+++ b/Sources/Teco/Cvm/V20170312/actions/ModifyInstancesAttribute.swift
@@ -26,11 +26,11 @@ extension Cvm {
 
         /// 实例名称。可任意命名，但不得超过60个字符。
         ///
-        /// - Note: 必须指定InstanceName与SecurityGroups的其中一个，但不能同时设置
+        /// > Note: 必须指定InstanceName与SecurityGroups的其中一个，但不能同时设置
         public let instanceName: String?
 
         /// 指定实例的安全组Id列表，子机将重新关联指定列表的安全组，原本关联的安全组会被解绑。
-        /// - Note: 必须指定SecurityGroups与InstanceName的其中一个，但不能同时设置
+        /// > Note: 必须指定SecurityGroups与InstanceName的其中一个，但不能同时设置
         public let securityGroups: [String]?
 
         /// 给实例绑定用户角色，传空值为解绑操作

--- a/Sources/Teco/Cvm/V20170312/actions/ModifyInstancesChargeType.swift
+++ b/Sources/Teco/Cvm/V20170312/actions/ModifyInstancesChargeType.swift
@@ -31,7 +31,7 @@ extension Cvm {
         public let instanceChargeType: String
 
         /// 预付费模式，即包年包月相关参数设置。通过该参数可以指定包年包月实例的购买时长、是否设置自动续费等属性。
-        /// - Note: 若指定实例的付费模式为预付费则该参数必传。
+        /// > Note: 若指定实例的付费模式为预付费则该参数必传。
         public let instanceChargePrepaid: InstanceChargePrepaid?
 
         /// 是否同时切换弹性数据云盘计费模式。取值范围：

--- a/Sources/Teco/Cvm/V20170312/actions/RenewInstances.swift
+++ b/Sources/Teco/Cvm/V20170312/actions/RenewInstances.swift
@@ -25,7 +25,7 @@ extension Cvm {
         public let instanceIds: [String]
 
         /// 预付费模式，即包年包月相关参数设置。通过该参数可以指定包年包月实例的续费时长、是否设置自动续费等属性。
-        /// - Note: 包年包月实例该参数为必传参数。
+        /// > Note: 包年包月实例该参数为必传参数。
         public let instanceChargePrepaid: InstanceChargePrepaid?
 
         /// 是否续费弹性数据盘。取值范围：

--- a/Sources/Teco/Ecdn/V20191012/actions/AddEcdnDomain.swift
+++ b/Sources/Teco/Ecdn/V20191012/actions/AddEcdnDomain.swift
@@ -107,7 +107,7 @@ extension Ecdn {
     ///
     /// 本接口（AddEcdnDomain）用于创建加速域名。
     ///
-    /// - Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41123)，使用  CDN 相关API 进行操作。
+    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41123)，使用  CDN 相关API 进行操作。
     @available(*, unavailable, message: "ECDN融合CDN后，接口都用CDN的，此接口已经废弃")
     @inlinable @discardableResult
     public func addEcdnDomain(_ input: AddEcdnDomainRequest, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<AddEcdnDomainResponse> {
@@ -118,7 +118,7 @@ extension Ecdn {
     ///
     /// 本接口（AddEcdnDomain）用于创建加速域名。
     ///
-    /// - Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41123)，使用  CDN 相关API 进行操作。
+    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41123)，使用  CDN 相关API 进行操作。
     @available(*, unavailable, message: "ECDN融合CDN后，接口都用CDN的，此接口已经废弃")
     @inlinable @discardableResult
     public func addEcdnDomain(_ input: AddEcdnDomainRequest, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> AddEcdnDomainResponse {
@@ -129,7 +129,7 @@ extension Ecdn {
     ///
     /// 本接口（AddEcdnDomain）用于创建加速域名。
     ///
-    /// - Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41123)，使用  CDN 相关API 进行操作。
+    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41123)，使用  CDN 相关API 进行操作。
     @available(*, unavailable, message: "ECDN融合CDN后，接口都用CDN的，此接口已经废弃")
     @inlinable @discardableResult
     public func addEcdnDomain(domain: String, origin: Origin, area: String, projectId: Int64? = nil, ipFilter: IpFilter? = nil, ipFreqLimit: IpFreqLimit? = nil, responseHeader: ResponseHeader? = nil, cacheKey: CacheKey? = nil, cache: Cache? = nil, https: Https? = nil, forceRedirect: ForceRedirect? = nil, tag: [Tag]? = nil, webSocket: WebSocket? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<AddEcdnDomainResponse> {
@@ -140,7 +140,7 @@ extension Ecdn {
     ///
     /// 本接口（AddEcdnDomain）用于创建加速域名。
     ///
-    /// - Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41123)，使用  CDN 相关API 进行操作。
+    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41123)，使用  CDN 相关API 进行操作。
     @available(*, unavailable, message: "ECDN融合CDN后，接口都用CDN的，此接口已经废弃")
     @inlinable @discardableResult
     public func addEcdnDomain(domain: String, origin: Origin, area: String, projectId: Int64? = nil, ipFilter: IpFilter? = nil, ipFreqLimit: IpFreqLimit? = nil, responseHeader: ResponseHeader? = nil, cacheKey: CacheKey? = nil, cache: Cache? = nil, https: Https? = nil, forceRedirect: ForceRedirect? = nil, tag: [Tag]? = nil, webSocket: WebSocket? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> AddEcdnDomainResponse {

--- a/Sources/Teco/Ecdn/V20191012/actions/AddEcdnDomain.swift
+++ b/Sources/Teco/Ecdn/V20191012/actions/AddEcdnDomain.swift
@@ -107,7 +107,7 @@ extension Ecdn {
     ///
     /// 本接口（AddEcdnDomain）用于创建加速域名。
     ///
-    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41123)，使用  CDN 相关API 进行操作。
+    /// > Important: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41123)，使用  CDN 相关API 进行操作。
     @available(*, unavailable, message: "ECDN融合CDN后，接口都用CDN的，此接口已经废弃")
     @inlinable @discardableResult
     public func addEcdnDomain(_ input: AddEcdnDomainRequest, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<AddEcdnDomainResponse> {
@@ -118,7 +118,7 @@ extension Ecdn {
     ///
     /// 本接口（AddEcdnDomain）用于创建加速域名。
     ///
-    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41123)，使用  CDN 相关API 进行操作。
+    /// > Important: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41123)，使用  CDN 相关API 进行操作。
     @available(*, unavailable, message: "ECDN融合CDN后，接口都用CDN的，此接口已经废弃")
     @inlinable @discardableResult
     public func addEcdnDomain(_ input: AddEcdnDomainRequest, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> AddEcdnDomainResponse {
@@ -129,7 +129,7 @@ extension Ecdn {
     ///
     /// 本接口（AddEcdnDomain）用于创建加速域名。
     ///
-    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41123)，使用  CDN 相关API 进行操作。
+    /// > Important: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41123)，使用  CDN 相关API 进行操作。
     @available(*, unavailable, message: "ECDN融合CDN后，接口都用CDN的，此接口已经废弃")
     @inlinable @discardableResult
     public func addEcdnDomain(domain: String, origin: Origin, area: String, projectId: Int64? = nil, ipFilter: IpFilter? = nil, ipFreqLimit: IpFreqLimit? = nil, responseHeader: ResponseHeader? = nil, cacheKey: CacheKey? = nil, cache: Cache? = nil, https: Https? = nil, forceRedirect: ForceRedirect? = nil, tag: [Tag]? = nil, webSocket: WebSocket? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<AddEcdnDomainResponse> {
@@ -140,7 +140,7 @@ extension Ecdn {
     ///
     /// 本接口（AddEcdnDomain）用于创建加速域名。
     ///
-    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41123)，使用  CDN 相关API 进行操作。
+    /// > Important: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41123)，使用  CDN 相关API 进行操作。
     @available(*, unavailable, message: "ECDN融合CDN后，接口都用CDN的，此接口已经废弃")
     @inlinable @discardableResult
     public func addEcdnDomain(domain: String, origin: Origin, area: String, projectId: Int64? = nil, ipFilter: IpFilter? = nil, ipFreqLimit: IpFreqLimit? = nil, responseHeader: ResponseHeader? = nil, cacheKey: CacheKey? = nil, cache: Cache? = nil, https: Https? = nil, forceRedirect: ForceRedirect? = nil, tag: [Tag]? = nil, webSocket: WebSocket? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> AddEcdnDomainResponse {

--- a/Sources/Teco/Ecdn/V20191012/actions/CreateVerifyRecord.swift
+++ b/Sources/Teco/Ecdn/V20191012/actions/CreateVerifyRecord.swift
@@ -59,7 +59,7 @@ extension Ecdn {
     ///
     /// 生成一条子域名解析，提示客户添加到域名解析上，用于泛域名及域名取回校验归属权。
     ///
-    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/48118)，使用  CDN 相关API 进行操作。
+    /// > Important: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/48118)，使用  CDN 相关API 进行操作。
     @available(*, unavailable, message: "ECDN融合CDN后，接口都用CDN的，此接口已经废弃")
     @inlinable
     public func createVerifyRecord(_ input: CreateVerifyRecordRequest, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<CreateVerifyRecordResponse> {
@@ -70,7 +70,7 @@ extension Ecdn {
     ///
     /// 生成一条子域名解析，提示客户添加到域名解析上，用于泛域名及域名取回校验归属权。
     ///
-    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/48118)，使用  CDN 相关API 进行操作。
+    /// > Important: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/48118)，使用  CDN 相关API 进行操作。
     @available(*, unavailable, message: "ECDN融合CDN后，接口都用CDN的，此接口已经废弃")
     @inlinable
     public func createVerifyRecord(_ input: CreateVerifyRecordRequest, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> CreateVerifyRecordResponse {
@@ -81,7 +81,7 @@ extension Ecdn {
     ///
     /// 生成一条子域名解析，提示客户添加到域名解析上，用于泛域名及域名取回校验归属权。
     ///
-    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/48118)，使用  CDN 相关API 进行操作。
+    /// > Important: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/48118)，使用  CDN 相关API 进行操作。
     @available(*, unavailable, message: "ECDN融合CDN后，接口都用CDN的，此接口已经废弃")
     @inlinable
     public func createVerifyRecord(domain: String, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<CreateVerifyRecordResponse> {
@@ -92,7 +92,7 @@ extension Ecdn {
     ///
     /// 生成一条子域名解析，提示客户添加到域名解析上，用于泛域名及域名取回校验归属权。
     ///
-    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/48118)，使用  CDN 相关API 进行操作。
+    /// > Important: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/48118)，使用  CDN 相关API 进行操作。
     @available(*, unavailable, message: "ECDN融合CDN后，接口都用CDN的，此接口已经废弃")
     @inlinable
     public func createVerifyRecord(domain: String, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> CreateVerifyRecordResponse {

--- a/Sources/Teco/Ecdn/V20191012/actions/CreateVerifyRecord.swift
+++ b/Sources/Teco/Ecdn/V20191012/actions/CreateVerifyRecord.swift
@@ -59,7 +59,7 @@ extension Ecdn {
     ///
     /// 生成一条子域名解析，提示客户添加到域名解析上，用于泛域名及域名取回校验归属权。
     ///
-    /// - Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/48118)，使用  CDN 相关API 进行操作。
+    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/48118)，使用  CDN 相关API 进行操作。
     @available(*, unavailable, message: "ECDN融合CDN后，接口都用CDN的，此接口已经废弃")
     @inlinable
     public func createVerifyRecord(_ input: CreateVerifyRecordRequest, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<CreateVerifyRecordResponse> {
@@ -70,7 +70,7 @@ extension Ecdn {
     ///
     /// 生成一条子域名解析，提示客户添加到域名解析上，用于泛域名及域名取回校验归属权。
     ///
-    /// - Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/48118)，使用  CDN 相关API 进行操作。
+    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/48118)，使用  CDN 相关API 进行操作。
     @available(*, unavailable, message: "ECDN融合CDN后，接口都用CDN的，此接口已经废弃")
     @inlinable
     public func createVerifyRecord(_ input: CreateVerifyRecordRequest, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> CreateVerifyRecordResponse {
@@ -81,7 +81,7 @@ extension Ecdn {
     ///
     /// 生成一条子域名解析，提示客户添加到域名解析上，用于泛域名及域名取回校验归属权。
     ///
-    /// - Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/48118)，使用  CDN 相关API 进行操作。
+    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/48118)，使用  CDN 相关API 进行操作。
     @available(*, unavailable, message: "ECDN融合CDN后，接口都用CDN的，此接口已经废弃")
     @inlinable
     public func createVerifyRecord(domain: String, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<CreateVerifyRecordResponse> {
@@ -92,7 +92,7 @@ extension Ecdn {
     ///
     /// 生成一条子域名解析，提示客户添加到域名解析上，用于泛域名及域名取回校验归属权。
     ///
-    /// - Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/48118)，使用  CDN 相关API 进行操作。
+    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/48118)，使用  CDN 相关API 进行操作。
     @available(*, unavailable, message: "ECDN融合CDN后，接口都用CDN的，此接口已经废弃")
     @inlinable
     public func createVerifyRecord(domain: String, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> CreateVerifyRecordResponse {

--- a/Sources/Teco/Ecdn/V20191012/actions/DeleteEcdnDomain.swift
+++ b/Sources/Teco/Ecdn/V20191012/actions/DeleteEcdnDomain.swift
@@ -47,7 +47,7 @@ extension Ecdn {
     ///
     /// 本接口（DeleteEcdnDomain）用于删除指定加速域名。待删除域名必须处于已停用状态。
     ///
-    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41122)，使用  CDN 相关API 进行操作。
+    /// > Important: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41122)，使用  CDN 相关API 进行操作。
     @available(*, unavailable, message: "ECDN融合CDN后，接口都用CDN的，此接口已经废弃")
     @inlinable @discardableResult
     public func deleteEcdnDomain(_ input: DeleteEcdnDomainRequest, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<DeleteEcdnDomainResponse> {
@@ -58,7 +58,7 @@ extension Ecdn {
     ///
     /// 本接口（DeleteEcdnDomain）用于删除指定加速域名。待删除域名必须处于已停用状态。
     ///
-    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41122)，使用  CDN 相关API 进行操作。
+    /// > Important: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41122)，使用  CDN 相关API 进行操作。
     @available(*, unavailable, message: "ECDN融合CDN后，接口都用CDN的，此接口已经废弃")
     @inlinable @discardableResult
     public func deleteEcdnDomain(_ input: DeleteEcdnDomainRequest, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> DeleteEcdnDomainResponse {
@@ -69,7 +69,7 @@ extension Ecdn {
     ///
     /// 本接口（DeleteEcdnDomain）用于删除指定加速域名。待删除域名必须处于已停用状态。
     ///
-    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41122)，使用  CDN 相关API 进行操作。
+    /// > Important: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41122)，使用  CDN 相关API 进行操作。
     @available(*, unavailable, message: "ECDN融合CDN后，接口都用CDN的，此接口已经废弃")
     @inlinable @discardableResult
     public func deleteEcdnDomain(domain: String, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<DeleteEcdnDomainResponse> {
@@ -80,7 +80,7 @@ extension Ecdn {
     ///
     /// 本接口（DeleteEcdnDomain）用于删除指定加速域名。待删除域名必须处于已停用状态。
     ///
-    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41122)，使用  CDN 相关API 进行操作。
+    /// > Important: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41122)，使用  CDN 相关API 进行操作。
     @available(*, unavailable, message: "ECDN融合CDN后，接口都用CDN的，此接口已经废弃")
     @inlinable @discardableResult
     public func deleteEcdnDomain(domain: String, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> DeleteEcdnDomainResponse {

--- a/Sources/Teco/Ecdn/V20191012/actions/DeleteEcdnDomain.swift
+++ b/Sources/Teco/Ecdn/V20191012/actions/DeleteEcdnDomain.swift
@@ -47,7 +47,7 @@ extension Ecdn {
     ///
     /// 本接口（DeleteEcdnDomain）用于删除指定加速域名。待删除域名必须处于已停用状态。
     ///
-    /// - Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41122)，使用  CDN 相关API 进行操作。
+    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41122)，使用  CDN 相关API 进行操作。
     @available(*, unavailable, message: "ECDN融合CDN后，接口都用CDN的，此接口已经废弃")
     @inlinable @discardableResult
     public func deleteEcdnDomain(_ input: DeleteEcdnDomainRequest, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<DeleteEcdnDomainResponse> {
@@ -58,7 +58,7 @@ extension Ecdn {
     ///
     /// 本接口（DeleteEcdnDomain）用于删除指定加速域名。待删除域名必须处于已停用状态。
     ///
-    /// - Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41122)，使用  CDN 相关API 进行操作。
+    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41122)，使用  CDN 相关API 进行操作。
     @available(*, unavailable, message: "ECDN融合CDN后，接口都用CDN的，此接口已经废弃")
     @inlinable @discardableResult
     public func deleteEcdnDomain(_ input: DeleteEcdnDomainRequest, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> DeleteEcdnDomainResponse {
@@ -69,7 +69,7 @@ extension Ecdn {
     ///
     /// 本接口（DeleteEcdnDomain）用于删除指定加速域名。待删除域名必须处于已停用状态。
     ///
-    /// - Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41122)，使用  CDN 相关API 进行操作。
+    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41122)，使用  CDN 相关API 进行操作。
     @available(*, unavailable, message: "ECDN融合CDN后，接口都用CDN的，此接口已经废弃")
     @inlinable @discardableResult
     public func deleteEcdnDomain(domain: String, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<DeleteEcdnDomainResponse> {
@@ -80,7 +80,7 @@ extension Ecdn {
     ///
     /// 本接口（DeleteEcdnDomain）用于删除指定加速域名。待删除域名必须处于已停用状态。
     ///
-    /// - Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41122)，使用  CDN 相关API 进行操作。
+    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41122)，使用  CDN 相关API 进行操作。
     @available(*, unavailable, message: "ECDN融合CDN后，接口都用CDN的，此接口已经废弃")
     @inlinable @discardableResult
     public func deleteEcdnDomain(domain: String, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> DeleteEcdnDomainResponse {

--- a/Sources/Teco/Ecdn/V20191012/actions/DescribeDomains.swift
+++ b/Sources/Teco/Ecdn/V20191012/actions/DescribeDomains.swift
@@ -84,7 +84,7 @@ extension Ecdn {
     ///
     /// 本接口（DescribeDomains）用于查询CDN域名基本信息，包括项目id，状态，业务类型，创建时间，更新时间等。
     ///
-    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41118)，使用  CDN 相关API 进行操作。
+    /// > Important: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41118)，使用  CDN 相关API 进行操作。
     @inlinable
     public func describeDomains(_ input: DescribeDomainsRequest, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<DescribeDomainsResponse> {
         self.client.execute(action: "DescribeDomains", region: region, serviceConfig: self.config, input: input, logger: logger, on: eventLoop)
@@ -94,7 +94,7 @@ extension Ecdn {
     ///
     /// 本接口（DescribeDomains）用于查询CDN域名基本信息，包括项目id，状态，业务类型，创建时间，更新时间等。
     ///
-    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41118)，使用  CDN 相关API 进行操作。
+    /// > Important: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41118)，使用  CDN 相关API 进行操作。
     @inlinable
     public func describeDomains(_ input: DescribeDomainsRequest, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> DescribeDomainsResponse {
         try await self.client.execute(action: "DescribeDomains", region: region, serviceConfig: self.config, input: input, logger: logger, on: eventLoop).get()
@@ -104,7 +104,7 @@ extension Ecdn {
     ///
     /// 本接口（DescribeDomains）用于查询CDN域名基本信息，包括项目id，状态，业务类型，创建时间，更新时间等。
     ///
-    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41118)，使用  CDN 相关API 进行操作。
+    /// > Important: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41118)，使用  CDN 相关API 进行操作。
     @inlinable
     public func describeDomains(offset: Int64? = nil, limit: Int64? = nil, filters: [DomainFilter]? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<DescribeDomainsResponse> {
         self.describeDomains(.init(offset: offset, limit: limit, filters: filters), region: region, logger: logger, on: eventLoop)
@@ -114,7 +114,7 @@ extension Ecdn {
     ///
     /// 本接口（DescribeDomains）用于查询CDN域名基本信息，包括项目id，状态，业务类型，创建时间，更新时间等。
     ///
-    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41118)，使用  CDN 相关API 进行操作。
+    /// > Important: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41118)，使用  CDN 相关API 进行操作。
     @inlinable
     public func describeDomains(offset: Int64? = nil, limit: Int64? = nil, filters: [DomainFilter]? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> DescribeDomainsResponse {
         try await self.describeDomains(.init(offset: offset, limit: limit, filters: filters), region: region, logger: logger, on: eventLoop)
@@ -124,7 +124,7 @@ extension Ecdn {
     ///
     /// 本接口（DescribeDomains）用于查询CDN域名基本信息，包括项目id，状态，业务类型，创建时间，更新时间等。
     ///
-    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41118)，使用  CDN 相关API 进行操作。
+    /// > Important: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41118)，使用  CDN 相关API 进行操作。
     @inlinable
     public func describeDomainsPaginated(_ input: DescribeDomainsRequest, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<(Int64?, [DomainBriefInfo])> {
         self.client.paginate(input: input, region: region, command: self.describeDomains, logger: logger, on: eventLoop)
@@ -134,7 +134,7 @@ extension Ecdn {
     ///
     /// 本接口（DescribeDomains）用于查询CDN域名基本信息，包括项目id，状态，业务类型，创建时间，更新时间等。
     ///
-    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41118)，使用  CDN 相关API 进行操作。
+    /// > Important: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41118)，使用  CDN 相关API 进行操作。
     @inlinable @discardableResult
     public func describeDomainsPaginated(_ input: DescribeDomainsRequest, region: TCRegion? = nil, onResponse: @escaping (DescribeDomainsResponse, EventLoop) -> EventLoopFuture<Bool>, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<Void> {
         self.client.paginate(input: input, region: region, command: self.describeDomains, callback: onResponse, logger: logger, on: eventLoop)
@@ -144,7 +144,7 @@ extension Ecdn {
     ///
     /// 本接口（DescribeDomains）用于查询CDN域名基本信息，包括项目id，状态，业务类型，创建时间，更新时间等。
     ///
-    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41118)，使用  CDN 相关API 进行操作。
+    /// > Important: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41118)，使用  CDN 相关API 进行操作。
     ///
     /// - Returns: `AsyncSequence`s of ``DomainBriefInfo`` and ``DescribeDomainsResponse`` that can be iterated over asynchronously on demand.
     @inlinable

--- a/Sources/Teco/Ecdn/V20191012/actions/DescribeDomains.swift
+++ b/Sources/Teco/Ecdn/V20191012/actions/DescribeDomains.swift
@@ -84,7 +84,7 @@ extension Ecdn {
     ///
     /// 本接口（DescribeDomains）用于查询CDN域名基本信息，包括项目id，状态，业务类型，创建时间，更新时间等。
     ///
-    /// - Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41118)，使用  CDN 相关API 进行操作。
+    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41118)，使用  CDN 相关API 进行操作。
     @inlinable
     public func describeDomains(_ input: DescribeDomainsRequest, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<DescribeDomainsResponse> {
         self.client.execute(action: "DescribeDomains", region: region, serviceConfig: self.config, input: input, logger: logger, on: eventLoop)
@@ -94,7 +94,7 @@ extension Ecdn {
     ///
     /// 本接口（DescribeDomains）用于查询CDN域名基本信息，包括项目id，状态，业务类型，创建时间，更新时间等。
     ///
-    /// - Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41118)，使用  CDN 相关API 进行操作。
+    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41118)，使用  CDN 相关API 进行操作。
     @inlinable
     public func describeDomains(_ input: DescribeDomainsRequest, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> DescribeDomainsResponse {
         try await self.client.execute(action: "DescribeDomains", region: region, serviceConfig: self.config, input: input, logger: logger, on: eventLoop).get()
@@ -104,7 +104,7 @@ extension Ecdn {
     ///
     /// 本接口（DescribeDomains）用于查询CDN域名基本信息，包括项目id，状态，业务类型，创建时间，更新时间等。
     ///
-    /// - Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41118)，使用  CDN 相关API 进行操作。
+    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41118)，使用  CDN 相关API 进行操作。
     @inlinable
     public func describeDomains(offset: Int64? = nil, limit: Int64? = nil, filters: [DomainFilter]? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<DescribeDomainsResponse> {
         self.describeDomains(.init(offset: offset, limit: limit, filters: filters), region: region, logger: logger, on: eventLoop)
@@ -114,7 +114,7 @@ extension Ecdn {
     ///
     /// 本接口（DescribeDomains）用于查询CDN域名基本信息，包括项目id，状态，业务类型，创建时间，更新时间等。
     ///
-    /// - Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41118)，使用  CDN 相关API 进行操作。
+    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41118)，使用  CDN 相关API 进行操作。
     @inlinable
     public func describeDomains(offset: Int64? = nil, limit: Int64? = nil, filters: [DomainFilter]? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> DescribeDomainsResponse {
         try await self.describeDomains(.init(offset: offset, limit: limit, filters: filters), region: region, logger: logger, on: eventLoop)
@@ -124,7 +124,7 @@ extension Ecdn {
     ///
     /// 本接口（DescribeDomains）用于查询CDN域名基本信息，包括项目id，状态，业务类型，创建时间，更新时间等。
     ///
-    /// - Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41118)，使用  CDN 相关API 进行操作。
+    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41118)，使用  CDN 相关API 进行操作。
     @inlinable
     public func describeDomainsPaginated(_ input: DescribeDomainsRequest, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<(Int64?, [DomainBriefInfo])> {
         self.client.paginate(input: input, region: region, command: self.describeDomains, logger: logger, on: eventLoop)
@@ -134,7 +134,7 @@ extension Ecdn {
     ///
     /// 本接口（DescribeDomains）用于查询CDN域名基本信息，包括项目id，状态，业务类型，创建时间，更新时间等。
     ///
-    /// - Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41118)，使用  CDN 相关API 进行操作。
+    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41118)，使用  CDN 相关API 进行操作。
     @inlinable @discardableResult
     public func describeDomainsPaginated(_ input: DescribeDomainsRequest, region: TCRegion? = nil, onResponse: @escaping (DescribeDomainsResponse, EventLoop) -> EventLoopFuture<Bool>, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<Void> {
         self.client.paginate(input: input, region: region, command: self.describeDomains, callback: onResponse, logger: logger, on: eventLoop)
@@ -144,7 +144,7 @@ extension Ecdn {
     ///
     /// 本接口（DescribeDomains）用于查询CDN域名基本信息，包括项目id，状态，业务类型，创建时间，更新时间等。
     ///
-    /// - Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41118)，使用  CDN 相关API 进行操作。
+    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41118)，使用  CDN 相关API 进行操作。
     ///
     /// - Returns: `AsyncSequence`s of ``DomainBriefInfo`` and ``DescribeDomainsResponse`` that can be iterated over asynchronously on demand.
     @inlinable

--- a/Sources/Teco/Ecdn/V20191012/actions/DescribeDomainsConfig.swift
+++ b/Sources/Teco/Ecdn/V20191012/actions/DescribeDomainsConfig.swift
@@ -89,7 +89,7 @@ extension Ecdn {
     ///
     /// 本接口（DescribeDomainsConfig）用于查询CDN加速域名详细配置信息。
     ///
-    /// - Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41117)，使用  CDN 相关API 进行操作。
+    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41117)，使用  CDN 相关API 进行操作。
     @inlinable
     public func describeDomainsConfig(_ input: DescribeDomainsConfigRequest, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<DescribeDomainsConfigResponse> {
         self.client.execute(action: "DescribeDomainsConfig", region: region, serviceConfig: self.config, input: input, logger: logger, on: eventLoop)
@@ -99,7 +99,7 @@ extension Ecdn {
     ///
     /// 本接口（DescribeDomainsConfig）用于查询CDN加速域名详细配置信息。
     ///
-    /// - Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41117)，使用  CDN 相关API 进行操作。
+    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41117)，使用  CDN 相关API 进行操作。
     @inlinable
     public func describeDomainsConfig(_ input: DescribeDomainsConfigRequest, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> DescribeDomainsConfigResponse {
         try await self.client.execute(action: "DescribeDomainsConfig", region: region, serviceConfig: self.config, input: input, logger: logger, on: eventLoop).get()
@@ -109,7 +109,7 @@ extension Ecdn {
     ///
     /// 本接口（DescribeDomainsConfig）用于查询CDN加速域名详细配置信息。
     ///
-    /// - Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41117)，使用  CDN 相关API 进行操作。
+    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41117)，使用  CDN 相关API 进行操作。
     @inlinable
     public func describeDomainsConfig(offset: Int64? = nil, limit: Int64? = nil, filters: [DomainFilter]? = nil, sort: Sort? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<DescribeDomainsConfigResponse> {
         self.describeDomainsConfig(.init(offset: offset, limit: limit, filters: filters, sort: sort), region: region, logger: logger, on: eventLoop)
@@ -119,7 +119,7 @@ extension Ecdn {
     ///
     /// 本接口（DescribeDomainsConfig）用于查询CDN加速域名详细配置信息。
     ///
-    /// - Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41117)，使用  CDN 相关API 进行操作。
+    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41117)，使用  CDN 相关API 进行操作。
     @inlinable
     public func describeDomainsConfig(offset: Int64? = nil, limit: Int64? = nil, filters: [DomainFilter]? = nil, sort: Sort? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> DescribeDomainsConfigResponse {
         try await self.describeDomainsConfig(.init(offset: offset, limit: limit, filters: filters, sort: sort), region: region, logger: logger, on: eventLoop)
@@ -129,7 +129,7 @@ extension Ecdn {
     ///
     /// 本接口（DescribeDomainsConfig）用于查询CDN加速域名详细配置信息。
     ///
-    /// - Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41117)，使用  CDN 相关API 进行操作。
+    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41117)，使用  CDN 相关API 进行操作。
     @inlinable
     public func describeDomainsConfigPaginated(_ input: DescribeDomainsConfigRequest, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<(Int64?, [DomainDetailInfo])> {
         self.client.paginate(input: input, region: region, command: self.describeDomainsConfig, logger: logger, on: eventLoop)
@@ -139,7 +139,7 @@ extension Ecdn {
     ///
     /// 本接口（DescribeDomainsConfig）用于查询CDN加速域名详细配置信息。
     ///
-    /// - Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41117)，使用  CDN 相关API 进行操作。
+    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41117)，使用  CDN 相关API 进行操作。
     @inlinable @discardableResult
     public func describeDomainsConfigPaginated(_ input: DescribeDomainsConfigRequest, region: TCRegion? = nil, onResponse: @escaping (DescribeDomainsConfigResponse, EventLoop) -> EventLoopFuture<Bool>, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<Void> {
         self.client.paginate(input: input, region: region, command: self.describeDomainsConfig, callback: onResponse, logger: logger, on: eventLoop)
@@ -149,7 +149,7 @@ extension Ecdn {
     ///
     /// 本接口（DescribeDomainsConfig）用于查询CDN加速域名详细配置信息。
     ///
-    /// - Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41117)，使用  CDN 相关API 进行操作。
+    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41117)，使用  CDN 相关API 进行操作。
     ///
     /// - Returns: `AsyncSequence`s of ``DomainDetailInfo`` and ``DescribeDomainsConfigResponse`` that can be iterated over asynchronously on demand.
     @inlinable

--- a/Sources/Teco/Ecdn/V20191012/actions/DescribeDomainsConfig.swift
+++ b/Sources/Teco/Ecdn/V20191012/actions/DescribeDomainsConfig.swift
@@ -89,7 +89,7 @@ extension Ecdn {
     ///
     /// 本接口（DescribeDomainsConfig）用于查询CDN加速域名详细配置信息。
     ///
-    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41117)，使用  CDN 相关API 进行操作。
+    /// > Important: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41117)，使用  CDN 相关API 进行操作。
     @inlinable
     public func describeDomainsConfig(_ input: DescribeDomainsConfigRequest, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<DescribeDomainsConfigResponse> {
         self.client.execute(action: "DescribeDomainsConfig", region: region, serviceConfig: self.config, input: input, logger: logger, on: eventLoop)
@@ -99,7 +99,7 @@ extension Ecdn {
     ///
     /// 本接口（DescribeDomainsConfig）用于查询CDN加速域名详细配置信息。
     ///
-    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41117)，使用  CDN 相关API 进行操作。
+    /// > Important: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41117)，使用  CDN 相关API 进行操作。
     @inlinable
     public func describeDomainsConfig(_ input: DescribeDomainsConfigRequest, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> DescribeDomainsConfigResponse {
         try await self.client.execute(action: "DescribeDomainsConfig", region: region, serviceConfig: self.config, input: input, logger: logger, on: eventLoop).get()
@@ -109,7 +109,7 @@ extension Ecdn {
     ///
     /// 本接口（DescribeDomainsConfig）用于查询CDN加速域名详细配置信息。
     ///
-    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41117)，使用  CDN 相关API 进行操作。
+    /// > Important: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41117)，使用  CDN 相关API 进行操作。
     @inlinable
     public func describeDomainsConfig(offset: Int64? = nil, limit: Int64? = nil, filters: [DomainFilter]? = nil, sort: Sort? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<DescribeDomainsConfigResponse> {
         self.describeDomainsConfig(.init(offset: offset, limit: limit, filters: filters, sort: sort), region: region, logger: logger, on: eventLoop)
@@ -119,7 +119,7 @@ extension Ecdn {
     ///
     /// 本接口（DescribeDomainsConfig）用于查询CDN加速域名详细配置信息。
     ///
-    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41117)，使用  CDN 相关API 进行操作。
+    /// > Important: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41117)，使用  CDN 相关API 进行操作。
     @inlinable
     public func describeDomainsConfig(offset: Int64? = nil, limit: Int64? = nil, filters: [DomainFilter]? = nil, sort: Sort? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> DescribeDomainsConfigResponse {
         try await self.describeDomainsConfig(.init(offset: offset, limit: limit, filters: filters, sort: sort), region: region, logger: logger, on: eventLoop)
@@ -129,7 +129,7 @@ extension Ecdn {
     ///
     /// 本接口（DescribeDomainsConfig）用于查询CDN加速域名详细配置信息。
     ///
-    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41117)，使用  CDN 相关API 进行操作。
+    /// > Important: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41117)，使用  CDN 相关API 进行操作。
     @inlinable
     public func describeDomainsConfigPaginated(_ input: DescribeDomainsConfigRequest, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<(Int64?, [DomainDetailInfo])> {
         self.client.paginate(input: input, region: region, command: self.describeDomainsConfig, logger: logger, on: eventLoop)
@@ -139,7 +139,7 @@ extension Ecdn {
     ///
     /// 本接口（DescribeDomainsConfig）用于查询CDN加速域名详细配置信息。
     ///
-    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41117)，使用  CDN 相关API 进行操作。
+    /// > Important: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41117)，使用  CDN 相关API 进行操作。
     @inlinable @discardableResult
     public func describeDomainsConfigPaginated(_ input: DescribeDomainsConfigRequest, region: TCRegion? = nil, onResponse: @escaping (DescribeDomainsConfigResponse, EventLoop) -> EventLoopFuture<Bool>, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<Void> {
         self.client.paginate(input: input, region: region, command: self.describeDomainsConfig, callback: onResponse, logger: logger, on: eventLoop)
@@ -149,7 +149,7 @@ extension Ecdn {
     ///
     /// 本接口（DescribeDomainsConfig）用于查询CDN加速域名详细配置信息。
     ///
-    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41117)，使用  CDN 相关API 进行操作。
+    /// > Important: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41117)，使用  CDN 相关API 进行操作。
     ///
     /// - Returns: `AsyncSequence`s of ``DomainDetailInfo`` and ``DescribeDomainsConfigResponse`` that can be iterated over asynchronously on demand.
     @inlinable

--- a/Sources/Teco/Ecdn/V20191012/actions/DescribeEcdnDomainStatistics.swift
+++ b/Sources/Teco/Ecdn/V20191012/actions/DescribeEcdnDomainStatistics.swift
@@ -127,7 +127,7 @@ extension Ecdn {
     ///
     /// 本接口（DescribeEcdnDomainStatistics）用于查询指定时间段内的域名访问统计指标。
     ///
-    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/30986)，使用  CDN 相关API 进行操作。
+    /// > Important: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/30986)，使用  CDN 相关API 进行操作。
     @inlinable
     public func describeEcdnDomainStatistics(_ input: DescribeEcdnDomainStatisticsRequest, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<DescribeEcdnDomainStatisticsResponse> {
         self.client.execute(action: "DescribeEcdnDomainStatistics", region: region, serviceConfig: self.config, input: input, logger: logger, on: eventLoop)
@@ -137,7 +137,7 @@ extension Ecdn {
     ///
     /// 本接口（DescribeEcdnDomainStatistics）用于查询指定时间段内的域名访问统计指标。
     ///
-    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/30986)，使用  CDN 相关API 进行操作。
+    /// > Important: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/30986)，使用  CDN 相关API 进行操作。
     @inlinable
     public func describeEcdnDomainStatistics(_ input: DescribeEcdnDomainStatisticsRequest, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> DescribeEcdnDomainStatisticsResponse {
         try await self.client.execute(action: "DescribeEcdnDomainStatistics", region: region, serviceConfig: self.config, input: input, logger: logger, on: eventLoop).get()
@@ -147,7 +147,7 @@ extension Ecdn {
     ///
     /// 本接口（DescribeEcdnDomainStatistics）用于查询指定时间段内的域名访问统计指标。
     ///
-    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/30986)，使用  CDN 相关API 进行操作。
+    /// > Important: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/30986)，使用  CDN 相关API 进行操作。
     @inlinable
     public func describeEcdnDomainStatistics(startTime: Date, endTime: Date, metrics: [String], domains: [String]? = nil, projects: [Int64]? = nil, offset: Int64? = nil, limit: Int64? = nil, area: String? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<DescribeEcdnDomainStatisticsResponse> {
         self.describeEcdnDomainStatistics(.init(startTime: startTime, endTime: endTime, metrics: metrics, domains: domains, projects: projects, offset: offset, limit: limit, area: area), region: region, logger: logger, on: eventLoop)
@@ -157,7 +157,7 @@ extension Ecdn {
     ///
     /// 本接口（DescribeEcdnDomainStatistics）用于查询指定时间段内的域名访问统计指标。
     ///
-    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/30986)，使用  CDN 相关API 进行操作。
+    /// > Important: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/30986)，使用  CDN 相关API 进行操作。
     @inlinable
     public func describeEcdnDomainStatistics(startTime: Date, endTime: Date, metrics: [String], domains: [String]? = nil, projects: [Int64]? = nil, offset: Int64? = nil, limit: Int64? = nil, area: String? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> DescribeEcdnDomainStatisticsResponse {
         try await self.describeEcdnDomainStatistics(.init(startTime: startTime, endTime: endTime, metrics: metrics, domains: domains, projects: projects, offset: offset, limit: limit, area: area), region: region, logger: logger, on: eventLoop)
@@ -167,7 +167,7 @@ extension Ecdn {
     ///
     /// 本接口（DescribeEcdnDomainStatistics）用于查询指定时间段内的域名访问统计指标。
     ///
-    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/30986)，使用  CDN 相关API 进行操作。
+    /// > Important: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/30986)，使用  CDN 相关API 进行操作。
     @inlinable
     public func describeEcdnDomainStatisticsPaginated(_ input: DescribeEcdnDomainStatisticsRequest, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<(Int64?, [DomainData])> {
         self.client.paginate(input: input, region: region, command: self.describeEcdnDomainStatistics, logger: logger, on: eventLoop)
@@ -177,7 +177,7 @@ extension Ecdn {
     ///
     /// 本接口（DescribeEcdnDomainStatistics）用于查询指定时间段内的域名访问统计指标。
     ///
-    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/30986)，使用  CDN 相关API 进行操作。
+    /// > Important: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/30986)，使用  CDN 相关API 进行操作。
     @inlinable @discardableResult
     public func describeEcdnDomainStatisticsPaginated(_ input: DescribeEcdnDomainStatisticsRequest, region: TCRegion? = nil, onResponse: @escaping (DescribeEcdnDomainStatisticsResponse, EventLoop) -> EventLoopFuture<Bool>, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<Void> {
         self.client.paginate(input: input, region: region, command: self.describeEcdnDomainStatistics, callback: onResponse, logger: logger, on: eventLoop)
@@ -187,7 +187,7 @@ extension Ecdn {
     ///
     /// 本接口（DescribeEcdnDomainStatistics）用于查询指定时间段内的域名访问统计指标。
     ///
-    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/30986)，使用  CDN 相关API 进行操作。
+    /// > Important: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/30986)，使用  CDN 相关API 进行操作。
     ///
     /// - Returns: `AsyncSequence`s of ``DomainData`` and ``DescribeEcdnDomainStatisticsResponse`` that can be iterated over asynchronously on demand.
     @inlinable

--- a/Sources/Teco/Ecdn/V20191012/actions/DescribeEcdnDomainStatistics.swift
+++ b/Sources/Teco/Ecdn/V20191012/actions/DescribeEcdnDomainStatistics.swift
@@ -127,7 +127,7 @@ extension Ecdn {
     ///
     /// 本接口（DescribeEcdnDomainStatistics）用于查询指定时间段内的域名访问统计指标。
     ///
-    /// - Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/30986)，使用  CDN 相关API 进行操作。
+    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/30986)，使用  CDN 相关API 进行操作。
     @inlinable
     public func describeEcdnDomainStatistics(_ input: DescribeEcdnDomainStatisticsRequest, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<DescribeEcdnDomainStatisticsResponse> {
         self.client.execute(action: "DescribeEcdnDomainStatistics", region: region, serviceConfig: self.config, input: input, logger: logger, on: eventLoop)
@@ -137,7 +137,7 @@ extension Ecdn {
     ///
     /// 本接口（DescribeEcdnDomainStatistics）用于查询指定时间段内的域名访问统计指标。
     ///
-    /// - Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/30986)，使用  CDN 相关API 进行操作。
+    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/30986)，使用  CDN 相关API 进行操作。
     @inlinable
     public func describeEcdnDomainStatistics(_ input: DescribeEcdnDomainStatisticsRequest, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> DescribeEcdnDomainStatisticsResponse {
         try await self.client.execute(action: "DescribeEcdnDomainStatistics", region: region, serviceConfig: self.config, input: input, logger: logger, on: eventLoop).get()
@@ -147,7 +147,7 @@ extension Ecdn {
     ///
     /// 本接口（DescribeEcdnDomainStatistics）用于查询指定时间段内的域名访问统计指标。
     ///
-    /// - Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/30986)，使用  CDN 相关API 进行操作。
+    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/30986)，使用  CDN 相关API 进行操作。
     @inlinable
     public func describeEcdnDomainStatistics(startTime: Date, endTime: Date, metrics: [String], domains: [String]? = nil, projects: [Int64]? = nil, offset: Int64? = nil, limit: Int64? = nil, area: String? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<DescribeEcdnDomainStatisticsResponse> {
         self.describeEcdnDomainStatistics(.init(startTime: startTime, endTime: endTime, metrics: metrics, domains: domains, projects: projects, offset: offset, limit: limit, area: area), region: region, logger: logger, on: eventLoop)
@@ -157,7 +157,7 @@ extension Ecdn {
     ///
     /// 本接口（DescribeEcdnDomainStatistics）用于查询指定时间段内的域名访问统计指标。
     ///
-    /// - Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/30986)，使用  CDN 相关API 进行操作。
+    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/30986)，使用  CDN 相关API 进行操作。
     @inlinable
     public func describeEcdnDomainStatistics(startTime: Date, endTime: Date, metrics: [String], domains: [String]? = nil, projects: [Int64]? = nil, offset: Int64? = nil, limit: Int64? = nil, area: String? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> DescribeEcdnDomainStatisticsResponse {
         try await self.describeEcdnDomainStatistics(.init(startTime: startTime, endTime: endTime, metrics: metrics, domains: domains, projects: projects, offset: offset, limit: limit, area: area), region: region, logger: logger, on: eventLoop)
@@ -167,7 +167,7 @@ extension Ecdn {
     ///
     /// 本接口（DescribeEcdnDomainStatistics）用于查询指定时间段内的域名访问统计指标。
     ///
-    /// - Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/30986)，使用  CDN 相关API 进行操作。
+    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/30986)，使用  CDN 相关API 进行操作。
     @inlinable
     public func describeEcdnDomainStatisticsPaginated(_ input: DescribeEcdnDomainStatisticsRequest, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<(Int64?, [DomainData])> {
         self.client.paginate(input: input, region: region, command: self.describeEcdnDomainStatistics, logger: logger, on: eventLoop)
@@ -177,7 +177,7 @@ extension Ecdn {
     ///
     /// 本接口（DescribeEcdnDomainStatistics）用于查询指定时间段内的域名访问统计指标。
     ///
-    /// - Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/30986)，使用  CDN 相关API 进行操作。
+    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/30986)，使用  CDN 相关API 进行操作。
     @inlinable @discardableResult
     public func describeEcdnDomainStatisticsPaginated(_ input: DescribeEcdnDomainStatisticsRequest, region: TCRegion? = nil, onResponse: @escaping (DescribeEcdnDomainStatisticsResponse, EventLoop) -> EventLoopFuture<Bool>, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<Void> {
         self.client.paginate(input: input, region: region, command: self.describeEcdnDomainStatistics, callback: onResponse, logger: logger, on: eventLoop)
@@ -187,7 +187,7 @@ extension Ecdn {
     ///
     /// 本接口（DescribeEcdnDomainStatistics）用于查询指定时间段内的域名访问统计指标。
     ///
-    /// - Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/30986)，使用  CDN 相关API 进行操作。
+    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/30986)，使用  CDN 相关API 进行操作。
     ///
     /// - Returns: `AsyncSequence`s of ``DomainData`` and ``DescribeEcdnDomainStatisticsResponse`` that can be iterated over asynchronously on demand.
     @inlinable

--- a/Sources/Teco/Ecdn/V20191012/actions/DescribePurgeQuota.swift
+++ b/Sources/Teco/Ecdn/V20191012/actions/DescribePurgeQuota.swift
@@ -47,7 +47,7 @@ extension Ecdn {
     ///
     /// 查询刷新接口的用量配额。
     ///
-    /// - Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41956)，使用  CDN 相关API 进行操作。
+    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41956)，使用  CDN 相关API 进行操作。
     @available(*, unavailable, message: "ECDN融合CDN后，接口都用CDN的，此接口已经废弃")
     @inlinable
     public func describePurgeQuota(_ input: DescribePurgeQuotaRequest, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<DescribePurgeQuotaResponse> {
@@ -58,7 +58,7 @@ extension Ecdn {
     ///
     /// 查询刷新接口的用量配额。
     ///
-    /// - Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41956)，使用  CDN 相关API 进行操作。
+    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41956)，使用  CDN 相关API 进行操作。
     @available(*, unavailable, message: "ECDN融合CDN后，接口都用CDN的，此接口已经废弃")
     @inlinable
     public func describePurgeQuota(_ input: DescribePurgeQuotaRequest, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> DescribePurgeQuotaResponse {
@@ -69,7 +69,7 @@ extension Ecdn {
     ///
     /// 查询刷新接口的用量配额。
     ///
-    /// - Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41956)，使用  CDN 相关API 进行操作。
+    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41956)，使用  CDN 相关API 进行操作。
     @available(*, unavailable, message: "ECDN融合CDN后，接口都用CDN的，此接口已经废弃")
     @inlinable
     public func describePurgeQuota(region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<DescribePurgeQuotaResponse> {
@@ -80,7 +80,7 @@ extension Ecdn {
     ///
     /// 查询刷新接口的用量配额。
     ///
-    /// - Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41956)，使用  CDN 相关API 进行操作。
+    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41956)，使用  CDN 相关API 进行操作。
     @available(*, unavailable, message: "ECDN融合CDN后，接口都用CDN的，此接口已经废弃")
     @inlinable
     public func describePurgeQuota(region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> DescribePurgeQuotaResponse {

--- a/Sources/Teco/Ecdn/V20191012/actions/DescribePurgeQuota.swift
+++ b/Sources/Teco/Ecdn/V20191012/actions/DescribePurgeQuota.swift
@@ -47,7 +47,7 @@ extension Ecdn {
     ///
     /// 查询刷新接口的用量配额。
     ///
-    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41956)，使用  CDN 相关API 进行操作。
+    /// > Important: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41956)，使用  CDN 相关API 进行操作。
     @available(*, unavailable, message: "ECDN融合CDN后，接口都用CDN的，此接口已经废弃")
     @inlinable
     public func describePurgeQuota(_ input: DescribePurgeQuotaRequest, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<DescribePurgeQuotaResponse> {
@@ -58,7 +58,7 @@ extension Ecdn {
     ///
     /// 查询刷新接口的用量配额。
     ///
-    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41956)，使用  CDN 相关API 进行操作。
+    /// > Important: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41956)，使用  CDN 相关API 进行操作。
     @available(*, unavailable, message: "ECDN融合CDN后，接口都用CDN的，此接口已经废弃")
     @inlinable
     public func describePurgeQuota(_ input: DescribePurgeQuotaRequest, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> DescribePurgeQuotaResponse {
@@ -69,7 +69,7 @@ extension Ecdn {
     ///
     /// 查询刷新接口的用量配额。
     ///
-    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41956)，使用  CDN 相关API 进行操作。
+    /// > Important: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41956)，使用  CDN 相关API 进行操作。
     @available(*, unavailable, message: "ECDN融合CDN后，接口都用CDN的，此接口已经废弃")
     @inlinable
     public func describePurgeQuota(region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<DescribePurgeQuotaResponse> {
@@ -80,7 +80,7 @@ extension Ecdn {
     ///
     /// 查询刷新接口的用量配额。
     ///
-    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41956)，使用  CDN 相关API 进行操作。
+    /// > Important: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/41956)，使用  CDN 相关API 进行操作。
     @available(*, unavailable, message: "ECDN融合CDN后，接口都用CDN的，此接口已经废弃")
     @inlinable
     public func describePurgeQuota(region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> DescribePurgeQuotaResponse {

--- a/Sources/Teco/Ecdn/V20191012/actions/DescribePurgeTasks.swift
+++ b/Sources/Teco/Ecdn/V20191012/actions/DescribePurgeTasks.swift
@@ -117,7 +117,7 @@ extension Ecdn {
     ///
     /// DescribePurgeTasks 用于查询刷新任务提交历史记录及执行进度。
     ///
-    /// - Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/37873)，使用  CDN 相关API 进行操作。
+    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/37873)，使用  CDN 相关API 进行操作。
     @inlinable
     public func describePurgeTasks(_ input: DescribePurgeTasksRequest, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<DescribePurgeTasksResponse> {
         self.client.execute(action: "DescribePurgeTasks", region: region, serviceConfig: self.config, input: input, logger: logger, on: eventLoop)
@@ -127,7 +127,7 @@ extension Ecdn {
     ///
     /// DescribePurgeTasks 用于查询刷新任务提交历史记录及执行进度。
     ///
-    /// - Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/37873)，使用  CDN 相关API 进行操作。
+    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/37873)，使用  CDN 相关API 进行操作。
     @inlinable
     public func describePurgeTasks(_ input: DescribePurgeTasksRequest, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> DescribePurgeTasksResponse {
         try await self.client.execute(action: "DescribePurgeTasks", region: region, serviceConfig: self.config, input: input, logger: logger, on: eventLoop).get()
@@ -137,7 +137,7 @@ extension Ecdn {
     ///
     /// DescribePurgeTasks 用于查询刷新任务提交历史记录及执行进度。
     ///
-    /// - Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/37873)，使用  CDN 相关API 进行操作。
+    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/37873)，使用  CDN 相关API 进行操作。
     @inlinable
     public func describePurgeTasks(purgeType: String? = nil, startTime: Date? = nil, endTime: Date? = nil, taskId: String? = nil, offset: Int64? = nil, limit: Int64? = nil, keyword: String? = nil, status: String? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<DescribePurgeTasksResponse> {
         self.describePurgeTasks(.init(purgeType: purgeType, startTime: startTime, endTime: endTime, taskId: taskId, offset: offset, limit: limit, keyword: keyword, status: status), region: region, logger: logger, on: eventLoop)
@@ -147,7 +147,7 @@ extension Ecdn {
     ///
     /// DescribePurgeTasks 用于查询刷新任务提交历史记录及执行进度。
     ///
-    /// - Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/37873)，使用  CDN 相关API 进行操作。
+    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/37873)，使用  CDN 相关API 进行操作。
     @inlinable
     public func describePurgeTasks(purgeType: String? = nil, startTime: Date? = nil, endTime: Date? = nil, taskId: String? = nil, offset: Int64? = nil, limit: Int64? = nil, keyword: String? = nil, status: String? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> DescribePurgeTasksResponse {
         try await self.describePurgeTasks(.init(purgeType: purgeType, startTime: startTime, endTime: endTime, taskId: taskId, offset: offset, limit: limit, keyword: keyword, status: status), region: region, logger: logger, on: eventLoop)
@@ -157,7 +157,7 @@ extension Ecdn {
     ///
     /// DescribePurgeTasks 用于查询刷新任务提交历史记录及执行进度。
     ///
-    /// - Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/37873)，使用  CDN 相关API 进行操作。
+    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/37873)，使用  CDN 相关API 进行操作。
     @inlinable
     public func describePurgeTasksPaginated(_ input: DescribePurgeTasksRequest, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<(Int64?, [PurgeTask])> {
         self.client.paginate(input: input, region: region, command: self.describePurgeTasks, logger: logger, on: eventLoop)
@@ -167,7 +167,7 @@ extension Ecdn {
     ///
     /// DescribePurgeTasks 用于查询刷新任务提交历史记录及执行进度。
     ///
-    /// - Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/37873)，使用  CDN 相关API 进行操作。
+    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/37873)，使用  CDN 相关API 进行操作。
     @inlinable @discardableResult
     public func describePurgeTasksPaginated(_ input: DescribePurgeTasksRequest, region: TCRegion? = nil, onResponse: @escaping (DescribePurgeTasksResponse, EventLoop) -> EventLoopFuture<Bool>, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<Void> {
         self.client.paginate(input: input, region: region, command: self.describePurgeTasks, callback: onResponse, logger: logger, on: eventLoop)
@@ -177,7 +177,7 @@ extension Ecdn {
     ///
     /// DescribePurgeTasks 用于查询刷新任务提交历史记录及执行进度。
     ///
-    /// - Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/37873)，使用  CDN 相关API 进行操作。
+    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/37873)，使用  CDN 相关API 进行操作。
     ///
     /// - Returns: `AsyncSequence`s of ``PurgeTask`` and ``DescribePurgeTasksResponse`` that can be iterated over asynchronously on demand.
     @inlinable

--- a/Sources/Teco/Ecdn/V20191012/actions/DescribePurgeTasks.swift
+++ b/Sources/Teco/Ecdn/V20191012/actions/DescribePurgeTasks.swift
@@ -117,7 +117,7 @@ extension Ecdn {
     ///
     /// DescribePurgeTasks 用于查询刷新任务提交历史记录及执行进度。
     ///
-    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/37873)，使用  CDN 相关API 进行操作。
+    /// > Important: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/37873)，使用  CDN 相关API 进行操作。
     @inlinable
     public func describePurgeTasks(_ input: DescribePurgeTasksRequest, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<DescribePurgeTasksResponse> {
         self.client.execute(action: "DescribePurgeTasks", region: region, serviceConfig: self.config, input: input, logger: logger, on: eventLoop)
@@ -127,7 +127,7 @@ extension Ecdn {
     ///
     /// DescribePurgeTasks 用于查询刷新任务提交历史记录及执行进度。
     ///
-    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/37873)，使用  CDN 相关API 进行操作。
+    /// > Important: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/37873)，使用  CDN 相关API 进行操作。
     @inlinable
     public func describePurgeTasks(_ input: DescribePurgeTasksRequest, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> DescribePurgeTasksResponse {
         try await self.client.execute(action: "DescribePurgeTasks", region: region, serviceConfig: self.config, input: input, logger: logger, on: eventLoop).get()
@@ -137,7 +137,7 @@ extension Ecdn {
     ///
     /// DescribePurgeTasks 用于查询刷新任务提交历史记录及执行进度。
     ///
-    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/37873)，使用  CDN 相关API 进行操作。
+    /// > Important: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/37873)，使用  CDN 相关API 进行操作。
     @inlinable
     public func describePurgeTasks(purgeType: String? = nil, startTime: Date? = nil, endTime: Date? = nil, taskId: String? = nil, offset: Int64? = nil, limit: Int64? = nil, keyword: String? = nil, status: String? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<DescribePurgeTasksResponse> {
         self.describePurgeTasks(.init(purgeType: purgeType, startTime: startTime, endTime: endTime, taskId: taskId, offset: offset, limit: limit, keyword: keyword, status: status), region: region, logger: logger, on: eventLoop)
@@ -147,7 +147,7 @@ extension Ecdn {
     ///
     /// DescribePurgeTasks 用于查询刷新任务提交历史记录及执行进度。
     ///
-    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/37873)，使用  CDN 相关API 进行操作。
+    /// > Important: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/37873)，使用  CDN 相关API 进行操作。
     @inlinable
     public func describePurgeTasks(purgeType: String? = nil, startTime: Date? = nil, endTime: Date? = nil, taskId: String? = nil, offset: Int64? = nil, limit: Int64? = nil, keyword: String? = nil, status: String? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> DescribePurgeTasksResponse {
         try await self.describePurgeTasks(.init(purgeType: purgeType, startTime: startTime, endTime: endTime, taskId: taskId, offset: offset, limit: limit, keyword: keyword, status: status), region: region, logger: logger, on: eventLoop)
@@ -157,7 +157,7 @@ extension Ecdn {
     ///
     /// DescribePurgeTasks 用于查询刷新任务提交历史记录及执行进度。
     ///
-    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/37873)，使用  CDN 相关API 进行操作。
+    /// > Important: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/37873)，使用  CDN 相关API 进行操作。
     @inlinable
     public func describePurgeTasksPaginated(_ input: DescribePurgeTasksRequest, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<(Int64?, [PurgeTask])> {
         self.client.paginate(input: input, region: region, command: self.describePurgeTasks, logger: logger, on: eventLoop)
@@ -167,7 +167,7 @@ extension Ecdn {
     ///
     /// DescribePurgeTasks 用于查询刷新任务提交历史记录及执行进度。
     ///
-    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/37873)，使用  CDN 相关API 进行操作。
+    /// > Important: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/37873)，使用  CDN 相关API 进行操作。
     @inlinable @discardableResult
     public func describePurgeTasksPaginated(_ input: DescribePurgeTasksRequest, region: TCRegion? = nil, onResponse: @escaping (DescribePurgeTasksResponse, EventLoop) -> EventLoopFuture<Bool>, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<Void> {
         self.client.paginate(input: input, region: region, command: self.describePurgeTasks, callback: onResponse, logger: logger, on: eventLoop)
@@ -177,7 +177,7 @@ extension Ecdn {
     ///
     /// DescribePurgeTasks 用于查询刷新任务提交历史记录及执行进度。
     ///
-    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/37873)，使用  CDN 相关API 进行操作。
+    /// > Important: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/37873)，使用  CDN 相关API 进行操作。
     ///
     /// - Returns: `AsyncSequence`s of ``PurgeTask`` and ``DescribePurgeTasksResponse`` that can be iterated over asynchronously on demand.
     @inlinable

--- a/Sources/Teco/Ecdn/V20191012/actions/PurgePathCache.swift
+++ b/Sources/Teco/Ecdn/V20191012/actions/PurgePathCache.swift
@@ -56,7 +56,7 @@ extension Ecdn {
     ///
     /// PurgePathCache 用于批量刷新目录缓存，一次提交将返回一个刷新任务id。
     ///
-    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/570/42475)，使用  CDN 相关API 进行操作。
+    /// > Important: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/570/42475)，使用  CDN 相关API 进行操作。
     @available(*, unavailable, message: "ECDN融合CDN后，接口都用CDN的，此接口已经废弃")
     @inlinable
     public func purgePathCache(_ input: PurgePathCacheRequest, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<PurgePathCacheResponse> {
@@ -67,7 +67,7 @@ extension Ecdn {
     ///
     /// PurgePathCache 用于批量刷新目录缓存，一次提交将返回一个刷新任务id。
     ///
-    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/570/42475)，使用  CDN 相关API 进行操作。
+    /// > Important: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/570/42475)，使用  CDN 相关API 进行操作。
     @available(*, unavailable, message: "ECDN融合CDN后，接口都用CDN的，此接口已经废弃")
     @inlinable
     public func purgePathCache(_ input: PurgePathCacheRequest, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> PurgePathCacheResponse {
@@ -78,7 +78,7 @@ extension Ecdn {
     ///
     /// PurgePathCache 用于批量刷新目录缓存，一次提交将返回一个刷新任务id。
     ///
-    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/570/42475)，使用  CDN 相关API 进行操作。
+    /// > Important: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/570/42475)，使用  CDN 相关API 进行操作。
     @available(*, unavailable, message: "ECDN融合CDN后，接口都用CDN的，此接口已经废弃")
     @inlinable
     public func purgePathCache(paths: [String], flushType: String, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<PurgePathCacheResponse> {
@@ -89,7 +89,7 @@ extension Ecdn {
     ///
     /// PurgePathCache 用于批量刷新目录缓存，一次提交将返回一个刷新任务id。
     ///
-    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/570/42475)，使用  CDN 相关API 进行操作。
+    /// > Important: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/570/42475)，使用  CDN 相关API 进行操作。
     @available(*, unavailable, message: "ECDN融合CDN后，接口都用CDN的，此接口已经废弃")
     @inlinable
     public func purgePathCache(paths: [String], flushType: String, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> PurgePathCacheResponse {

--- a/Sources/Teco/Ecdn/V20191012/actions/PurgePathCache.swift
+++ b/Sources/Teco/Ecdn/V20191012/actions/PurgePathCache.swift
@@ -56,7 +56,7 @@ extension Ecdn {
     ///
     /// PurgePathCache 用于批量刷新目录缓存，一次提交将返回一个刷新任务id。
     ///
-    /// - Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/570/42475)，使用  CDN 相关API 进行操作。
+    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/570/42475)，使用  CDN 相关API 进行操作。
     @available(*, unavailable, message: "ECDN融合CDN后，接口都用CDN的，此接口已经废弃")
     @inlinable
     public func purgePathCache(_ input: PurgePathCacheRequest, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<PurgePathCacheResponse> {
@@ -67,7 +67,7 @@ extension Ecdn {
     ///
     /// PurgePathCache 用于批量刷新目录缓存，一次提交将返回一个刷新任务id。
     ///
-    /// - Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/570/42475)，使用  CDN 相关API 进行操作。
+    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/570/42475)，使用  CDN 相关API 进行操作。
     @available(*, unavailable, message: "ECDN融合CDN后，接口都用CDN的，此接口已经废弃")
     @inlinable
     public func purgePathCache(_ input: PurgePathCacheRequest, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> PurgePathCacheResponse {
@@ -78,7 +78,7 @@ extension Ecdn {
     ///
     /// PurgePathCache 用于批量刷新目录缓存，一次提交将返回一个刷新任务id。
     ///
-    /// - Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/570/42475)，使用  CDN 相关API 进行操作。
+    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/570/42475)，使用  CDN 相关API 进行操作。
     @available(*, unavailable, message: "ECDN融合CDN后，接口都用CDN的，此接口已经废弃")
     @inlinable
     public func purgePathCache(paths: [String], flushType: String, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<PurgePathCacheResponse> {
@@ -89,7 +89,7 @@ extension Ecdn {
     ///
     /// PurgePathCache 用于批量刷新目录缓存，一次提交将返回一个刷新任务id。
     ///
-    /// - Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/570/42475)，使用  CDN 相关API 进行操作。
+    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/570/42475)，使用  CDN 相关API 进行操作。
     @available(*, unavailable, message: "ECDN融合CDN后，接口都用CDN的，此接口已经废弃")
     @inlinable
     public func purgePathCache(paths: [String], flushType: String, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> PurgePathCacheResponse {

--- a/Sources/Teco/Ecdn/V20191012/actions/PurgeUrlsCache.swift
+++ b/Sources/Teco/Ecdn/V20191012/actions/PurgeUrlsCache.swift
@@ -51,7 +51,7 @@ extension Ecdn {
     ///
     /// PurgeUrlsCache 用于批量刷新Url，一次提交将返回一个刷新任务id。
     ///
-    /// - Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/37870)，使用  CDN 相关API 进行操作。
+    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/37870)，使用  CDN 相关API 进行操作。
     @inlinable
     public func purgeUrlsCache(_ input: PurgeUrlsCacheRequest, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<PurgeUrlsCacheResponse> {
         self.client.execute(action: "PurgeUrlsCache", region: region, serviceConfig: self.config, input: input, logger: logger, on: eventLoop)
@@ -61,7 +61,7 @@ extension Ecdn {
     ///
     /// PurgeUrlsCache 用于批量刷新Url，一次提交将返回一个刷新任务id。
     ///
-    /// - Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/37870)，使用  CDN 相关API 进行操作。
+    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/37870)，使用  CDN 相关API 进行操作。
     @inlinable
     public func purgeUrlsCache(_ input: PurgeUrlsCacheRequest, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> PurgeUrlsCacheResponse {
         try await self.client.execute(action: "PurgeUrlsCache", region: region, serviceConfig: self.config, input: input, logger: logger, on: eventLoop).get()
@@ -71,7 +71,7 @@ extension Ecdn {
     ///
     /// PurgeUrlsCache 用于批量刷新Url，一次提交将返回一个刷新任务id。
     ///
-    /// - Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/37870)，使用  CDN 相关API 进行操作。
+    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/37870)，使用  CDN 相关API 进行操作。
     @inlinable
     public func purgeUrlsCache(urls: [String], region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<PurgeUrlsCacheResponse> {
         self.purgeUrlsCache(.init(urls: urls), region: region, logger: logger, on: eventLoop)
@@ -81,7 +81,7 @@ extension Ecdn {
     ///
     /// PurgeUrlsCache 用于批量刷新Url，一次提交将返回一个刷新任务id。
     ///
-    /// - Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/37870)，使用  CDN 相关API 进行操作。
+    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/37870)，使用  CDN 相关API 进行操作。
     @inlinable
     public func purgeUrlsCache(urls: [String], region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> PurgeUrlsCacheResponse {
         try await self.purgeUrlsCache(.init(urls: urls), region: region, logger: logger, on: eventLoop)

--- a/Sources/Teco/Ecdn/V20191012/actions/PurgeUrlsCache.swift
+++ b/Sources/Teco/Ecdn/V20191012/actions/PurgeUrlsCache.swift
@@ -51,7 +51,7 @@ extension Ecdn {
     ///
     /// PurgeUrlsCache 用于批量刷新Url，一次提交将返回一个刷新任务id。
     ///
-    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/37870)，使用  CDN 相关API 进行操作。
+    /// > Important: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/37870)，使用  CDN 相关API 进行操作。
     @inlinable
     public func purgeUrlsCache(_ input: PurgeUrlsCacheRequest, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<PurgeUrlsCacheResponse> {
         self.client.execute(action: "PurgeUrlsCache", region: region, serviceConfig: self.config, input: input, logger: logger, on: eventLoop)
@@ -61,7 +61,7 @@ extension Ecdn {
     ///
     /// PurgeUrlsCache 用于批量刷新Url，一次提交将返回一个刷新任务id。
     ///
-    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/37870)，使用  CDN 相关API 进行操作。
+    /// > Important: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/37870)，使用  CDN 相关API 进行操作。
     @inlinable
     public func purgeUrlsCache(_ input: PurgeUrlsCacheRequest, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> PurgeUrlsCacheResponse {
         try await self.client.execute(action: "PurgeUrlsCache", region: region, serviceConfig: self.config, input: input, logger: logger, on: eventLoop).get()
@@ -71,7 +71,7 @@ extension Ecdn {
     ///
     /// PurgeUrlsCache 用于批量刷新Url，一次提交将返回一个刷新任务id。
     ///
-    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/37870)，使用  CDN 相关API 进行操作。
+    /// > Important: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/37870)，使用  CDN 相关API 进行操作。
     @inlinable
     public func purgeUrlsCache(urls: [String], region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<PurgeUrlsCacheResponse> {
         self.purgeUrlsCache(.init(urls: urls), region: region, logger: logger, on: eventLoop)
@@ -81,7 +81,7 @@ extension Ecdn {
     ///
     /// PurgeUrlsCache 用于批量刷新Url，一次提交将返回一个刷新任务id。
     ///
-    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/37870)，使用  CDN 相关API 进行操作。
+    /// > Important: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/api/228/37870)，使用  CDN 相关API 进行操作。
     @inlinable
     public func purgeUrlsCache(urls: [String], region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> PurgeUrlsCacheResponse {
         try await self.purgeUrlsCache(.init(urls: urls), region: region, logger: logger, on: eventLoop)

--- a/Sources/Teco/Ecdn/V20191012/actions/StartEcdnDomain.swift
+++ b/Sources/Teco/Ecdn/V20191012/actions/StartEcdnDomain.swift
@@ -47,7 +47,7 @@ extension Ecdn {
     ///
     /// 本接口（StartEcdnDomain）用于启用加速域名，待启用域名必须处于已下线状态。
     ///
-    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/product/228/41121)，使用  CDN 相关API 进行操作。
+    /// > Important: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/product/228/41121)，使用  CDN 相关API 进行操作。
     @available(*, unavailable, message: "ECDN融合CDN后，接口都用CDN的，此接口已经废弃")
     @inlinable @discardableResult
     public func startEcdnDomain(_ input: StartEcdnDomainRequest, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<StartEcdnDomainResponse> {
@@ -58,7 +58,7 @@ extension Ecdn {
     ///
     /// 本接口（StartEcdnDomain）用于启用加速域名，待启用域名必须处于已下线状态。
     ///
-    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/product/228/41121)，使用  CDN 相关API 进行操作。
+    /// > Important: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/product/228/41121)，使用  CDN 相关API 进行操作。
     @available(*, unavailable, message: "ECDN融合CDN后，接口都用CDN的，此接口已经废弃")
     @inlinable @discardableResult
     public func startEcdnDomain(_ input: StartEcdnDomainRequest, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> StartEcdnDomainResponse {
@@ -69,7 +69,7 @@ extension Ecdn {
     ///
     /// 本接口（StartEcdnDomain）用于启用加速域名，待启用域名必须处于已下线状态。
     ///
-    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/product/228/41121)，使用  CDN 相关API 进行操作。
+    /// > Important: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/product/228/41121)，使用  CDN 相关API 进行操作。
     @available(*, unavailable, message: "ECDN融合CDN后，接口都用CDN的，此接口已经废弃")
     @inlinable @discardableResult
     public func startEcdnDomain(domain: String, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<StartEcdnDomainResponse> {
@@ -80,7 +80,7 @@ extension Ecdn {
     ///
     /// 本接口（StartEcdnDomain）用于启用加速域名，待启用域名必须处于已下线状态。
     ///
-    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/product/228/41121)，使用  CDN 相关API 进行操作。
+    /// > Important: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/product/228/41121)，使用  CDN 相关API 进行操作。
     @available(*, unavailable, message: "ECDN融合CDN后，接口都用CDN的，此接口已经废弃")
     @inlinable @discardableResult
     public func startEcdnDomain(domain: String, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> StartEcdnDomainResponse {

--- a/Sources/Teco/Ecdn/V20191012/actions/StartEcdnDomain.swift
+++ b/Sources/Teco/Ecdn/V20191012/actions/StartEcdnDomain.swift
@@ -47,7 +47,7 @@ extension Ecdn {
     ///
     /// 本接口（StartEcdnDomain）用于启用加速域名，待启用域名必须处于已下线状态。
     ///
-    /// - Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/product/228/41121)，使用  CDN 相关API 进行操作。
+    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/product/228/41121)，使用  CDN 相关API 进行操作。
     @available(*, unavailable, message: "ECDN融合CDN后，接口都用CDN的，此接口已经废弃")
     @inlinable @discardableResult
     public func startEcdnDomain(_ input: StartEcdnDomainRequest, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<StartEcdnDomainResponse> {
@@ -58,7 +58,7 @@ extension Ecdn {
     ///
     /// 本接口（StartEcdnDomain）用于启用加速域名，待启用域名必须处于已下线状态。
     ///
-    /// - Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/product/228/41121)，使用  CDN 相关API 进行操作。
+    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/product/228/41121)，使用  CDN 相关API 进行操作。
     @available(*, unavailable, message: "ECDN融合CDN后，接口都用CDN的，此接口已经废弃")
     @inlinable @discardableResult
     public func startEcdnDomain(_ input: StartEcdnDomainRequest, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> StartEcdnDomainResponse {
@@ -69,7 +69,7 @@ extension Ecdn {
     ///
     /// 本接口（StartEcdnDomain）用于启用加速域名，待启用域名必须处于已下线状态。
     ///
-    /// - Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/product/228/41121)，使用  CDN 相关API 进行操作。
+    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/product/228/41121)，使用  CDN 相关API 进行操作。
     @available(*, unavailable, message: "ECDN融合CDN后，接口都用CDN的，此接口已经废弃")
     @inlinable @discardableResult
     public func startEcdnDomain(domain: String, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<StartEcdnDomainResponse> {
@@ -80,7 +80,7 @@ extension Ecdn {
     ///
     /// 本接口（StartEcdnDomain）用于启用加速域名，待启用域名必须处于已下线状态。
     ///
-    /// - Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/product/228/41121)，使用  CDN 相关API 进行操作。
+    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/product/228/41121)，使用  CDN 相关API 进行操作。
     @available(*, unavailable, message: "ECDN融合CDN后，接口都用CDN的，此接口已经废弃")
     @inlinable @discardableResult
     public func startEcdnDomain(domain: String, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> StartEcdnDomainResponse {

--- a/Sources/Teco/Ecdn/V20191012/actions/StopEcdnDomain.swift
+++ b/Sources/Teco/Ecdn/V20191012/actions/StopEcdnDomain.swift
@@ -47,7 +47,7 @@ extension Ecdn {
     ///
     /// 本接口（StopCdnDomain）用于停止加速域名，待停用加速域名必须处于已上线或部署中状态。
     ///
-    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/product/228/41120)，使用  CDN 相关API 进行操作。
+    /// > Important: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/product/228/41120)，使用  CDN 相关API 进行操作。
     @available(*, unavailable, message: "ECDN融合CDN后，接口都用CDN的，此接口已经废弃")
     @inlinable @discardableResult
     public func stopEcdnDomain(_ input: StopEcdnDomainRequest, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<StopEcdnDomainResponse> {
@@ -58,7 +58,7 @@ extension Ecdn {
     ///
     /// 本接口（StopCdnDomain）用于停止加速域名，待停用加速域名必须处于已上线或部署中状态。
     ///
-    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/product/228/41120)，使用  CDN 相关API 进行操作。
+    /// > Important: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/product/228/41120)，使用  CDN 相关API 进行操作。
     @available(*, unavailable, message: "ECDN融合CDN后，接口都用CDN的，此接口已经废弃")
     @inlinable @discardableResult
     public func stopEcdnDomain(_ input: StopEcdnDomainRequest, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> StopEcdnDomainResponse {
@@ -69,7 +69,7 @@ extension Ecdn {
     ///
     /// 本接口（StopCdnDomain）用于停止加速域名，待停用加速域名必须处于已上线或部署中状态。
     ///
-    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/product/228/41120)，使用  CDN 相关API 进行操作。
+    /// > Important: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/product/228/41120)，使用  CDN 相关API 进行操作。
     @available(*, unavailable, message: "ECDN融合CDN后，接口都用CDN的，此接口已经废弃")
     @inlinable @discardableResult
     public func stopEcdnDomain(domain: String, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<StopEcdnDomainResponse> {
@@ -80,7 +80,7 @@ extension Ecdn {
     ///
     /// 本接口（StopCdnDomain）用于停止加速域名，待停用加速域名必须处于已上线或部署中状态。
     ///
-    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/product/228/41120)，使用  CDN 相关API 进行操作。
+    /// > Important: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/product/228/41120)，使用  CDN 相关API 进行操作。
     @available(*, unavailable, message: "ECDN融合CDN后，接口都用CDN的，此接口已经废弃")
     @inlinable @discardableResult
     public func stopEcdnDomain(domain: String, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> StopEcdnDomainResponse {

--- a/Sources/Teco/Ecdn/V20191012/actions/StopEcdnDomain.swift
+++ b/Sources/Teco/Ecdn/V20191012/actions/StopEcdnDomain.swift
@@ -47,7 +47,7 @@ extension Ecdn {
     ///
     /// 本接口（StopCdnDomain）用于停止加速域名，待停用加速域名必须处于已上线或部署中状态。
     ///
-    /// - Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/product/228/41120)，使用  CDN 相关API 进行操作。
+    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/product/228/41120)，使用  CDN 相关API 进行操作。
     @available(*, unavailable, message: "ECDN融合CDN后，接口都用CDN的，此接口已经废弃")
     @inlinable @discardableResult
     public func stopEcdnDomain(_ input: StopEcdnDomainRequest, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<StopEcdnDomainResponse> {
@@ -58,7 +58,7 @@ extension Ecdn {
     ///
     /// 本接口（StopCdnDomain）用于停止加速域名，待停用加速域名必须处于已上线或部署中状态。
     ///
-    /// - Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/product/228/41120)，使用  CDN 相关API 进行操作。
+    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/product/228/41120)，使用  CDN 相关API 进行操作。
     @available(*, unavailable, message: "ECDN融合CDN后，接口都用CDN的，此接口已经废弃")
     @inlinable @discardableResult
     public func stopEcdnDomain(_ input: StopEcdnDomainRequest, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> StopEcdnDomainResponse {
@@ -69,7 +69,7 @@ extension Ecdn {
     ///
     /// 本接口（StopCdnDomain）用于停止加速域名，待停用加速域名必须处于已上线或部署中状态。
     ///
-    /// - Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/product/228/41120)，使用  CDN 相关API 进行操作。
+    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/product/228/41120)，使用  CDN 相关API 进行操作。
     @available(*, unavailable, message: "ECDN融合CDN后，接口都用CDN的，此接口已经废弃")
     @inlinable @discardableResult
     public func stopEcdnDomain(domain: String, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<StopEcdnDomainResponse> {
@@ -80,7 +80,7 @@ extension Ecdn {
     ///
     /// 本接口（StopCdnDomain）用于停止加速域名，待停用加速域名必须处于已上线或部署中状态。
     ///
-    /// - Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/product/228/41120)，使用  CDN 相关API 进行操作。
+    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/product/228/41120)，使用  CDN 相关API 进行操作。
     @available(*, unavailable, message: "ECDN融合CDN后，接口都用CDN的，此接口已经废弃")
     @inlinable @discardableResult
     public func stopEcdnDomain(domain: String, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> StopEcdnDomainResponse {

--- a/Sources/Teco/Ecdn/V20191012/actions/UpdateDomainConfig.swift
+++ b/Sources/Teco/Ecdn/V20191012/actions/UpdateDomainConfig.swift
@@ -103,7 +103,7 @@ extension Ecdn {
     /// 本接口（UpdateDomainConfig）用于更新ECDN加速域名配置信息。
     /// 注意：如果需要更新复杂类型的配置项，必须传递整个对象的所有属性，未传递的属性将使用默认值。建议通过查询接口获取配置属性后，直接修改后传递给本接口。Https配置由于证书的特殊性，更新时不用传递证书和密钥字段。
     ///
-    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/product/228/41116)，使用  CDN 相关API 进行操作。
+    /// > Important: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/product/228/41116)，使用  CDN 相关API 进行操作。
     @available(*, unavailable, message: "ECDN融合CDN后，接口都用CDN的，此接口已经废弃")
     @inlinable @discardableResult
     public func updateDomainConfig(_ input: UpdateDomainConfigRequest, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<UpdateDomainConfigResponse> {
@@ -115,7 +115,7 @@ extension Ecdn {
     /// 本接口（UpdateDomainConfig）用于更新ECDN加速域名配置信息。
     /// 注意：如果需要更新复杂类型的配置项，必须传递整个对象的所有属性，未传递的属性将使用默认值。建议通过查询接口获取配置属性后，直接修改后传递给本接口。Https配置由于证书的特殊性，更新时不用传递证书和密钥字段。
     ///
-    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/product/228/41116)，使用  CDN 相关API 进行操作。
+    /// > Important: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/product/228/41116)，使用  CDN 相关API 进行操作。
     @available(*, unavailable, message: "ECDN融合CDN后，接口都用CDN的，此接口已经废弃")
     @inlinable @discardableResult
     public func updateDomainConfig(_ input: UpdateDomainConfigRequest, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> UpdateDomainConfigResponse {
@@ -127,7 +127,7 @@ extension Ecdn {
     /// 本接口（UpdateDomainConfig）用于更新ECDN加速域名配置信息。
     /// 注意：如果需要更新复杂类型的配置项，必须传递整个对象的所有属性，未传递的属性将使用默认值。建议通过查询接口获取配置属性后，直接修改后传递给本接口。Https配置由于证书的特殊性，更新时不用传递证书和密钥字段。
     ///
-    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/product/228/41116)，使用  CDN 相关API 进行操作。
+    /// > Important: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/product/228/41116)，使用  CDN 相关API 进行操作。
     @available(*, unavailable, message: "ECDN融合CDN后，接口都用CDN的，此接口已经废弃")
     @inlinable @discardableResult
     public func updateDomainConfig(domain: String, origin: Origin? = nil, projectId: Int64? = nil, ipFilter: IpFilter? = nil, ipFreqLimit: IpFreqLimit? = nil, responseHeader: ResponseHeader? = nil, cacheKey: CacheKey? = nil, cache: Cache? = nil, https: Https? = nil, forceRedirect: ForceRedirect? = nil, area: String? = nil, webSocket: WebSocket? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<UpdateDomainConfigResponse> {
@@ -139,7 +139,7 @@ extension Ecdn {
     /// 本接口（UpdateDomainConfig）用于更新ECDN加速域名配置信息。
     /// 注意：如果需要更新复杂类型的配置项，必须传递整个对象的所有属性，未传递的属性将使用默认值。建议通过查询接口获取配置属性后，直接修改后传递给本接口。Https配置由于证书的特殊性，更新时不用传递证书和密钥字段。
     ///
-    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/product/228/41116)，使用  CDN 相关API 进行操作。
+    /// > Important: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/product/228/41116)，使用  CDN 相关API 进行操作。
     @available(*, unavailable, message: "ECDN融合CDN后，接口都用CDN的，此接口已经废弃")
     @inlinable @discardableResult
     public func updateDomainConfig(domain: String, origin: Origin? = nil, projectId: Int64? = nil, ipFilter: IpFilter? = nil, ipFreqLimit: IpFreqLimit? = nil, responseHeader: ResponseHeader? = nil, cacheKey: CacheKey? = nil, cache: Cache? = nil, https: Https? = nil, forceRedirect: ForceRedirect? = nil, area: String? = nil, webSocket: WebSocket? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> UpdateDomainConfigResponse {

--- a/Sources/Teco/Ecdn/V20191012/actions/UpdateDomainConfig.swift
+++ b/Sources/Teco/Ecdn/V20191012/actions/UpdateDomainConfig.swift
@@ -103,7 +103,7 @@ extension Ecdn {
     /// 本接口（UpdateDomainConfig）用于更新ECDN加速域名配置信息。
     /// 注意：如果需要更新复杂类型的配置项，必须传递整个对象的所有属性，未传递的属性将使用默认值。建议通过查询接口获取配置属性后，直接修改后传递给本接口。Https配置由于证书的特殊性，更新时不用传递证书和密钥字段。
     ///
-    /// - Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/product/228/41116)，使用  CDN 相关API 进行操作。
+    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/product/228/41116)，使用  CDN 相关API 进行操作。
     @available(*, unavailable, message: "ECDN融合CDN后，接口都用CDN的，此接口已经废弃")
     @inlinable @discardableResult
     public func updateDomainConfig(_ input: UpdateDomainConfigRequest, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<UpdateDomainConfigResponse> {
@@ -115,7 +115,7 @@ extension Ecdn {
     /// 本接口（UpdateDomainConfig）用于更新ECDN加速域名配置信息。
     /// 注意：如果需要更新复杂类型的配置项，必须传递整个对象的所有属性，未传递的属性将使用默认值。建议通过查询接口获取配置属性后，直接修改后传递给本接口。Https配置由于证书的特殊性，更新时不用传递证书和密钥字段。
     ///
-    /// - Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/product/228/41116)，使用  CDN 相关API 进行操作。
+    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/product/228/41116)，使用  CDN 相关API 进行操作。
     @available(*, unavailable, message: "ECDN融合CDN后，接口都用CDN的，此接口已经废弃")
     @inlinable @discardableResult
     public func updateDomainConfig(_ input: UpdateDomainConfigRequest, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> UpdateDomainConfigResponse {
@@ -127,7 +127,7 @@ extension Ecdn {
     /// 本接口（UpdateDomainConfig）用于更新ECDN加速域名配置信息。
     /// 注意：如果需要更新复杂类型的配置项，必须传递整个对象的所有属性，未传递的属性将使用默认值。建议通过查询接口获取配置属性后，直接修改后传递给本接口。Https配置由于证书的特殊性，更新时不用传递证书和密钥字段。
     ///
-    /// - Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/product/228/41116)，使用  CDN 相关API 进行操作。
+    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/product/228/41116)，使用  CDN 相关API 进行操作。
     @available(*, unavailable, message: "ECDN融合CDN后，接口都用CDN的，此接口已经废弃")
     @inlinable @discardableResult
     public func updateDomainConfig(domain: String, origin: Origin? = nil, projectId: Int64? = nil, ipFilter: IpFilter? = nil, ipFreqLimit: IpFreqLimit? = nil, responseHeader: ResponseHeader? = nil, cacheKey: CacheKey? = nil, cache: Cache? = nil, https: Https? = nil, forceRedirect: ForceRedirect? = nil, area: String? = nil, webSocket: WebSocket? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<UpdateDomainConfigResponse> {
@@ -139,7 +139,7 @@ extension Ecdn {
     /// 本接口（UpdateDomainConfig）用于更新ECDN加速域名配置信息。
     /// 注意：如果需要更新复杂类型的配置项，必须传递整个对象的所有属性，未传递的属性将使用默认值。建议通过查询接口获取配置属性后，直接修改后传递给本接口。Https配置由于证书的特殊性，更新时不用传递证书和密钥字段。
     ///
-    /// - Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/product/228/41116)，使用  CDN 相关API 进行操作。
+    /// > Attention: 若您的业务已迁移至 CDN 控制台，请参考[ CDN 接口文档](https://cloud.tencent.com/document/product/228/41116)，使用  CDN 相关API 进行操作。
     @available(*, unavailable, message: "ECDN融合CDN后，接口都用CDN的，此接口已经废弃")
     @inlinable @discardableResult
     public func updateDomainConfig(domain: String, origin: Origin? = nil, projectId: Int64? = nil, ipFilter: IpFilter? = nil, ipFreqLimit: IpFreqLimit? = nil, responseHeader: ResponseHeader? = nil, cacheKey: CacheKey? = nil, cache: Cache? = nil, https: Https? = nil, forceRedirect: ForceRedirect? = nil, area: String? = nil, webSocket: WebSocket? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> UpdateDomainConfigResponse {

--- a/Sources/Teco/Sms/V20210111/actions/DescribeSmsTemplateList.swift
+++ b/Sources/Teco/Sms/V20210111/actions/DescribeSmsTemplateList.swift
@@ -29,7 +29,7 @@ extension Sms {
 
         /// 模板 ID 数组。数组为空时默认查询模板列表信息，请使用 Limit 和 Offset 字段设置查询范围。
         ///
-        /// > Attention: 默认数组长度最大100
+        /// > Important: 默认数组长度最大100
         public let templateIdSet: [UInt64]?
 
         /// 最大上限，最多100。

--- a/Sources/Teco/Sms/V20210111/actions/DescribeSmsTemplateList.swift
+++ b/Sources/Teco/Sms/V20210111/actions/DescribeSmsTemplateList.swift
@@ -29,7 +29,7 @@ extension Sms {
 
         /// 模板 ID 数组。数组为空时默认查询模板列表信息，请使用 Limit 和 Offset 字段设置查询范围。
         ///
-        /// - Attention: 默认数组长度最大100
+        /// > Attention: 默认数组长度最大100
         public let templateIdSet: [UInt64]?
 
         /// 最大上限，最多100。

--- a/Sources/Teco/Sms/V20210111/actions/SendSms.swift
+++ b/Sources/Teco/Sms/V20210111/actions/SendSms.swift
@@ -34,12 +34,12 @@ extension Sms {
 
         /// 短信签名内容，使用 UTF-8 编码，必须填写已审核通过的签名，例如：腾讯云，签名信息可前往 [国内短信](https://console.cloud.tencent.com/smsv2/csms-sign) 或 [国际/港澳台短信](https://console.cloud.tencent.com/smsv2/isms-sign) 的签名管理查看。
         ///
-        /// > Attention: 发送国内短信该参数必填，且需填写签名内容而非签名ID。
+        /// > Important: 发送国内短信该参数必填，且需填写签名内容而非签名ID。
         public let signName: String?
 
         /// 模板参数，若无模板参数，则设置为空。
         ///
-        /// > Attention: 模板参数的个数需要与 TemplateId 对应模板的变量个数保持一致。
+        /// > Important: 模板参数的个数需要与 TemplateId 对应模板的变量个数保持一致。
         public let templateParamSet: [String]?
 
         /// 短信码号扩展号，默认未开通，如需开通请联系 [腾讯云短信小助手](https://cloud.tencent.com/document/product/382/3773#.E6.8A.80.E6.9C.AF.E4.BA.A4.E6.B5.81)。

--- a/Sources/Teco/Sms/V20210111/actions/SendSms.swift
+++ b/Sources/Teco/Sms/V20210111/actions/SendSms.swift
@@ -34,12 +34,12 @@ extension Sms {
 
         /// 短信签名内容，使用 UTF-8 编码，必须填写已审核通过的签名，例如：腾讯云，签名信息可前往 [国内短信](https://console.cloud.tencent.com/smsv2/csms-sign) 或 [国际/港澳台短信](https://console.cloud.tencent.com/smsv2/isms-sign) 的签名管理查看。
         ///
-        /// - Attention: 发送国内短信该参数必填，且需填写签名内容而非签名ID。
+        /// > Attention: 发送国内短信该参数必填，且需填写签名内容而非签名ID。
         public let signName: String?
 
         /// 模板参数，若无模板参数，则设置为空。
         ///
-        /// - Attention: 模板参数的个数需要与 TemplateId 对应模板的变量个数保持一致。
+        /// > Attention: 模板参数的个数需要与 TemplateId 对应模板的变量个数保持一致。
         public let templateParamSet: [String]?
 
         /// 短信码号扩展号，默认未开通，如需开通请联系 [腾讯云短信小助手](https://cloud.tencent.com/document/product/382/3773#.E6.8A.80.E6.9C.AF.E4.BA.A4.E6.B5.81)。

--- a/Sources/Teco/Vpc/V20170312/actions/AssignPrivateIpAddresses.swift
+++ b/Sources/Teco/Vpc/V20170312/actions/AssignPrivateIpAddresses.swift
@@ -68,7 +68,7 @@ extension Vpc {
     /// * 一个弹性网卡支持绑定的IP地址是有限制的，更多资源限制信息详见[弹性网卡使用限制](/document/product/576/18527)。
     /// * 可以指定内网IP地址申请，内网IP地址类型不能为主IP，主IP已存在，不能修改，内网IP必须要弹性网卡所在子网内，而且不能被占用。
     /// * 在弹性网卡上申请一个到多个辅助内网IP，接口会在弹性网卡所在子网网段内返回指定数量的辅助内网IP。
-    /// > Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
+    /// > Important: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
     @inlinable
     public func assignPrivateIpAddresses(_ input: AssignPrivateIpAddressesRequest, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<AssignPrivateIpAddressesResponse> {
         self.client.execute(action: "AssignPrivateIpAddresses", region: region, serviceConfig: self.config, input: input, logger: logger, on: eventLoop)
@@ -80,7 +80,7 @@ extension Vpc {
     /// * 一个弹性网卡支持绑定的IP地址是有限制的，更多资源限制信息详见[弹性网卡使用限制](/document/product/576/18527)。
     /// * 可以指定内网IP地址申请，内网IP地址类型不能为主IP，主IP已存在，不能修改，内网IP必须要弹性网卡所在子网内，而且不能被占用。
     /// * 在弹性网卡上申请一个到多个辅助内网IP，接口会在弹性网卡所在子网网段内返回指定数量的辅助内网IP。
-    /// > Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
+    /// > Important: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
     @inlinable
     public func assignPrivateIpAddresses(_ input: AssignPrivateIpAddressesRequest, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> AssignPrivateIpAddressesResponse {
         try await self.client.execute(action: "AssignPrivateIpAddresses", region: region, serviceConfig: self.config, input: input, logger: logger, on: eventLoop).get()
@@ -92,7 +92,7 @@ extension Vpc {
     /// * 一个弹性网卡支持绑定的IP地址是有限制的，更多资源限制信息详见[弹性网卡使用限制](/document/product/576/18527)。
     /// * 可以指定内网IP地址申请，内网IP地址类型不能为主IP，主IP已存在，不能修改，内网IP必须要弹性网卡所在子网内，而且不能被占用。
     /// * 在弹性网卡上申请一个到多个辅助内网IP，接口会在弹性网卡所在子网网段内返回指定数量的辅助内网IP。
-    /// > Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
+    /// > Important: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
     @inlinable
     public func assignPrivateIpAddresses(networkInterfaceId: String, privateIpAddresses: [PrivateIpAddressSpecification]? = nil, secondaryPrivateIpAddressCount: UInt64? = nil, qosLevel: String? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<AssignPrivateIpAddressesResponse> {
         self.assignPrivateIpAddresses(.init(networkInterfaceId: networkInterfaceId, privateIpAddresses: privateIpAddresses, secondaryPrivateIpAddressCount: secondaryPrivateIpAddressCount, qosLevel: qosLevel), region: region, logger: logger, on: eventLoop)
@@ -104,7 +104,7 @@ extension Vpc {
     /// * 一个弹性网卡支持绑定的IP地址是有限制的，更多资源限制信息详见[弹性网卡使用限制](/document/product/576/18527)。
     /// * 可以指定内网IP地址申请，内网IP地址类型不能为主IP，主IP已存在，不能修改，内网IP必须要弹性网卡所在子网内，而且不能被占用。
     /// * 在弹性网卡上申请一个到多个辅助内网IP，接口会在弹性网卡所在子网网段内返回指定数量的辅助内网IP。
-    /// > Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
+    /// > Important: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
     @inlinable
     public func assignPrivateIpAddresses(networkInterfaceId: String, privateIpAddresses: [PrivateIpAddressSpecification]? = nil, secondaryPrivateIpAddressCount: UInt64? = nil, qosLevel: String? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> AssignPrivateIpAddressesResponse {
         try await self.assignPrivateIpAddresses(.init(networkInterfaceId: networkInterfaceId, privateIpAddresses: privateIpAddresses, secondaryPrivateIpAddressCount: secondaryPrivateIpAddressCount, qosLevel: qosLevel), region: region, logger: logger, on: eventLoop)

--- a/Sources/Teco/Vpc/V20170312/actions/AssignPrivateIpAddresses.swift
+++ b/Sources/Teco/Vpc/V20170312/actions/AssignPrivateIpAddresses.swift
@@ -68,8 +68,7 @@ extension Vpc {
     /// * 一个弹性网卡支持绑定的IP地址是有限制的，更多资源限制信息详见[弹性网卡使用限制](/document/product/576/18527)。
     /// * 可以指定内网IP地址申请，内网IP地址类型不能为主IP，主IP已存在，不能修改，内网IP必须要弹性网卡所在子网内，而且不能被占用。
     /// * 在弹性网卡上申请一个到多个辅助内网IP，接口会在弹性网卡所在子网网段内返回指定数量的辅助内网IP。
-    /// - Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
-    /// >
+    /// > Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
     @inlinable
     public func assignPrivateIpAddresses(_ input: AssignPrivateIpAddressesRequest, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<AssignPrivateIpAddressesResponse> {
         self.client.execute(action: "AssignPrivateIpAddresses", region: region, serviceConfig: self.config, input: input, logger: logger, on: eventLoop)
@@ -81,8 +80,7 @@ extension Vpc {
     /// * 一个弹性网卡支持绑定的IP地址是有限制的，更多资源限制信息详见[弹性网卡使用限制](/document/product/576/18527)。
     /// * 可以指定内网IP地址申请，内网IP地址类型不能为主IP，主IP已存在，不能修改，内网IP必须要弹性网卡所在子网内，而且不能被占用。
     /// * 在弹性网卡上申请一个到多个辅助内网IP，接口会在弹性网卡所在子网网段内返回指定数量的辅助内网IP。
-    /// - Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
-    /// >
+    /// > Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
     @inlinable
     public func assignPrivateIpAddresses(_ input: AssignPrivateIpAddressesRequest, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> AssignPrivateIpAddressesResponse {
         try await self.client.execute(action: "AssignPrivateIpAddresses", region: region, serviceConfig: self.config, input: input, logger: logger, on: eventLoop).get()
@@ -94,8 +92,7 @@ extension Vpc {
     /// * 一个弹性网卡支持绑定的IP地址是有限制的，更多资源限制信息详见[弹性网卡使用限制](/document/product/576/18527)。
     /// * 可以指定内网IP地址申请，内网IP地址类型不能为主IP，主IP已存在，不能修改，内网IP必须要弹性网卡所在子网内，而且不能被占用。
     /// * 在弹性网卡上申请一个到多个辅助内网IP，接口会在弹性网卡所在子网网段内返回指定数量的辅助内网IP。
-    /// - Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
-    /// >
+    /// > Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
     @inlinable
     public func assignPrivateIpAddresses(networkInterfaceId: String, privateIpAddresses: [PrivateIpAddressSpecification]? = nil, secondaryPrivateIpAddressCount: UInt64? = nil, qosLevel: String? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<AssignPrivateIpAddressesResponse> {
         self.assignPrivateIpAddresses(.init(networkInterfaceId: networkInterfaceId, privateIpAddresses: privateIpAddresses, secondaryPrivateIpAddressCount: secondaryPrivateIpAddressCount, qosLevel: qosLevel), region: region, logger: logger, on: eventLoop)
@@ -107,8 +104,7 @@ extension Vpc {
     /// * 一个弹性网卡支持绑定的IP地址是有限制的，更多资源限制信息详见[弹性网卡使用限制](/document/product/576/18527)。
     /// * 可以指定内网IP地址申请，内网IP地址类型不能为主IP，主IP已存在，不能修改，内网IP必须要弹性网卡所在子网内，而且不能被占用。
     /// * 在弹性网卡上申请一个到多个辅助内网IP，接口会在弹性网卡所在子网网段内返回指定数量的辅助内网IP。
-    /// - Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
-    /// >
+    /// > Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
     @inlinable
     public func assignPrivateIpAddresses(networkInterfaceId: String, privateIpAddresses: [PrivateIpAddressSpecification]? = nil, secondaryPrivateIpAddressCount: UInt64? = nil, qosLevel: String? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> AssignPrivateIpAddressesResponse {
         try await self.assignPrivateIpAddresses(.init(networkInterfaceId: networkInterfaceId, privateIpAddresses: privateIpAddresses, secondaryPrivateIpAddressCount: secondaryPrivateIpAddressCount, qosLevel: qosLevel), region: region, logger: logger, on: eventLoop)

--- a/Sources/Teco/Vpc/V20170312/actions/AssociateDhcpIpWithAddressIp.swift
+++ b/Sources/Teco/Vpc/V20170312/actions/AssociateDhcpIpWithAddressIp.swift
@@ -52,8 +52,7 @@ extension Vpc {
     ///
     /// 本接口（AssociateDhcpIpWithAddressIp）用于DhcpIp绑定弹性公网IP（EIP）。
     ///
-    /// - Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
-    /// >
+    /// > Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
     @inlinable @discardableResult
     public func associateDhcpIpWithAddressIp(_ input: AssociateDhcpIpWithAddressIpRequest, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<AssociateDhcpIpWithAddressIpResponse> {
         self.client.execute(action: "AssociateDhcpIpWithAddressIp", region: region, serviceConfig: self.config, input: input, logger: logger, on: eventLoop)
@@ -63,8 +62,7 @@ extension Vpc {
     ///
     /// 本接口（AssociateDhcpIpWithAddressIp）用于DhcpIp绑定弹性公网IP（EIP）。
     ///
-    /// - Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
-    /// >
+    /// > Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
     @inlinable @discardableResult
     public func associateDhcpIpWithAddressIp(_ input: AssociateDhcpIpWithAddressIpRequest, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> AssociateDhcpIpWithAddressIpResponse {
         try await self.client.execute(action: "AssociateDhcpIpWithAddressIp", region: region, serviceConfig: self.config, input: input, logger: logger, on: eventLoop).get()
@@ -74,8 +72,7 @@ extension Vpc {
     ///
     /// 本接口（AssociateDhcpIpWithAddressIp）用于DhcpIp绑定弹性公网IP（EIP）。
     ///
-    /// - Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
-    /// >
+    /// > Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
     @inlinable @discardableResult
     public func associateDhcpIpWithAddressIp(dhcpIpId: String, addressIp: String, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<AssociateDhcpIpWithAddressIpResponse> {
         self.associateDhcpIpWithAddressIp(.init(dhcpIpId: dhcpIpId, addressIp: addressIp), region: region, logger: logger, on: eventLoop)
@@ -85,8 +82,7 @@ extension Vpc {
     ///
     /// 本接口（AssociateDhcpIpWithAddressIp）用于DhcpIp绑定弹性公网IP（EIP）。
     ///
-    /// - Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
-    /// >
+    /// > Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
     @inlinable @discardableResult
     public func associateDhcpIpWithAddressIp(dhcpIpId: String, addressIp: String, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> AssociateDhcpIpWithAddressIpResponse {
         try await self.associateDhcpIpWithAddressIp(.init(dhcpIpId: dhcpIpId, addressIp: addressIp), region: region, logger: logger, on: eventLoop)

--- a/Sources/Teco/Vpc/V20170312/actions/AssociateDhcpIpWithAddressIp.swift
+++ b/Sources/Teco/Vpc/V20170312/actions/AssociateDhcpIpWithAddressIp.swift
@@ -52,7 +52,7 @@ extension Vpc {
     ///
     /// 本接口（AssociateDhcpIpWithAddressIp）用于DhcpIp绑定弹性公网IP（EIP）。
     ///
-    /// > Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
+    /// > Important: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
     @inlinable @discardableResult
     public func associateDhcpIpWithAddressIp(_ input: AssociateDhcpIpWithAddressIpRequest, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<AssociateDhcpIpWithAddressIpResponse> {
         self.client.execute(action: "AssociateDhcpIpWithAddressIp", region: region, serviceConfig: self.config, input: input, logger: logger, on: eventLoop)
@@ -62,7 +62,7 @@ extension Vpc {
     ///
     /// 本接口（AssociateDhcpIpWithAddressIp）用于DhcpIp绑定弹性公网IP（EIP）。
     ///
-    /// > Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
+    /// > Important: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
     @inlinable @discardableResult
     public func associateDhcpIpWithAddressIp(_ input: AssociateDhcpIpWithAddressIpRequest, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> AssociateDhcpIpWithAddressIpResponse {
         try await self.client.execute(action: "AssociateDhcpIpWithAddressIp", region: region, serviceConfig: self.config, input: input, logger: logger, on: eventLoop).get()
@@ -72,7 +72,7 @@ extension Vpc {
     ///
     /// 本接口（AssociateDhcpIpWithAddressIp）用于DhcpIp绑定弹性公网IP（EIP）。
     ///
-    /// > Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
+    /// > Important: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
     @inlinable @discardableResult
     public func associateDhcpIpWithAddressIp(dhcpIpId: String, addressIp: String, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<AssociateDhcpIpWithAddressIpResponse> {
         self.associateDhcpIpWithAddressIp(.init(dhcpIpId: dhcpIpId, addressIp: addressIp), region: region, logger: logger, on: eventLoop)
@@ -82,7 +82,7 @@ extension Vpc {
     ///
     /// 本接口（AssociateDhcpIpWithAddressIp）用于DhcpIp绑定弹性公网IP（EIP）。
     ///
-    /// > Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
+    /// > Important: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
     @inlinable @discardableResult
     public func associateDhcpIpWithAddressIp(dhcpIpId: String, addressIp: String, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> AssociateDhcpIpWithAddressIpResponse {
         try await self.associateDhcpIpWithAddressIp(.init(dhcpIpId: dhcpIpId, addressIp: addressIp), region: region, logger: logger, on: eventLoop)

--- a/Sources/Teco/Vpc/V20170312/actions/AttachClassicLinkVpc.swift
+++ b/Sources/Teco/Vpc/V20170312/actions/AttachClassicLinkVpc.swift
@@ -53,7 +53,7 @@ extension Vpc {
     /// 本接口(AttachClassicLinkVpc)用于创建私有网络和基础网络设备互通。
     /// * 私有网络和基础网络设备必须在同一个地域。
     /// * 私有网络和基础网络的区别详见vpc产品文档-[私有网络与基础网络](https://cloud.tencent.com/document/product/215/30720)。
-    /// > Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
+    /// > Important: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
     @inlinable @discardableResult
     public func attachClassicLinkVpc(_ input: AttachClassicLinkVpcRequest, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<AttachClassicLinkVpcResponse> {
         self.client.execute(action: "AttachClassicLinkVpc", region: region, serviceConfig: self.config, input: input, logger: logger, on: eventLoop)
@@ -64,7 +64,7 @@ extension Vpc {
     /// 本接口(AttachClassicLinkVpc)用于创建私有网络和基础网络设备互通。
     /// * 私有网络和基础网络设备必须在同一个地域。
     /// * 私有网络和基础网络的区别详见vpc产品文档-[私有网络与基础网络](https://cloud.tencent.com/document/product/215/30720)。
-    /// > Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
+    /// > Important: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
     @inlinable @discardableResult
     public func attachClassicLinkVpc(_ input: AttachClassicLinkVpcRequest, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> AttachClassicLinkVpcResponse {
         try await self.client.execute(action: "AttachClassicLinkVpc", region: region, serviceConfig: self.config, input: input, logger: logger, on: eventLoop).get()
@@ -75,7 +75,7 @@ extension Vpc {
     /// 本接口(AttachClassicLinkVpc)用于创建私有网络和基础网络设备互通。
     /// * 私有网络和基础网络设备必须在同一个地域。
     /// * 私有网络和基础网络的区别详见vpc产品文档-[私有网络与基础网络](https://cloud.tencent.com/document/product/215/30720)。
-    /// > Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
+    /// > Important: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
     @inlinable @discardableResult
     public func attachClassicLinkVpc(vpcId: String, instanceIds: [String], region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<AttachClassicLinkVpcResponse> {
         self.attachClassicLinkVpc(.init(vpcId: vpcId, instanceIds: instanceIds), region: region, logger: logger, on: eventLoop)
@@ -86,7 +86,7 @@ extension Vpc {
     /// 本接口(AttachClassicLinkVpc)用于创建私有网络和基础网络设备互通。
     /// * 私有网络和基础网络设备必须在同一个地域。
     /// * 私有网络和基础网络的区别详见vpc产品文档-[私有网络与基础网络](https://cloud.tencent.com/document/product/215/30720)。
-    /// > Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
+    /// > Important: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
     @inlinable @discardableResult
     public func attachClassicLinkVpc(vpcId: String, instanceIds: [String], region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> AttachClassicLinkVpcResponse {
         try await self.attachClassicLinkVpc(.init(vpcId: vpcId, instanceIds: instanceIds), region: region, logger: logger, on: eventLoop)

--- a/Sources/Teco/Vpc/V20170312/actions/AttachClassicLinkVpc.swift
+++ b/Sources/Teco/Vpc/V20170312/actions/AttachClassicLinkVpc.swift
@@ -53,8 +53,7 @@ extension Vpc {
     /// 本接口(AttachClassicLinkVpc)用于创建私有网络和基础网络设备互通。
     /// * 私有网络和基础网络设备必须在同一个地域。
     /// * 私有网络和基础网络的区别详见vpc产品文档-[私有网络与基础网络](https://cloud.tencent.com/document/product/215/30720)。
-    /// - Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
-    /// >
+    /// > Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
     @inlinable @discardableResult
     public func attachClassicLinkVpc(_ input: AttachClassicLinkVpcRequest, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<AttachClassicLinkVpcResponse> {
         self.client.execute(action: "AttachClassicLinkVpc", region: region, serviceConfig: self.config, input: input, logger: logger, on: eventLoop)
@@ -65,8 +64,7 @@ extension Vpc {
     /// 本接口(AttachClassicLinkVpc)用于创建私有网络和基础网络设备互通。
     /// * 私有网络和基础网络设备必须在同一个地域。
     /// * 私有网络和基础网络的区别详见vpc产品文档-[私有网络与基础网络](https://cloud.tencent.com/document/product/215/30720)。
-    /// - Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
-    /// >
+    /// > Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
     @inlinable @discardableResult
     public func attachClassicLinkVpc(_ input: AttachClassicLinkVpcRequest, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> AttachClassicLinkVpcResponse {
         try await self.client.execute(action: "AttachClassicLinkVpc", region: region, serviceConfig: self.config, input: input, logger: logger, on: eventLoop).get()
@@ -77,8 +75,7 @@ extension Vpc {
     /// 本接口(AttachClassicLinkVpc)用于创建私有网络和基础网络设备互通。
     /// * 私有网络和基础网络设备必须在同一个地域。
     /// * 私有网络和基础网络的区别详见vpc产品文档-[私有网络与基础网络](https://cloud.tencent.com/document/product/215/30720)。
-    /// - Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
-    /// >
+    /// > Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
     @inlinable @discardableResult
     public func attachClassicLinkVpc(vpcId: String, instanceIds: [String], region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<AttachClassicLinkVpcResponse> {
         self.attachClassicLinkVpc(.init(vpcId: vpcId, instanceIds: instanceIds), region: region, logger: logger, on: eventLoop)
@@ -89,8 +86,7 @@ extension Vpc {
     /// 本接口(AttachClassicLinkVpc)用于创建私有网络和基础网络设备互通。
     /// * 私有网络和基础网络设备必须在同一个地域。
     /// * 私有网络和基础网络的区别详见vpc产品文档-[私有网络与基础网络](https://cloud.tencent.com/document/product/215/30720)。
-    /// - Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
-    /// >
+    /// > Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
     @inlinable @discardableResult
     public func attachClassicLinkVpc(vpcId: String, instanceIds: [String], region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> AttachClassicLinkVpcResponse {
         try await self.attachClassicLinkVpc(.init(vpcId: vpcId, instanceIds: instanceIds), region: region, logger: logger, on: eventLoop)

--- a/Sources/Teco/Vpc/V20170312/actions/CreateAndAttachNetworkInterface.swift
+++ b/Sources/Teco/Vpc/V20170312/actions/CreateAndAttachNetworkInterface.swift
@@ -105,7 +105,7 @@ extension Vpc {
     /// * 一个弹性网卡支持绑定的IP地址是有限制的，更多资源限制信息详见[弹性网卡使用限制](/document/product/576/18527)。
     /// * 创建弹性网卡同时可以绑定已有安全组。
     /// * 创建弹性网卡同时可以绑定标签, 应答里的标签列表代表添加成功的标签。
-    /// > Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
+    /// > Important: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
     @inlinable
     public func createAndAttachNetworkInterface(_ input: CreateAndAttachNetworkInterfaceRequest, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<CreateAndAttachNetworkInterfaceResponse> {
         self.client.execute(action: "CreateAndAttachNetworkInterface", region: region, serviceConfig: self.config, input: input, logger: logger, on: eventLoop)
@@ -119,7 +119,7 @@ extension Vpc {
     /// * 一个弹性网卡支持绑定的IP地址是有限制的，更多资源限制信息详见[弹性网卡使用限制](/document/product/576/18527)。
     /// * 创建弹性网卡同时可以绑定已有安全组。
     /// * 创建弹性网卡同时可以绑定标签, 应答里的标签列表代表添加成功的标签。
-    /// > Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
+    /// > Important: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
     @inlinable
     public func createAndAttachNetworkInterface(_ input: CreateAndAttachNetworkInterfaceRequest, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> CreateAndAttachNetworkInterfaceResponse {
         try await self.client.execute(action: "CreateAndAttachNetworkInterface", region: region, serviceConfig: self.config, input: input, logger: logger, on: eventLoop).get()
@@ -133,7 +133,7 @@ extension Vpc {
     /// * 一个弹性网卡支持绑定的IP地址是有限制的，更多资源限制信息详见[弹性网卡使用限制](/document/product/576/18527)。
     /// * 创建弹性网卡同时可以绑定已有安全组。
     /// * 创建弹性网卡同时可以绑定标签, 应答里的标签列表代表添加成功的标签。
-    /// > Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
+    /// > Important: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
     @inlinable
     public func createAndAttachNetworkInterface(vpcId: String, networkInterfaceName: String, subnetId: String, instanceId: String, privateIpAddresses: [PrivateIpAddressSpecification]? = nil, secondaryPrivateIpAddressCount: UInt64? = nil, qosLevel: String? = nil, securityGroupIds: [String]? = nil, networkInterfaceDescription: String? = nil, tags: [Tag]? = nil, attachType: UInt64? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<CreateAndAttachNetworkInterfaceResponse> {
         self.createAndAttachNetworkInterface(.init(vpcId: vpcId, networkInterfaceName: networkInterfaceName, subnetId: subnetId, instanceId: instanceId, privateIpAddresses: privateIpAddresses, secondaryPrivateIpAddressCount: secondaryPrivateIpAddressCount, qosLevel: qosLevel, securityGroupIds: securityGroupIds, networkInterfaceDescription: networkInterfaceDescription, tags: tags, attachType: attachType), region: region, logger: logger, on: eventLoop)
@@ -147,7 +147,7 @@ extension Vpc {
     /// * 一个弹性网卡支持绑定的IP地址是有限制的，更多资源限制信息详见[弹性网卡使用限制](/document/product/576/18527)。
     /// * 创建弹性网卡同时可以绑定已有安全组。
     /// * 创建弹性网卡同时可以绑定标签, 应答里的标签列表代表添加成功的标签。
-    /// > Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
+    /// > Important: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
     @inlinable
     public func createAndAttachNetworkInterface(vpcId: String, networkInterfaceName: String, subnetId: String, instanceId: String, privateIpAddresses: [PrivateIpAddressSpecification]? = nil, secondaryPrivateIpAddressCount: UInt64? = nil, qosLevel: String? = nil, securityGroupIds: [String]? = nil, networkInterfaceDescription: String? = nil, tags: [Tag]? = nil, attachType: UInt64? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> CreateAndAttachNetworkInterfaceResponse {
         try await self.createAndAttachNetworkInterface(.init(vpcId: vpcId, networkInterfaceName: networkInterfaceName, subnetId: subnetId, instanceId: instanceId, privateIpAddresses: privateIpAddresses, secondaryPrivateIpAddressCount: secondaryPrivateIpAddressCount, qosLevel: qosLevel, securityGroupIds: securityGroupIds, networkInterfaceDescription: networkInterfaceDescription, tags: tags, attachType: attachType), region: region, logger: logger, on: eventLoop)

--- a/Sources/Teco/Vpc/V20170312/actions/CreateAndAttachNetworkInterface.swift
+++ b/Sources/Teco/Vpc/V20170312/actions/CreateAndAttachNetworkInterface.swift
@@ -105,8 +105,7 @@ extension Vpc {
     /// * 一个弹性网卡支持绑定的IP地址是有限制的，更多资源限制信息详见[弹性网卡使用限制](/document/product/576/18527)。
     /// * 创建弹性网卡同时可以绑定已有安全组。
     /// * 创建弹性网卡同时可以绑定标签, 应答里的标签列表代表添加成功的标签。
-    /// - Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
-    /// >
+    /// > Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
     @inlinable
     public func createAndAttachNetworkInterface(_ input: CreateAndAttachNetworkInterfaceRequest, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<CreateAndAttachNetworkInterfaceResponse> {
         self.client.execute(action: "CreateAndAttachNetworkInterface", region: region, serviceConfig: self.config, input: input, logger: logger, on: eventLoop)
@@ -120,8 +119,7 @@ extension Vpc {
     /// * 一个弹性网卡支持绑定的IP地址是有限制的，更多资源限制信息详见[弹性网卡使用限制](/document/product/576/18527)。
     /// * 创建弹性网卡同时可以绑定已有安全组。
     /// * 创建弹性网卡同时可以绑定标签, 应答里的标签列表代表添加成功的标签。
-    /// - Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
-    /// >
+    /// > Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
     @inlinable
     public func createAndAttachNetworkInterface(_ input: CreateAndAttachNetworkInterfaceRequest, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> CreateAndAttachNetworkInterfaceResponse {
         try await self.client.execute(action: "CreateAndAttachNetworkInterface", region: region, serviceConfig: self.config, input: input, logger: logger, on: eventLoop).get()
@@ -135,8 +133,7 @@ extension Vpc {
     /// * 一个弹性网卡支持绑定的IP地址是有限制的，更多资源限制信息详见[弹性网卡使用限制](/document/product/576/18527)。
     /// * 创建弹性网卡同时可以绑定已有安全组。
     /// * 创建弹性网卡同时可以绑定标签, 应答里的标签列表代表添加成功的标签。
-    /// - Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
-    /// >
+    /// > Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
     @inlinable
     public func createAndAttachNetworkInterface(vpcId: String, networkInterfaceName: String, subnetId: String, instanceId: String, privateIpAddresses: [PrivateIpAddressSpecification]? = nil, secondaryPrivateIpAddressCount: UInt64? = nil, qosLevel: String? = nil, securityGroupIds: [String]? = nil, networkInterfaceDescription: String? = nil, tags: [Tag]? = nil, attachType: UInt64? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<CreateAndAttachNetworkInterfaceResponse> {
         self.createAndAttachNetworkInterface(.init(vpcId: vpcId, networkInterfaceName: networkInterfaceName, subnetId: subnetId, instanceId: instanceId, privateIpAddresses: privateIpAddresses, secondaryPrivateIpAddressCount: secondaryPrivateIpAddressCount, qosLevel: qosLevel, securityGroupIds: securityGroupIds, networkInterfaceDescription: networkInterfaceDescription, tags: tags, attachType: attachType), region: region, logger: logger, on: eventLoop)
@@ -150,8 +147,7 @@ extension Vpc {
     /// * 一个弹性网卡支持绑定的IP地址是有限制的，更多资源限制信息详见[弹性网卡使用限制](/document/product/576/18527)。
     /// * 创建弹性网卡同时可以绑定已有安全组。
     /// * 创建弹性网卡同时可以绑定标签, 应答里的标签列表代表添加成功的标签。
-    /// - Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
-    /// >
+    /// > Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
     @inlinable
     public func createAndAttachNetworkInterface(vpcId: String, networkInterfaceName: String, subnetId: String, instanceId: String, privateIpAddresses: [PrivateIpAddressSpecification]? = nil, secondaryPrivateIpAddressCount: UInt64? = nil, qosLevel: String? = nil, securityGroupIds: [String]? = nil, networkInterfaceDescription: String? = nil, tags: [Tag]? = nil, attachType: UInt64? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> CreateAndAttachNetworkInterfaceResponse {
         try await self.createAndAttachNetworkInterface(.init(vpcId: vpcId, networkInterfaceName: networkInterfaceName, subnetId: subnetId, instanceId: instanceId, privateIpAddresses: privateIpAddresses, secondaryPrivateIpAddressCount: secondaryPrivateIpAddressCount, qosLevel: qosLevel, securityGroupIds: securityGroupIds, networkInterfaceDescription: networkInterfaceDescription, tags: tags, attachType: attachType), region: region, logger: logger, on: eventLoop)

--- a/Sources/Teco/Vpc/V20170312/actions/CreateNetworkInterface.swift
+++ b/Sources/Teco/Vpc/V20170312/actions/CreateNetworkInterface.swift
@@ -100,8 +100,7 @@ extension Vpc {
     /// * 一个弹性网卡支持绑定的IP地址是有限制的，更多资源限制信息详见[弹性网卡使用限制](/document/product/576/18527)。
     /// * 创建弹性网卡同时可以绑定已有安全组。
     /// * 创建弹性网卡同时可以绑定标签, 应答里的标签列表代表添加成功的标签。
-    /// - Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
-    /// >
+    /// > Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
     @inlinable
     public func createNetworkInterface(_ input: CreateNetworkInterfaceRequest, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<CreateNetworkInterfaceResponse> {
         self.client.execute(action: "CreateNetworkInterface", region: region, serviceConfig: self.config, input: input, logger: logger, on: eventLoop)
@@ -115,8 +114,7 @@ extension Vpc {
     /// * 一个弹性网卡支持绑定的IP地址是有限制的，更多资源限制信息详见[弹性网卡使用限制](/document/product/576/18527)。
     /// * 创建弹性网卡同时可以绑定已有安全组。
     /// * 创建弹性网卡同时可以绑定标签, 应答里的标签列表代表添加成功的标签。
-    /// - Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
-    /// >
+    /// > Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
     @inlinable
     public func createNetworkInterface(_ input: CreateNetworkInterfaceRequest, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> CreateNetworkInterfaceResponse {
         try await self.client.execute(action: "CreateNetworkInterface", region: region, serviceConfig: self.config, input: input, logger: logger, on: eventLoop).get()
@@ -130,8 +128,7 @@ extension Vpc {
     /// * 一个弹性网卡支持绑定的IP地址是有限制的，更多资源限制信息详见[弹性网卡使用限制](/document/product/576/18527)。
     /// * 创建弹性网卡同时可以绑定已有安全组。
     /// * 创建弹性网卡同时可以绑定标签, 应答里的标签列表代表添加成功的标签。
-    /// - Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
-    /// >
+    /// > Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
     @inlinable
     public func createNetworkInterface(vpcId: String, networkInterfaceName: String, subnetId: String, networkInterfaceDescription: String? = nil, secondaryPrivateIpAddressCount: UInt64? = nil, qosLevel: String? = nil, securityGroupIds: [String]? = nil, privateIpAddresses: [PrivateIpAddressSpecification]? = nil, tags: [Tag]? = nil, trunkingFlag: String? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<CreateNetworkInterfaceResponse> {
         self.createNetworkInterface(.init(vpcId: vpcId, networkInterfaceName: networkInterfaceName, subnetId: subnetId, networkInterfaceDescription: networkInterfaceDescription, secondaryPrivateIpAddressCount: secondaryPrivateIpAddressCount, qosLevel: qosLevel, securityGroupIds: securityGroupIds, privateIpAddresses: privateIpAddresses, tags: tags, trunkingFlag: trunkingFlag), region: region, logger: logger, on: eventLoop)
@@ -145,8 +142,7 @@ extension Vpc {
     /// * 一个弹性网卡支持绑定的IP地址是有限制的，更多资源限制信息详见[弹性网卡使用限制](/document/product/576/18527)。
     /// * 创建弹性网卡同时可以绑定已有安全组。
     /// * 创建弹性网卡同时可以绑定标签, 应答里的标签列表代表添加成功的标签。
-    /// - Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
-    /// >
+    /// > Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
     @inlinable
     public func createNetworkInterface(vpcId: String, networkInterfaceName: String, subnetId: String, networkInterfaceDescription: String? = nil, secondaryPrivateIpAddressCount: UInt64? = nil, qosLevel: String? = nil, securityGroupIds: [String]? = nil, privateIpAddresses: [PrivateIpAddressSpecification]? = nil, tags: [Tag]? = nil, trunkingFlag: String? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> CreateNetworkInterfaceResponse {
         try await self.createNetworkInterface(.init(vpcId: vpcId, networkInterfaceName: networkInterfaceName, subnetId: subnetId, networkInterfaceDescription: networkInterfaceDescription, secondaryPrivateIpAddressCount: secondaryPrivateIpAddressCount, qosLevel: qosLevel, securityGroupIds: securityGroupIds, privateIpAddresses: privateIpAddresses, tags: tags, trunkingFlag: trunkingFlag), region: region, logger: logger, on: eventLoop)

--- a/Sources/Teco/Vpc/V20170312/actions/CreateNetworkInterface.swift
+++ b/Sources/Teco/Vpc/V20170312/actions/CreateNetworkInterface.swift
@@ -100,7 +100,7 @@ extension Vpc {
     /// * 一个弹性网卡支持绑定的IP地址是有限制的，更多资源限制信息详见[弹性网卡使用限制](/document/product/576/18527)。
     /// * 创建弹性网卡同时可以绑定已有安全组。
     /// * 创建弹性网卡同时可以绑定标签, 应答里的标签列表代表添加成功的标签。
-    /// > Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
+    /// > Important: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
     @inlinable
     public func createNetworkInterface(_ input: CreateNetworkInterfaceRequest, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<CreateNetworkInterfaceResponse> {
         self.client.execute(action: "CreateNetworkInterface", region: region, serviceConfig: self.config, input: input, logger: logger, on: eventLoop)
@@ -114,7 +114,7 @@ extension Vpc {
     /// * 一个弹性网卡支持绑定的IP地址是有限制的，更多资源限制信息详见[弹性网卡使用限制](/document/product/576/18527)。
     /// * 创建弹性网卡同时可以绑定已有安全组。
     /// * 创建弹性网卡同时可以绑定标签, 应答里的标签列表代表添加成功的标签。
-    /// > Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
+    /// > Important: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
     @inlinable
     public func createNetworkInterface(_ input: CreateNetworkInterfaceRequest, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> CreateNetworkInterfaceResponse {
         try await self.client.execute(action: "CreateNetworkInterface", region: region, serviceConfig: self.config, input: input, logger: logger, on: eventLoop).get()
@@ -128,7 +128,7 @@ extension Vpc {
     /// * 一个弹性网卡支持绑定的IP地址是有限制的，更多资源限制信息详见[弹性网卡使用限制](/document/product/576/18527)。
     /// * 创建弹性网卡同时可以绑定已有安全组。
     /// * 创建弹性网卡同时可以绑定标签, 应答里的标签列表代表添加成功的标签。
-    /// > Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
+    /// > Important: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
     @inlinable
     public func createNetworkInterface(vpcId: String, networkInterfaceName: String, subnetId: String, networkInterfaceDescription: String? = nil, secondaryPrivateIpAddressCount: UInt64? = nil, qosLevel: String? = nil, securityGroupIds: [String]? = nil, privateIpAddresses: [PrivateIpAddressSpecification]? = nil, tags: [Tag]? = nil, trunkingFlag: String? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<CreateNetworkInterfaceResponse> {
         self.createNetworkInterface(.init(vpcId: vpcId, networkInterfaceName: networkInterfaceName, subnetId: subnetId, networkInterfaceDescription: networkInterfaceDescription, secondaryPrivateIpAddressCount: secondaryPrivateIpAddressCount, qosLevel: qosLevel, securityGroupIds: securityGroupIds, privateIpAddresses: privateIpAddresses, tags: tags, trunkingFlag: trunkingFlag), region: region, logger: logger, on: eventLoop)
@@ -142,7 +142,7 @@ extension Vpc {
     /// * 一个弹性网卡支持绑定的IP地址是有限制的，更多资源限制信息详见[弹性网卡使用限制](/document/product/576/18527)。
     /// * 创建弹性网卡同时可以绑定已有安全组。
     /// * 创建弹性网卡同时可以绑定标签, 应答里的标签列表代表添加成功的标签。
-    /// > Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
+    /// > Important: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
     @inlinable
     public func createNetworkInterface(vpcId: String, networkInterfaceName: String, subnetId: String, networkInterfaceDescription: String? = nil, secondaryPrivateIpAddressCount: UInt64? = nil, qosLevel: String? = nil, securityGroupIds: [String]? = nil, privateIpAddresses: [PrivateIpAddressSpecification]? = nil, tags: [Tag]? = nil, trunkingFlag: String? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> CreateNetworkInterfaceResponse {
         try await self.createNetworkInterface(.init(vpcId: vpcId, networkInterfaceName: networkInterfaceName, subnetId: subnetId, networkInterfaceDescription: networkInterfaceDescription, secondaryPrivateIpAddressCount: secondaryPrivateIpAddressCount, qosLevel: qosLevel, securityGroupIds: securityGroupIds, privateIpAddresses: privateIpAddresses, tags: tags, trunkingFlag: trunkingFlag), region: region, logger: logger, on: eventLoop)

--- a/Sources/Teco/Vpc/V20170312/actions/CreateVpnConnection.swift
+++ b/Sources/Teco/Vpc/V20170312/actions/CreateVpnConnection.swift
@@ -131,7 +131,7 @@ extension Vpc {
     /// 创建VPN通道
     ///
     /// 本接口（CreateVpnConnection）用于创建VPN通道。
-    /// > Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
+    /// > Important: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
     @inlinable
     public func createVpnConnection(_ input: CreateVpnConnectionRequest, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<CreateVpnConnectionResponse> {
         self.client.execute(action: "CreateVpnConnection", region: region, serviceConfig: self.config, input: input, logger: logger, on: eventLoop)
@@ -140,7 +140,7 @@ extension Vpc {
     /// 创建VPN通道
     ///
     /// 本接口（CreateVpnConnection）用于创建VPN通道。
-    /// > Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
+    /// > Important: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
     @inlinable
     public func createVpnConnection(_ input: CreateVpnConnectionRequest, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> CreateVpnConnectionResponse {
         try await self.client.execute(action: "CreateVpnConnection", region: region, serviceConfig: self.config, input: input, logger: logger, on: eventLoop).get()
@@ -149,7 +149,7 @@ extension Vpc {
     /// 创建VPN通道
     ///
     /// 本接口（CreateVpnConnection）用于创建VPN通道。
-    /// > Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
+    /// > Important: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
     @inlinable
     public func createVpnConnection(vpnGatewayId: String, customerGatewayId: String, vpnConnectionName: String, preShareKey: String, vpcId: String? = nil, securityPolicyDatabases: [SecurityPolicyDatabase]? = nil, ikeOptionsSpecification: IKEOptionsSpecification? = nil, ipsecOptionsSpecification: IPSECOptionsSpecification? = nil, tags: [Tag]? = nil, enableHealthCheck: Bool? = nil, healthCheckLocalIp: String? = nil, healthCheckRemoteIp: String? = nil, routeType: String? = nil, negotiationType: String? = nil, dpdEnable: Int64? = nil, dpdTimeout: String? = nil, dpdAction: String? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<CreateVpnConnectionResponse> {
         self.createVpnConnection(.init(vpnGatewayId: vpnGatewayId, customerGatewayId: customerGatewayId, vpnConnectionName: vpnConnectionName, preShareKey: preShareKey, vpcId: vpcId, securityPolicyDatabases: securityPolicyDatabases, ikeOptionsSpecification: ikeOptionsSpecification, ipsecOptionsSpecification: ipsecOptionsSpecification, tags: tags, enableHealthCheck: enableHealthCheck, healthCheckLocalIp: healthCheckLocalIp, healthCheckRemoteIp: healthCheckRemoteIp, routeType: routeType, negotiationType: negotiationType, dpdEnable: dpdEnable, dpdTimeout: dpdTimeout, dpdAction: dpdAction), region: region, logger: logger, on: eventLoop)
@@ -158,7 +158,7 @@ extension Vpc {
     /// 创建VPN通道
     ///
     /// 本接口（CreateVpnConnection）用于创建VPN通道。
-    /// > Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
+    /// > Important: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
     @inlinable
     public func createVpnConnection(vpnGatewayId: String, customerGatewayId: String, vpnConnectionName: String, preShareKey: String, vpcId: String? = nil, securityPolicyDatabases: [SecurityPolicyDatabase]? = nil, ikeOptionsSpecification: IKEOptionsSpecification? = nil, ipsecOptionsSpecification: IPSECOptionsSpecification? = nil, tags: [Tag]? = nil, enableHealthCheck: Bool? = nil, healthCheckLocalIp: String? = nil, healthCheckRemoteIp: String? = nil, routeType: String? = nil, negotiationType: String? = nil, dpdEnable: Int64? = nil, dpdTimeout: String? = nil, dpdAction: String? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> CreateVpnConnectionResponse {
         try await self.createVpnConnection(.init(vpnGatewayId: vpnGatewayId, customerGatewayId: customerGatewayId, vpnConnectionName: vpnConnectionName, preShareKey: preShareKey, vpcId: vpcId, securityPolicyDatabases: securityPolicyDatabases, ikeOptionsSpecification: ikeOptionsSpecification, ipsecOptionsSpecification: ipsecOptionsSpecification, tags: tags, enableHealthCheck: enableHealthCheck, healthCheckLocalIp: healthCheckLocalIp, healthCheckRemoteIp: healthCheckRemoteIp, routeType: routeType, negotiationType: negotiationType, dpdEnable: dpdEnable, dpdTimeout: dpdTimeout, dpdAction: dpdAction), region: region, logger: logger, on: eventLoop)

--- a/Sources/Teco/Vpc/V20170312/actions/CreateVpnConnection.swift
+++ b/Sources/Teco/Vpc/V20170312/actions/CreateVpnConnection.swift
@@ -131,8 +131,7 @@ extension Vpc {
     /// 创建VPN通道
     ///
     /// 本接口（CreateVpnConnection）用于创建VPN通道。
-    /// - Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
-    /// >
+    /// > Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
     @inlinable
     public func createVpnConnection(_ input: CreateVpnConnectionRequest, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<CreateVpnConnectionResponse> {
         self.client.execute(action: "CreateVpnConnection", region: region, serviceConfig: self.config, input: input, logger: logger, on: eventLoop)
@@ -141,8 +140,7 @@ extension Vpc {
     /// 创建VPN通道
     ///
     /// 本接口（CreateVpnConnection）用于创建VPN通道。
-    /// - Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
-    /// >
+    /// > Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
     @inlinable
     public func createVpnConnection(_ input: CreateVpnConnectionRequest, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> CreateVpnConnectionResponse {
         try await self.client.execute(action: "CreateVpnConnection", region: region, serviceConfig: self.config, input: input, logger: logger, on: eventLoop).get()
@@ -151,8 +149,7 @@ extension Vpc {
     /// 创建VPN通道
     ///
     /// 本接口（CreateVpnConnection）用于创建VPN通道。
-    /// - Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
-    /// >
+    /// > Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
     @inlinable
     public func createVpnConnection(vpnGatewayId: String, customerGatewayId: String, vpnConnectionName: String, preShareKey: String, vpcId: String? = nil, securityPolicyDatabases: [SecurityPolicyDatabase]? = nil, ikeOptionsSpecification: IKEOptionsSpecification? = nil, ipsecOptionsSpecification: IPSECOptionsSpecification? = nil, tags: [Tag]? = nil, enableHealthCheck: Bool? = nil, healthCheckLocalIp: String? = nil, healthCheckRemoteIp: String? = nil, routeType: String? = nil, negotiationType: String? = nil, dpdEnable: Int64? = nil, dpdTimeout: String? = nil, dpdAction: String? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<CreateVpnConnectionResponse> {
         self.createVpnConnection(.init(vpnGatewayId: vpnGatewayId, customerGatewayId: customerGatewayId, vpnConnectionName: vpnConnectionName, preShareKey: preShareKey, vpcId: vpcId, securityPolicyDatabases: securityPolicyDatabases, ikeOptionsSpecification: ikeOptionsSpecification, ipsecOptionsSpecification: ipsecOptionsSpecification, tags: tags, enableHealthCheck: enableHealthCheck, healthCheckLocalIp: healthCheckLocalIp, healthCheckRemoteIp: healthCheckRemoteIp, routeType: routeType, negotiationType: negotiationType, dpdEnable: dpdEnable, dpdTimeout: dpdTimeout, dpdAction: dpdAction), region: region, logger: logger, on: eventLoop)
@@ -161,8 +158,7 @@ extension Vpc {
     /// 创建VPN通道
     ///
     /// 本接口（CreateVpnConnection）用于创建VPN通道。
-    /// - Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
-    /// >
+    /// > Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
     @inlinable
     public func createVpnConnection(vpnGatewayId: String, customerGatewayId: String, vpnConnectionName: String, preShareKey: String, vpcId: String? = nil, securityPolicyDatabases: [SecurityPolicyDatabase]? = nil, ikeOptionsSpecification: IKEOptionsSpecification? = nil, ipsecOptionsSpecification: IPSECOptionsSpecification? = nil, tags: [Tag]? = nil, enableHealthCheck: Bool? = nil, healthCheckLocalIp: String? = nil, healthCheckRemoteIp: String? = nil, routeType: String? = nil, negotiationType: String? = nil, dpdEnable: Int64? = nil, dpdTimeout: String? = nil, dpdAction: String? = nil, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> CreateVpnConnectionResponse {
         try await self.createVpnConnection(.init(vpnGatewayId: vpnGatewayId, customerGatewayId: customerGatewayId, vpnConnectionName: vpnConnectionName, preShareKey: preShareKey, vpcId: vpcId, securityPolicyDatabases: securityPolicyDatabases, ikeOptionsSpecification: ikeOptionsSpecification, ipsecOptionsSpecification: ipsecOptionsSpecification, tags: tags, enableHealthCheck: enableHealthCheck, healthCheckLocalIp: healthCheckLocalIp, healthCheckRemoteIp: healthCheckRemoteIp, routeType: routeType, negotiationType: negotiationType, dpdEnable: dpdEnable, dpdTimeout: dpdTimeout, dpdAction: dpdAction), region: region, logger: logger, on: eventLoop)

--- a/Sources/Teco/Vpc/V20170312/actions/DeleteDhcpIp.swift
+++ b/Sources/Teco/Vpc/V20170312/actions/DeleteDhcpIp.swift
@@ -46,8 +46,7 @@ extension Vpc {
     /// 删除DhcpIp
     ///
     /// 本接口（DeleteDhcpIp）用于删除DhcpIp。
-    /// - Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
-    /// >
+    /// > Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
     @inlinable @discardableResult
     public func deleteDhcpIp(_ input: DeleteDhcpIpRequest, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<DeleteDhcpIpResponse> {
         self.client.execute(action: "DeleteDhcpIp", region: region, serviceConfig: self.config, input: input, logger: logger, on: eventLoop)
@@ -56,8 +55,7 @@ extension Vpc {
     /// 删除DhcpIp
     ///
     /// 本接口（DeleteDhcpIp）用于删除DhcpIp。
-    /// - Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
-    /// >
+    /// > Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
     @inlinable @discardableResult
     public func deleteDhcpIp(_ input: DeleteDhcpIpRequest, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> DeleteDhcpIpResponse {
         try await self.client.execute(action: "DeleteDhcpIp", region: region, serviceConfig: self.config, input: input, logger: logger, on: eventLoop).get()
@@ -66,8 +64,7 @@ extension Vpc {
     /// 删除DhcpIp
     ///
     /// 本接口（DeleteDhcpIp）用于删除DhcpIp。
-    /// - Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
-    /// >
+    /// > Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
     @inlinable @discardableResult
     public func deleteDhcpIp(dhcpIpId: String, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<DeleteDhcpIpResponse> {
         self.deleteDhcpIp(.init(dhcpIpId: dhcpIpId), region: region, logger: logger, on: eventLoop)
@@ -76,8 +73,7 @@ extension Vpc {
     /// 删除DhcpIp
     ///
     /// 本接口（DeleteDhcpIp）用于删除DhcpIp。
-    /// - Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
-    /// >
+    /// > Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
     @inlinable @discardableResult
     public func deleteDhcpIp(dhcpIpId: String, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> DeleteDhcpIpResponse {
         try await self.deleteDhcpIp(.init(dhcpIpId: dhcpIpId), region: region, logger: logger, on: eventLoop)

--- a/Sources/Teco/Vpc/V20170312/actions/DeleteDhcpIp.swift
+++ b/Sources/Teco/Vpc/V20170312/actions/DeleteDhcpIp.swift
@@ -46,7 +46,7 @@ extension Vpc {
     /// 删除DhcpIp
     ///
     /// 本接口（DeleteDhcpIp）用于删除DhcpIp。
-    /// > Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
+    /// > Important: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
     @inlinable @discardableResult
     public func deleteDhcpIp(_ input: DeleteDhcpIpRequest, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<DeleteDhcpIpResponse> {
         self.client.execute(action: "DeleteDhcpIp", region: region, serviceConfig: self.config, input: input, logger: logger, on: eventLoop)
@@ -55,7 +55,7 @@ extension Vpc {
     /// 删除DhcpIp
     ///
     /// 本接口（DeleteDhcpIp）用于删除DhcpIp。
-    /// > Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
+    /// > Important: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
     @inlinable @discardableResult
     public func deleteDhcpIp(_ input: DeleteDhcpIpRequest, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> DeleteDhcpIpResponse {
         try await self.client.execute(action: "DeleteDhcpIp", region: region, serviceConfig: self.config, input: input, logger: logger, on: eventLoop).get()
@@ -64,7 +64,7 @@ extension Vpc {
     /// 删除DhcpIp
     ///
     /// 本接口（DeleteDhcpIp）用于删除DhcpIp。
-    /// > Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
+    /// > Important: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
     @inlinable @discardableResult
     public func deleteDhcpIp(dhcpIpId: String, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<DeleteDhcpIpResponse> {
         self.deleteDhcpIp(.init(dhcpIpId: dhcpIpId), region: region, logger: logger, on: eventLoop)
@@ -73,7 +73,7 @@ extension Vpc {
     /// 删除DhcpIp
     ///
     /// 本接口（DeleteDhcpIp）用于删除DhcpIp。
-    /// > Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
+    /// > Important: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
     @inlinable @discardableResult
     public func deleteDhcpIp(dhcpIpId: String, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> DeleteDhcpIpResponse {
         try await self.deleteDhcpIp(.init(dhcpIpId: dhcpIpId), region: region, logger: logger, on: eventLoop)

--- a/Sources/Teco/Vpc/V20170312/actions/DetachClassicLinkVpc.swift
+++ b/Sources/Teco/Vpc/V20170312/actions/DetachClassicLinkVpc.swift
@@ -51,7 +51,7 @@ extension Vpc {
     /// 删除基础网络互通
     ///
     /// 本接口(DetachClassicLinkVpc)用于删除私有网络和基础网络设备互通。
-    /// > Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
+    /// > Important: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
     @inlinable @discardableResult
     public func detachClassicLinkVpc(_ input: DetachClassicLinkVpcRequest, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<DetachClassicLinkVpcResponse> {
         self.client.execute(action: "DetachClassicLinkVpc", region: region, serviceConfig: self.config, input: input, logger: logger, on: eventLoop)
@@ -60,7 +60,7 @@ extension Vpc {
     /// 删除基础网络互通
     ///
     /// 本接口(DetachClassicLinkVpc)用于删除私有网络和基础网络设备互通。
-    /// > Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
+    /// > Important: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
     @inlinable @discardableResult
     public func detachClassicLinkVpc(_ input: DetachClassicLinkVpcRequest, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> DetachClassicLinkVpcResponse {
         try await self.client.execute(action: "DetachClassicLinkVpc", region: region, serviceConfig: self.config, input: input, logger: logger, on: eventLoop).get()
@@ -69,7 +69,7 @@ extension Vpc {
     /// 删除基础网络互通
     ///
     /// 本接口(DetachClassicLinkVpc)用于删除私有网络和基础网络设备互通。
-    /// > Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
+    /// > Important: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
     @inlinable @discardableResult
     public func detachClassicLinkVpc(vpcId: String, instanceIds: [String], region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<DetachClassicLinkVpcResponse> {
         self.detachClassicLinkVpc(.init(vpcId: vpcId, instanceIds: instanceIds), region: region, logger: logger, on: eventLoop)
@@ -78,7 +78,7 @@ extension Vpc {
     /// 删除基础网络互通
     ///
     /// 本接口(DetachClassicLinkVpc)用于删除私有网络和基础网络设备互通。
-    /// > Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
+    /// > Important: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
     @inlinable @discardableResult
     public func detachClassicLinkVpc(vpcId: String, instanceIds: [String], region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> DetachClassicLinkVpcResponse {
         try await self.detachClassicLinkVpc(.init(vpcId: vpcId, instanceIds: instanceIds), region: region, logger: logger, on: eventLoop)

--- a/Sources/Teco/Vpc/V20170312/actions/DetachClassicLinkVpc.swift
+++ b/Sources/Teco/Vpc/V20170312/actions/DetachClassicLinkVpc.swift
@@ -51,8 +51,7 @@ extension Vpc {
     /// 删除基础网络互通
     ///
     /// 本接口(DetachClassicLinkVpc)用于删除私有网络和基础网络设备互通。
-    /// - Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
-    /// >
+    /// > Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
     @inlinable @discardableResult
     public func detachClassicLinkVpc(_ input: DetachClassicLinkVpcRequest, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<DetachClassicLinkVpcResponse> {
         self.client.execute(action: "DetachClassicLinkVpc", region: region, serviceConfig: self.config, input: input, logger: logger, on: eventLoop)
@@ -61,8 +60,7 @@ extension Vpc {
     /// 删除基础网络互通
     ///
     /// 本接口(DetachClassicLinkVpc)用于删除私有网络和基础网络设备互通。
-    /// - Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
-    /// >
+    /// > Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
     @inlinable @discardableResult
     public func detachClassicLinkVpc(_ input: DetachClassicLinkVpcRequest, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> DetachClassicLinkVpcResponse {
         try await self.client.execute(action: "DetachClassicLinkVpc", region: region, serviceConfig: self.config, input: input, logger: logger, on: eventLoop).get()
@@ -71,8 +69,7 @@ extension Vpc {
     /// 删除基础网络互通
     ///
     /// 本接口(DetachClassicLinkVpc)用于删除私有网络和基础网络设备互通。
-    /// - Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
-    /// >
+    /// > Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
     @inlinable @discardableResult
     public func detachClassicLinkVpc(vpcId: String, instanceIds: [String], region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<DetachClassicLinkVpcResponse> {
         self.detachClassicLinkVpc(.init(vpcId: vpcId, instanceIds: instanceIds), region: region, logger: logger, on: eventLoop)
@@ -81,8 +78,7 @@ extension Vpc {
     /// 删除基础网络互通
     ///
     /// 本接口(DetachClassicLinkVpc)用于删除私有网络和基础网络设备互通。
-    /// - Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
-    /// >
+    /// > Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
     @inlinable @discardableResult
     public func detachClassicLinkVpc(vpcId: String, instanceIds: [String], region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> DetachClassicLinkVpcResponse {
         try await self.detachClassicLinkVpc(.init(vpcId: vpcId, instanceIds: instanceIds), region: region, logger: logger, on: eventLoop)

--- a/Sources/Teco/Vpc/V20170312/actions/DisassociateDhcpIpWithAddressIp.swift
+++ b/Sources/Teco/Vpc/V20170312/actions/DisassociateDhcpIpWithAddressIp.swift
@@ -47,8 +47,7 @@ extension Vpc {
     ///
     /// 本接口（DisassociateDhcpIpWithAddressIp）用于将DhcpIp已绑定的弹性公网IP（EIP）解除绑定。
     ///
-    /// - Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
-    /// >
+    /// > Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
     @inlinable @discardableResult
     public func disassociateDhcpIpWithAddressIp(_ input: DisassociateDhcpIpWithAddressIpRequest, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<DisassociateDhcpIpWithAddressIpResponse> {
         self.client.execute(action: "DisassociateDhcpIpWithAddressIp", region: region, serviceConfig: self.config, input: input, logger: logger, on: eventLoop)
@@ -58,8 +57,7 @@ extension Vpc {
     ///
     /// 本接口（DisassociateDhcpIpWithAddressIp）用于将DhcpIp已绑定的弹性公网IP（EIP）解除绑定。
     ///
-    /// - Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
-    /// >
+    /// > Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
     @inlinable @discardableResult
     public func disassociateDhcpIpWithAddressIp(_ input: DisassociateDhcpIpWithAddressIpRequest, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> DisassociateDhcpIpWithAddressIpResponse {
         try await self.client.execute(action: "DisassociateDhcpIpWithAddressIp", region: region, serviceConfig: self.config, input: input, logger: logger, on: eventLoop).get()
@@ -69,8 +67,7 @@ extension Vpc {
     ///
     /// 本接口（DisassociateDhcpIpWithAddressIp）用于将DhcpIp已绑定的弹性公网IP（EIP）解除绑定。
     ///
-    /// - Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
-    /// >
+    /// > Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
     @inlinable @discardableResult
     public func disassociateDhcpIpWithAddressIp(dhcpIpId: String, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<DisassociateDhcpIpWithAddressIpResponse> {
         self.disassociateDhcpIpWithAddressIp(.init(dhcpIpId: dhcpIpId), region: region, logger: logger, on: eventLoop)
@@ -80,8 +77,7 @@ extension Vpc {
     ///
     /// 本接口（DisassociateDhcpIpWithAddressIp）用于将DhcpIp已绑定的弹性公网IP（EIP）解除绑定。
     ///
-    /// - Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
-    /// >
+    /// > Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
     @inlinable @discardableResult
     public func disassociateDhcpIpWithAddressIp(dhcpIpId: String, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> DisassociateDhcpIpWithAddressIpResponse {
         try await self.disassociateDhcpIpWithAddressIp(.init(dhcpIpId: dhcpIpId), region: region, logger: logger, on: eventLoop)

--- a/Sources/Teco/Vpc/V20170312/actions/DisassociateDhcpIpWithAddressIp.swift
+++ b/Sources/Teco/Vpc/V20170312/actions/DisassociateDhcpIpWithAddressIp.swift
@@ -47,7 +47,7 @@ extension Vpc {
     ///
     /// 本接口（DisassociateDhcpIpWithAddressIp）用于将DhcpIp已绑定的弹性公网IP（EIP）解除绑定。
     ///
-    /// > Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
+    /// > Important: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
     @inlinable @discardableResult
     public func disassociateDhcpIpWithAddressIp(_ input: DisassociateDhcpIpWithAddressIpRequest, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<DisassociateDhcpIpWithAddressIpResponse> {
         self.client.execute(action: "DisassociateDhcpIpWithAddressIp", region: region, serviceConfig: self.config, input: input, logger: logger, on: eventLoop)
@@ -57,7 +57,7 @@ extension Vpc {
     ///
     /// 本接口（DisassociateDhcpIpWithAddressIp）用于将DhcpIp已绑定的弹性公网IP（EIP）解除绑定。
     ///
-    /// > Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
+    /// > Important: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
     @inlinable @discardableResult
     public func disassociateDhcpIpWithAddressIp(_ input: DisassociateDhcpIpWithAddressIpRequest, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> DisassociateDhcpIpWithAddressIpResponse {
         try await self.client.execute(action: "DisassociateDhcpIpWithAddressIp", region: region, serviceConfig: self.config, input: input, logger: logger, on: eventLoop).get()
@@ -67,7 +67,7 @@ extension Vpc {
     ///
     /// 本接口（DisassociateDhcpIpWithAddressIp）用于将DhcpIp已绑定的弹性公网IP（EIP）解除绑定。
     ///
-    /// > Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
+    /// > Important: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
     @inlinable @discardableResult
     public func disassociateDhcpIpWithAddressIp(dhcpIpId: String, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<DisassociateDhcpIpWithAddressIpResponse> {
         self.disassociateDhcpIpWithAddressIp(.init(dhcpIpId: dhcpIpId), region: region, logger: logger, on: eventLoop)
@@ -77,7 +77,7 @@ extension Vpc {
     ///
     /// 本接口（DisassociateDhcpIpWithAddressIp）用于将DhcpIp已绑定的弹性公网IP（EIP）解除绑定。
     ///
-    /// > Attention: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
+    /// > Important: 本接口为异步接口，可调用 [DescribeVpcTaskResult](https://cloud.tencent.com/document/api/215/59037) 接口查询任务执行结果，待任务执行成功后再进行其他操作。
     @inlinable @discardableResult
     public func disassociateDhcpIpWithAddressIp(dhcpIpId: String, region: TCRegion? = nil, logger: Logger = TCClient.loggingDisabled, on eventLoop: EventLoop? = nil) async throws -> DisassociateDhcpIpWithAddressIpResponse {
         try await self.disassociateDhcpIpWithAddressIp(.init(dhcpIpId: dhcpIpId), region: region, logger: logger, on: eventLoop)


### PR DESCRIPTION
The `>` syntax for asides is documented in https://www.swift.org/documentation/docc/formatting-your-documentation-content#Add-Notes-and-Other-Asides. This PR also renames the previous "Attention" aside to "Important", to match the documentation.

Companioned by https://github.com/teco-project/teco-code-generators/pull/41.