### PR TITLE
Updates CI to include Swift 5.9 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,20 +41,20 @@ jobs:
         with:
           swift-version: ${{ matrix.swift }}
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Build
         run: swift build
   build-without-warnings:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Build
         run: swift build --build-tests -Xswiftc -warnings-as-errors
   build-with-docc:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Build
         run: swift build -Xswiftc -DBUILDING_DOCC

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,8 +14,6 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-11
-          - macos-12
           - ubuntu-20.04
           - ubuntu-22.04
         swift:
@@ -23,13 +21,19 @@ jobs:
           - '5.6'
           - '5.7'
           - '5.8'
-        exclude:
+          - '5.9'
+        include:
           - os: macos-11
-            swift: '5.8'
-          - os: macos-12
             swift: '5.5'
           - os: macos-12
             swift: '5.6'
+          - os: macos-12
+            swift: '5.7'
+          - os: macos-13
+            swift: '5.8'
+          - os: macos-13
+            swift: '5.9'
+        exclude:
           - os: ubuntu-22.04
             swift: '5.5'
           - os: ubuntu-22.04

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,11 +25,11 @@ jobs:
         include:
           - os: macos-11
             swift: '5.5'
-          - os: macos-12
+          - os: macos-11
             swift: '5.6'
           - os: macos-12
             swift: '5.7'
-          - os: macos-13
+          - os: macos-12
             swift: '5.8'
           - os: macos-13
             swift: '5.9'


### PR DESCRIPTION
Swift 5.9 was released a short while ago, and it’s time to add it into the test preset. We’re also utilizing the new macOS 13 runners and `actions/checkout@v4`.

Note: Due to macOS runner parallel limits, we can only test one OS version for each language version.