### PR TITLE
Uses globally shared `TCClient` by default

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/swift-server/async-http-client.git",
         "state": {
           "branch": null,
-          "revision": "864c8d9e0ead5de7ba70b61c8982f89126710863",
-          "version": "1.15.0"
+          "revision": "16f7e62c08c6969899ce6cc277041e868364e5cf",
+          "version": "1.19.0"
         }
       },
       {
@@ -69,8 +69,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "9b2848d76f5caad08b97e71a04345aa5bdb23a06",
-          "version": "2.49.0"
+          "revision": "3db5c4aeee8100d2db6f1eaf3864afdad5dc68fd",
+          "version": "2.59.0"
         }
       },
       {
@@ -105,8 +105,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-transport-services.git",
         "state": {
           "branch": null,
-          "revision": "c0d9a144cfaec8d3d596aadde3039286a266c15c",
-          "version": "1.15.0"
+          "revision": "e7403c35ca6bb539a7ca353b91cc2d8ec0362d58",
+          "version": "1.19.0"
         }
       },
       {
@@ -114,8 +114,8 @@
         "repositoryURL": "https://github.com/teco-project/teco-core.git",
         "state": {
           "branch": null,
-          "revision": "5005cb05f352dfe898e3c45fadbce1ba15233132",
-          "version": "0.5.5"
+          "revision": "18df839cc76c24ea228d686770bd38ad57cad00d",
+          "version": "0.5.6"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -293,7 +293,7 @@ let package = Package(
         .library(name: "TecoZjV20190121", targets: ["TecoZjV20190121"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/teco-project/teco-core.git", .upToNextMinor(from: "0.5.5"))
+        .package(url: "https://github.com/teco-project/teco-core.git", .upToNextMinor(from: "0.5.6"))
     ],
     targets: [
         .target(name: "TecoAaV20200224", dependencies: [.product(name: "TecoCore", package: "teco-core")], path: "./Sources/Teco/Aa/V20200224"),

--- a/Sources/Teco/Aa/V20200224/client.swift
+++ b/Sources/Teco/Aa/V20200224/client.swift
@@ -35,7 +35,7 @@ public struct Aa: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Aa``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Aai/V20180522/client.swift
+++ b/Sources/Teco/Aai/V20180522/client.swift
@@ -35,7 +35,7 @@ public struct Aai: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Aai``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Acp/V20220105/client.swift
+++ b/Sources/Teco/Acp/V20220105/client.swift
@@ -37,7 +37,7 @@ public struct Acp: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Acp``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Advisor/V20200721/client.swift
+++ b/Sources/Teco/Advisor/V20200721/client.swift
@@ -35,7 +35,7 @@ public struct Advisor: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Advisor``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Af/V20200226/client.swift
+++ b/Sources/Teco/Af/V20200226/client.swift
@@ -37,7 +37,7 @@ public struct Af: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Af``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Afc/V20200226/client.swift
+++ b/Sources/Teco/Afc/V20200226/client.swift
@@ -37,7 +37,7 @@ public struct Afc: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Afc``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Aiart/V20221229/client.swift
+++ b/Sources/Teco/Aiart/V20221229/client.swift
@@ -37,7 +37,7 @@ public struct Aiart: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Aiart``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Ame/V20190916/client.swift
+++ b/Sources/Teco/Ame/V20190916/client.swift
@@ -37,7 +37,7 @@ public struct Ame: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Ame``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Ams/V20200608/client.swift
+++ b/Sources/Teco/Ams/V20200608/client.swift
@@ -37,7 +37,7 @@ public struct Ams: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Ams``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Ams/V20201229/client.swift
+++ b/Sources/Teco/Ams/V20201229/client.swift
@@ -37,7 +37,7 @@ public struct Ams: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Ams``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Anicloud/V20220923/client.swift
+++ b/Sources/Teco/Anicloud/V20220923/client.swift
@@ -37,7 +37,7 @@ public struct Anicloud: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Anicloud``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Antiddos/V20200309/client.swift
+++ b/Sources/Teco/Antiddos/V20200309/client.swift
@@ -39,7 +39,7 @@ public struct Antiddos: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Antiddos``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Apcas/V20201127/client.swift
+++ b/Sources/Teco/Apcas/V20201127/client.swift
@@ -37,7 +37,7 @@ public struct Apcas: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Apcas``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Ape/V20200513/client.swift
+++ b/Sources/Teco/Ape/V20200513/client.swift
@@ -37,7 +37,7 @@ public struct Ape: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Ape``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Api/V20201106/client.swift
+++ b/Sources/Teco/Api/V20201106/client.swift
@@ -37,7 +37,7 @@ public struct Api: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Api``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Apigateway/V20180808/client.swift
+++ b/Sources/Teco/Apigateway/V20180808/client.swift
@@ -37,7 +37,7 @@ public struct Apigateway: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Apigateway``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Apm/V20210622/client.swift
+++ b/Sources/Teco/Apm/V20210622/client.swift
@@ -42,7 +42,7 @@ public struct Apm: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Apm``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Asr/V20190614/client.swift
+++ b/Sources/Teco/Asr/V20190614/client.swift
@@ -37,7 +37,7 @@ public struct Asr: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Asr``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Asw/V20200722/client.swift
+++ b/Sources/Teco/Asw/V20200722/client.swift
@@ -37,7 +37,7 @@ public struct Asw: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Asw``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Autoscaling/V20180419/client.swift
+++ b/Sources/Teco/Autoscaling/V20180419/client.swift
@@ -37,7 +37,7 @@ public struct As: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``As``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Ba/V20200720/client.swift
+++ b/Sources/Teco/Ba/V20200720/client.swift
@@ -37,7 +37,7 @@ public struct Ba: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Ba``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Batch/V20170312/client.swift
+++ b/Sources/Teco/Batch/V20170312/client.swift
@@ -37,7 +37,7 @@ public struct Batch: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Batch``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Bda/V20200324/client.swift
+++ b/Sources/Teco/Bda/V20200324/client.swift
@@ -37,7 +37,7 @@ public struct Bda: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Bda``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Bi/V20220105/client.swift
+++ b/Sources/Teco/Bi/V20220105/client.swift
@@ -37,7 +37,7 @@ public struct Bi: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Bi``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Billing/V20180709/client.swift
+++ b/Sources/Teco/Billing/V20180709/client.swift
@@ -37,7 +37,7 @@ public struct Billing: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Billing``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Bizlive/V20190313/client.swift
+++ b/Sources/Teco/Bizlive/V20190313/client.swift
@@ -35,7 +35,7 @@ public struct Bizlive: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Bizlive``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Bm/V20180423/client.swift
+++ b/Sources/Teco/Bm/V20180423/client.swift
@@ -37,7 +37,7 @@ public struct Bm: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Bm``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Bma/V20210624/client.swift
+++ b/Sources/Teco/Bma/V20210624/client.swift
@@ -35,7 +35,7 @@ public struct Bma: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Bma``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Bma/V20221115/client.swift
+++ b/Sources/Teco/Bma/V20221115/client.swift
@@ -35,7 +35,7 @@ public struct Bma: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Bma``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Bmeip/V20180625/client.swift
+++ b/Sources/Teco/Bmeip/V20180625/client.swift
@@ -35,7 +35,7 @@ public struct Bmeip: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Bmeip``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Bmlb/V20180625/client.swift
+++ b/Sources/Teco/Bmlb/V20180625/client.swift
@@ -35,7 +35,7 @@ public struct Bmlb: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Bmlb``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Bmvpc/V20180625/client.swift
+++ b/Sources/Teco/Bmvpc/V20180625/client.swift
@@ -35,7 +35,7 @@ public struct Bmvpc: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Bmvpc``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Bpaas/V20181217/client.swift
+++ b/Sources/Teco/Bpaas/V20181217/client.swift
@@ -38,7 +38,7 @@ public struct Bpaas: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Bpaas``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Bri/V20190328/client.swift
+++ b/Sources/Teco/Bri/V20190328/client.swift
@@ -37,7 +37,7 @@ public struct Bri: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Bri``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Bsca/V20210811/client.swift
+++ b/Sources/Teco/Bsca/V20210811/client.swift
@@ -37,7 +37,7 @@ public struct Bsca: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Bsca``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Btoe/V20210303/client.swift
+++ b/Sources/Teco/Btoe/V20210303/client.swift
@@ -40,7 +40,7 @@ public struct Btoe: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Btoe``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Btoe/V20210514/client.swift
+++ b/Sources/Teco/Btoe/V20210514/client.swift
@@ -40,7 +40,7 @@ public struct Btoe: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Btoe``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Cam/V20190116/client.swift
+++ b/Sources/Teco/Cam/V20190116/client.swift
@@ -37,7 +37,7 @@ public struct Cam: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Cam``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Captcha/V20190722/client.swift
+++ b/Sources/Teco/Captcha/V20190722/client.swift
@@ -37,7 +37,7 @@ public struct Captcha: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Captcha``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Car/V20220110/client.swift
+++ b/Sources/Teco/Car/V20220110/client.swift
@@ -37,7 +37,7 @@ public struct Car: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Car``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Casb/V20200507/client.swift
+++ b/Sources/Teco/Casb/V20200507/client.swift
@@ -35,7 +35,7 @@ public struct Casb: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Casb``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Cat/V20180409/client.swift
+++ b/Sources/Teco/Cat/V20180409/client.swift
@@ -37,7 +37,7 @@ public struct Cat: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Cat``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Cbs/V20170312/client.swift
+++ b/Sources/Teco/Cbs/V20170312/client.swift
@@ -37,7 +37,7 @@ public struct Cbs: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Cbs``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Ccc/V20200210/client.swift
+++ b/Sources/Teco/Ccc/V20200210/client.swift
@@ -37,7 +37,7 @@ public struct Ccc: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Ccc``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Cdb/V20170320/client.swift
+++ b/Sources/Teco/Cdb/V20170320/client.swift
@@ -37,7 +37,7 @@ public struct Cdb: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Cdb``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Cdc/V20201214/client.swift
+++ b/Sources/Teco/Cdc/V20201214/client.swift
@@ -37,7 +37,7 @@ public struct Cdc: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Cdc``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Cdn/V20180606/client.swift
+++ b/Sources/Teco/Cdn/V20180606/client.swift
@@ -37,7 +37,7 @@ public struct Cdn: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Cdn``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Cds/V20180420/client.swift
+++ b/Sources/Teco/Cds/V20180420/client.swift
@@ -37,7 +37,7 @@ public struct Cds: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Cds``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Cdwch/V20200915/client.swift
+++ b/Sources/Teco/Cdwch/V20200915/client.swift
@@ -37,7 +37,7 @@ public struct Cdwch: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Cdwch``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Cdwpg/V20201230/client.swift
+++ b/Sources/Teco/Cdwpg/V20201230/client.swift
@@ -37,7 +37,7 @@ public struct Cdwpg: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Cdwpg``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Cfg/V20210820/client.swift
+++ b/Sources/Teco/Cfg/V20210820/client.swift
@@ -37,7 +37,7 @@ public struct Cfg: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Cfg``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Cfs/V20190719/client.swift
+++ b/Sources/Teco/Cfs/V20190719/client.swift
@@ -37,7 +37,7 @@ public struct Cfs: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Cfs``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Cfw/V20190904/client.swift
+++ b/Sources/Teco/Cfw/V20190904/client.swift
@@ -37,7 +37,7 @@ public struct Cfw: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Cfw``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Chdfs/V20190718/client.swift
+++ b/Sources/Teco/Chdfs/V20190718/client.swift
@@ -37,7 +37,7 @@ public struct Chdfs: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Chdfs``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Chdfs/V20201112/client.swift
+++ b/Sources/Teco/Chdfs/V20201112/client.swift
@@ -37,7 +37,7 @@ public struct Chdfs: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Chdfs``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Ciam/V20220331/client.swift
+++ b/Sources/Teco/Ciam/V20220331/client.swift
@@ -37,7 +37,7 @@ public struct Ciam: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Ciam``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Cii/V20201210/client.swift
+++ b/Sources/Teco/Cii/V20201210/client.swift
@@ -38,7 +38,7 @@ public struct Cii: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Cii``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Cii/V20210408/client.swift
+++ b/Sources/Teco/Cii/V20210408/client.swift
@@ -38,7 +38,7 @@ public struct Cii: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Cii``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Cim/V20190318/client.swift
+++ b/Sources/Teco/Cim/V20190318/client.swift
@@ -35,7 +35,7 @@ public struct Cim: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Cim``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Cis/V20180408/client.swift
+++ b/Sources/Teco/Cis/V20180408/client.swift
@@ -35,7 +35,7 @@ public struct Cis: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Cis``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Ckafka/V20190819/client.swift
+++ b/Sources/Teco/Ckafka/V20190819/client.swift
@@ -37,7 +37,7 @@ public struct Ckafka: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Ckafka``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Clb/V20180317/client.swift
+++ b/Sources/Teco/Clb/V20180317/client.swift
@@ -37,7 +37,7 @@ public struct Clb: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Clb``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Cloudaudit/V20190319/client.swift
+++ b/Sources/Teco/Cloudaudit/V20190319/client.swift
@@ -37,7 +37,7 @@ public struct Cloudaudit: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Cloudaudit``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Cloudhsm/V20191112/client.swift
+++ b/Sources/Teco/Cloudhsm/V20191112/client.swift
@@ -37,7 +37,7 @@ public struct Cloudhsm: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Cloudhsm``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Cloudstudio/V20210524/client.swift
+++ b/Sources/Teco/Cloudstudio/V20210524/client.swift
@@ -37,7 +37,7 @@ public struct Cloudstudio: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Cloudstudio``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Cloudstudio/V20230508/client.swift
+++ b/Sources/Teco/Cloudstudio/V20230508/client.swift
@@ -37,7 +37,7 @@ public struct Cloudstudio: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Cloudstudio``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Cls/V20201016/client.swift
+++ b/Sources/Teco/Cls/V20201016/client.swift
@@ -37,7 +37,7 @@ public struct Cls: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Cls``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Cme/V20191029/client.swift
+++ b/Sources/Teco/Cme/V20191029/client.swift
@@ -37,7 +37,7 @@ public struct Cme: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Cme``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Cmq/V20190304/client.swift
+++ b/Sources/Teco/Cmq/V20190304/client.swift
@@ -37,7 +37,7 @@ public struct Cmq: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Cmq``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Cms/V20190321/client.swift
+++ b/Sources/Teco/Cms/V20190321/client.swift
@@ -37,7 +37,7 @@ public struct Cms: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Cms``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Cpdp/V20190820/client.swift
+++ b/Sources/Teco/Cpdp/V20190820/client.swift
@@ -37,7 +37,7 @@ public struct Cpdp: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Cpdp``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Cr/V20180321/client.swift
+++ b/Sources/Teco/Cr/V20180321/client.swift
@@ -37,7 +37,7 @@ public struct Cr: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Cr``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Csip/V20221121/client.swift
+++ b/Sources/Teco/Csip/V20221121/client.swift
@@ -35,7 +35,7 @@ public struct Csip: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Csip``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Csxg/V20230303/client.swift
+++ b/Sources/Teco/Csxg/V20230303/client.swift
@@ -37,7 +37,7 @@ public struct Csxg: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Csxg``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Cvm/V20170312/client.swift
+++ b/Sources/Teco/Cvm/V20170312/client.swift
@@ -37,7 +37,7 @@ public struct Cvm: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Cvm``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Cwp/V20180228/client.swift
+++ b/Sources/Teco/Cwp/V20180228/client.swift
@@ -37,7 +37,7 @@ public struct Cwp: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Cwp``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Cws/V20180312/client.swift
+++ b/Sources/Teco/Cws/V20180312/client.swift
@@ -35,7 +35,7 @@ public struct Cws: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Cws``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Cynosdb/V20190107/client.swift
+++ b/Sources/Teco/Cynosdb/V20190107/client.swift
@@ -35,7 +35,7 @@ public struct Cynosdb: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Cynosdb``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Dasb/V20191018/client.swift
+++ b/Sources/Teco/Dasb/V20191018/client.swift
@@ -37,7 +37,7 @@ public struct Dasb: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Dasb``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Dataintegration/V20220613/client.swift
+++ b/Sources/Teco/Dataintegration/V20220613/client.swift
@@ -37,7 +37,7 @@ public struct Dataintegration: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Dataintegration``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Dayu/V20180709/client.swift
+++ b/Sources/Teco/Dayu/V20180709/client.swift
@@ -37,7 +37,7 @@ public struct Dayu: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Dayu``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Dbbrain/V20191016/client.swift
+++ b/Sources/Teco/Dbbrain/V20191016/client.swift
@@ -37,7 +37,7 @@ public struct Dbbrain: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Dbbrain``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Dbbrain/V20210527/client.swift
+++ b/Sources/Teco/Dbbrain/V20210527/client.swift
@@ -37,7 +37,7 @@ public struct Dbbrain: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Dbbrain``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Dbdc/V20201029/client.swift
+++ b/Sources/Teco/Dbdc/V20201029/client.swift
@@ -37,7 +37,7 @@ public struct Dbdc: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Dbdc``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Dc/V20180410/client.swift
+++ b/Sources/Teco/Dc/V20180410/client.swift
@@ -37,7 +37,7 @@ public struct Dc: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Dc``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Dcdb/V20180411/client.swift
+++ b/Sources/Teco/Dcdb/V20180411/client.swift
@@ -37,7 +37,7 @@ public struct Dcdb: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Dcdb``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Dlc/V20210125/client.swift
+++ b/Sources/Teco/Dlc/V20210125/client.swift
@@ -37,7 +37,7 @@ public struct Dlc: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Dlc``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Dnspod/V20210323/client.swift
+++ b/Sources/Teco/Dnspod/V20210323/client.swift
@@ -39,7 +39,7 @@ public struct Dnspod: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Dnspod``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Domain/V20180808/client.swift
+++ b/Sources/Teco/Domain/V20180808/client.swift
@@ -37,7 +37,7 @@ public struct Domain: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Domain``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Drm/V20181115/client.swift
+++ b/Sources/Teco/Drm/V20181115/client.swift
@@ -37,7 +37,7 @@ public struct Drm: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Drm``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Ds/V20180523/client.swift
+++ b/Sources/Teco/Ds/V20180523/client.swift
@@ -35,7 +35,7 @@ public struct Ds: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Ds``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Dsgc/V20190723/client.swift
+++ b/Sources/Teco/Dsgc/V20190723/client.swift
@@ -37,7 +37,7 @@ public struct Dsgc: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Dsgc``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Dtf/V20200506/client.swift
+++ b/Sources/Teco/Dtf/V20200506/client.swift
@@ -35,7 +35,7 @@ public struct Dtf: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Dtf``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Dts/V20180330/client.swift
+++ b/Sources/Teco/Dts/V20180330/client.swift
@@ -37,7 +37,7 @@ public struct Dts: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Dts``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Dts/V20211206/client.swift
+++ b/Sources/Teco/Dts/V20211206/client.swift
@@ -37,7 +37,7 @@ public struct Dts: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Dts``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Eb/V20210416/client.swift
+++ b/Sources/Teco/Eb/V20210416/client.swift
@@ -37,7 +37,7 @@ public struct Eb: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Eb``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Ecc/V20181213/client.swift
+++ b/Sources/Teco/Ecc/V20181213/client.swift
@@ -37,7 +37,7 @@ public struct Ecc: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Ecc``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Ecdn/V20191012/client.swift
+++ b/Sources/Teco/Ecdn/V20191012/client.swift
@@ -37,7 +37,7 @@ public struct Ecdn: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Ecdn``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Ecm/V20190719/client.swift
+++ b/Sources/Teco/Ecm/V20190719/client.swift
@@ -37,7 +37,7 @@ public struct Ecm: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Ecm``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Eiam/V20210420/client.swift
+++ b/Sources/Teco/Eiam/V20210420/client.swift
@@ -59,7 +59,7 @@ public struct Eiam: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Eiam``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Eis/V20200715/client.swift
+++ b/Sources/Teco/Eis/V20200715/client.swift
@@ -35,7 +35,7 @@ public struct Eis: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Eis``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Eis/V20210601/client.swift
+++ b/Sources/Teco/Eis/V20210601/client.swift
@@ -35,7 +35,7 @@ public struct Eis: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Eis``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Emr/V20190103/client.swift
+++ b/Sources/Teco/Emr/V20190103/client.swift
@@ -37,7 +37,7 @@ public struct Emr: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Emr``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Es/V20180416/client.swift
+++ b/Sources/Teco/Es/V20180416/client.swift
@@ -37,7 +37,7 @@ public struct Es: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Es``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Ess/V20201111/client.swift
+++ b/Sources/Teco/Ess/V20201111/client.swift
@@ -37,7 +37,7 @@ public struct Ess: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Ess``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Essbasic/V20201222/client.swift
+++ b/Sources/Teco/Essbasic/V20201222/client.swift
@@ -37,7 +37,7 @@ public struct Essbasic: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Essbasic``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Essbasic/V20210526/client.swift
+++ b/Sources/Teco/Essbasic/V20210526/client.swift
@@ -37,7 +37,7 @@ public struct Essbasic: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Essbasic``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Facefusion/V20181201/client.swift
+++ b/Sources/Teco/Facefusion/V20181201/client.swift
@@ -37,7 +37,7 @@ public struct Facefusion: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Facefusion``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Facefusion/V20220927/client.swift
+++ b/Sources/Teco/Facefusion/V20220927/client.swift
@@ -37,7 +37,7 @@ public struct Facefusion: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Facefusion``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Faceid/V20180301/client.swift
+++ b/Sources/Teco/Faceid/V20180301/client.swift
@@ -37,7 +37,7 @@ public struct Faceid: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Faceid``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Fmu/V20191213/client.swift
+++ b/Sources/Teco/Fmu/V20191213/client.swift
@@ -37,7 +37,7 @@ public struct Fmu: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Fmu``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Ft/V20200304/client.swift
+++ b/Sources/Teco/Ft/V20200304/client.swift
@@ -37,7 +37,7 @@ public struct Ft: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Ft``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Gaap/V20180529/client.swift
+++ b/Sources/Teco/Gaap/V20180529/client.swift
@@ -37,7 +37,7 @@ public struct Gaap: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Gaap``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Gme/V20180711/client.swift
+++ b/Sources/Teco/Gme/V20180711/client.swift
@@ -37,7 +37,7 @@ public struct Gme: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Gme``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Goosefs/V20220519/client.swift
+++ b/Sources/Teco/Goosefs/V20220519/client.swift
@@ -37,7 +37,7 @@ public struct Goosefs: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Goosefs``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Gpm/V20200820/client.swift
+++ b/Sources/Teco/Gpm/V20200820/client.swift
@@ -37,7 +37,7 @@ public struct Gpm: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Gpm``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Gs/V20191118/client.swift
+++ b/Sources/Teco/Gs/V20191118/client.swift
@@ -37,7 +37,7 @@ public struct Gs: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Gs``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Gse/V20191112/client.swift
+++ b/Sources/Teco/Gse/V20191112/client.swift
@@ -37,7 +37,7 @@ public struct Gse: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Gse``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Habo/V20181203/client.swift
+++ b/Sources/Teco/Habo/V20181203/client.swift
@@ -35,7 +35,7 @@ public struct Habo: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Habo``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Hasim/V20210716/client.swift
+++ b/Sources/Teco/Hasim/V20210716/client.swift
@@ -37,7 +37,7 @@ public struct Hasim: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Hasim``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Hcm/V20181106/client.swift
+++ b/Sources/Teco/Hcm/V20181106/client.swift
@@ -37,7 +37,7 @@ public struct Hcm: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Hcm``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Iai/V20180301/client.swift
+++ b/Sources/Teco/Iai/V20180301/client.swift
@@ -37,7 +37,7 @@ public struct Iai: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Iai``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Iai/V20200303/client.swift
+++ b/Sources/Teco/Iai/V20200303/client.swift
@@ -37,7 +37,7 @@ public struct Iai: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Iai``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Ic/V20190307/client.swift
+++ b/Sources/Teco/Ic/V20190307/client.swift
@@ -37,7 +37,7 @@ public struct Ic: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Ic``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Icr/V20211014/client.swift
+++ b/Sources/Teco/Icr/V20211014/client.swift
@@ -38,7 +38,7 @@ public struct Icr: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Icr``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Ie/V20200304/client.swift
+++ b/Sources/Teco/Ie/V20200304/client.swift
@@ -37,7 +37,7 @@ public struct Ie: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Ie``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Iecp/V20210914/client.swift
+++ b/Sources/Teco/Iecp/V20210914/client.swift
@@ -37,7 +37,7 @@ public struct Iecp: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Iecp``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Iir/V20200417/client.swift
+++ b/Sources/Teco/Iir/V20200417/client.swift
@@ -37,7 +37,7 @@ public struct Iir: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Iir``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Ims/V20200713/client.swift
+++ b/Sources/Teco/Ims/V20200713/client.swift
@@ -37,7 +37,7 @@ public struct Ims: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Ims``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Ims/V20201229/client.swift
+++ b/Sources/Teco/Ims/V20201229/client.swift
@@ -37,7 +37,7 @@ public struct Ims: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Ims``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Intlpartnersmgt/V20220928/client.swift
+++ b/Sources/Teco/Intlpartnersmgt/V20220928/client.swift
@@ -37,7 +37,7 @@ public struct Intlpartnersmgt: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Intlpartnersmgt``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Iot/V20180123/client.swift
+++ b/Sources/Teco/Iot/V20180123/client.swift
@@ -35,7 +35,7 @@ public struct Iot: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Iot``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Iotcloud/V20180614/client.swift
+++ b/Sources/Teco/Iotcloud/V20180614/client.swift
@@ -37,7 +37,7 @@ public struct Iotcloud: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Iotcloud``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Iotcloud/V20210408/client.swift
+++ b/Sources/Teco/Iotcloud/V20210408/client.swift
@@ -37,7 +37,7 @@ public struct Iotcloud: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Iotcloud``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Iotexplorer/V20190423/client.swift
+++ b/Sources/Teco/Iotexplorer/V20190423/client.swift
@@ -37,7 +37,7 @@ public struct Iotexplorer: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Iotexplorer``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Iottid/V20190411/client.swift
+++ b/Sources/Teco/Iottid/V20190411/client.swift
@@ -37,7 +37,7 @@ public struct Iottid: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Iottid``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Iotvideo/V20191126/client.swift
+++ b/Sources/Teco/Iotvideo/V20191126/client.swift
@@ -37,7 +37,7 @@ public struct Iotvideo: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Iotvideo``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Iotvideo/V20201215/client.swift
+++ b/Sources/Teco/Iotvideo/V20201215/client.swift
@@ -37,7 +37,7 @@ public struct Iotvideo: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Iotvideo``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Iotvideo/V20211125/client.swift
+++ b/Sources/Teco/Iotvideo/V20211125/client.swift
@@ -37,7 +37,7 @@ public struct Iotvideo: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Iotvideo``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Iotvideoindustry/V20201201/client.swift
+++ b/Sources/Teco/Iotvideoindustry/V20201201/client.swift
@@ -37,7 +37,7 @@ public struct Iotvideoindustry: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Iotvideoindustry``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Irp/V20220324/client.swift
+++ b/Sources/Teco/Irp/V20220324/client.swift
@@ -37,7 +37,7 @@ public struct Irp: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Irp``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Irp/V20220805/client.swift
+++ b/Sources/Teco/Irp/V20220805/client.swift
@@ -37,7 +37,7 @@ public struct Irp: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Irp``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Iss/V20230517/client.swift
+++ b/Sources/Teco/Iss/V20230517/client.swift
@@ -37,7 +37,7 @@ public struct Iss: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Iss``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Ivld/V20210903/client.swift
+++ b/Sources/Teco/Ivld/V20210903/client.swift
@@ -37,7 +37,7 @@ public struct Ivld: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Ivld``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Keewidb/V20220308/client.swift
+++ b/Sources/Teco/Keewidb/V20220308/client.swift
@@ -37,7 +37,7 @@ public struct Keewidb: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Keewidb``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Kms/V20190118/client.swift
+++ b/Sources/Teco/Kms/V20190118/client.swift
@@ -37,7 +37,7 @@ public struct Kms: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Kms``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Lcic/V20220817/client.swift
+++ b/Sources/Teco/Lcic/V20220817/client.swift
@@ -37,7 +37,7 @@ public struct Lcic: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Lcic``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Lighthouse/V20200324/client.swift
+++ b/Sources/Teco/Lighthouse/V20200324/client.swift
@@ -37,7 +37,7 @@ public struct Lighthouse: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Lighthouse``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Live/V20180801/client.swift
+++ b/Sources/Teco/Live/V20180801/client.swift
@@ -37,7 +37,7 @@ public struct Live: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Live``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Lowcode/V20210108/client.swift
+++ b/Sources/Teco/Lowcode/V20210108/client.swift
@@ -37,7 +37,7 @@ public struct Lowcode: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Lowcode``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Lp/V20200224/client.swift
+++ b/Sources/Teco/Lp/V20200224/client.swift
@@ -35,7 +35,7 @@ public struct Lp: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Lp``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Mall/V20230518/client.swift
+++ b/Sources/Teco/Mall/V20230518/client.swift
@@ -37,7 +37,7 @@ public struct Mall: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Mall``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Mariadb/V20170312/client.swift
+++ b/Sources/Teco/Mariadb/V20170312/client.swift
@@ -37,7 +37,7 @@ public struct Mariadb: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Mariadb``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Market/V20191010/client.swift
+++ b/Sources/Teco/Market/V20191010/client.swift
@@ -37,7 +37,7 @@ public struct Market: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Market``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Memcached/V20190318/client.swift
+++ b/Sources/Teco/Memcached/V20190318/client.swift
@@ -37,7 +37,7 @@ public struct Memcached: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Memcached``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Mgobe/V20190929/client.swift
+++ b/Sources/Teco/Mgobe/V20190929/client.swift
@@ -37,7 +37,7 @@ public struct Mgobe: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Mgobe``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Mgobe/V20201014/client.swift
+++ b/Sources/Teco/Mgobe/V20201014/client.swift
@@ -37,7 +37,7 @@ public struct Mgobe: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Mgobe``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Mmps/V20200710/client.swift
+++ b/Sources/Teco/Mmps/V20200710/client.swift
@@ -35,7 +35,7 @@ public struct Mmps: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Mmps``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Mna/V20210119/client.swift
+++ b/Sources/Teco/Mna/V20210119/client.swift
@@ -37,7 +37,7 @@ public struct Mna: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Mna``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Mongodb/V20180408/client.swift
+++ b/Sources/Teco/Mongodb/V20180408/client.swift
@@ -37,7 +37,7 @@ public struct Mongodb: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Mongodb``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Mongodb/V20190725/client.swift
+++ b/Sources/Teco/Mongodb/V20190725/client.swift
@@ -37,7 +37,7 @@ public struct Mongodb: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Mongodb``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Monitor/V20180724/client.swift
+++ b/Sources/Teco/Monitor/V20180724/client.swift
@@ -37,7 +37,7 @@ public struct Monitor: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Monitor``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Mps/V20190612/client.swift
+++ b/Sources/Teco/Mps/V20190612/client.swift
@@ -37,7 +37,7 @@ public struct Mps: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Mps``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Mrs/V20200910/client.swift
+++ b/Sources/Teco/Mrs/V20200910/client.swift
@@ -37,7 +37,7 @@ public struct Mrs: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Mrs``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Ms/V20180408/client.swift
+++ b/Sources/Teco/Ms/V20180408/client.swift
@@ -35,7 +35,7 @@ public struct Ms: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Ms``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Msp/V20180319/client.swift
+++ b/Sources/Teco/Msp/V20180319/client.swift
@@ -37,7 +37,7 @@ public struct Msp: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Msp``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Mvj/V20190926/client.swift
+++ b/Sources/Teco/Mvj/V20190926/client.swift
@@ -35,7 +35,7 @@ public struct Mvj: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Mvj``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Nlp/V20190408/client.swift
+++ b/Sources/Teco/Nlp/V20190408/client.swift
@@ -37,7 +37,7 @@ public struct Nlp: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Nlp``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Npp/V20190823/client.swift
+++ b/Sources/Teco/Npp/V20190823/client.swift
@@ -35,7 +35,7 @@ public struct Npp: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Npp``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Oceanus/V20190422/client.swift
+++ b/Sources/Teco/Oceanus/V20190422/client.swift
@@ -37,7 +37,7 @@ public struct Oceanus: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Oceanus``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Ocr/V20181119/client.swift
+++ b/Sources/Teco/Ocr/V20181119/client.swift
@@ -37,7 +37,7 @@ public struct Ocr: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Ocr``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Omics/V20221128/client.swift
+++ b/Sources/Teco/Omics/V20221128/client.swift
@@ -37,7 +37,7 @@ public struct Omics: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Omics``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Organization/V20181225/client.swift
+++ b/Sources/Teco/Organization/V20181225/client.swift
@@ -37,7 +37,7 @@ public struct Organization: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Organization``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Organization/V20210331/client.swift
+++ b/Sources/Teco/Organization/V20210331/client.swift
@@ -37,7 +37,7 @@ public struct Organization: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Organization``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Partners/V20180321/client.swift
+++ b/Sources/Teco/Partners/V20180321/client.swift
@@ -37,7 +37,7 @@ public struct Partners: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Partners``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Pds/V20210701/client.swift
+++ b/Sources/Teco/Pds/V20210701/client.swift
@@ -37,7 +37,7 @@ public struct Pds: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Pds``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Postgres/V20170312/client.swift
+++ b/Sources/Teco/Postgres/V20170312/client.swift
@@ -37,7 +37,7 @@ public struct Postgres: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Postgres``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Privatedns/V20201028/client.swift
+++ b/Sources/Teco/Privatedns/V20201028/client.swift
@@ -41,7 +41,7 @@ public struct Privatedns: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Privatedns``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Pts/V20210728/client.swift
+++ b/Sources/Teco/Pts/V20210728/client.swift
@@ -37,7 +37,7 @@ public struct Pts: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Pts``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Rce/V20201103/client.swift
+++ b/Sources/Teco/Rce/V20201103/client.swift
@@ -41,7 +41,7 @@ public struct Rce: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Rce``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Redis/V20180412/client.swift
+++ b/Sources/Teco/Redis/V20180412/client.swift
@@ -37,7 +37,7 @@ public struct Redis: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Redis``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Region/V20220627/client.swift
+++ b/Sources/Teco/Region/V20220627/client.swift
@@ -37,7 +37,7 @@ public struct Region: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Region``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Rkp/V20191209/client.swift
+++ b/Sources/Teco/Rkp/V20191209/client.swift
@@ -35,7 +35,7 @@ public struct Rkp: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Rkp``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Rp/V20200224/client.swift
+++ b/Sources/Teco/Rp/V20200224/client.swift
@@ -35,7 +35,7 @@ public struct Rp: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Rp``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Rum/V20210622/client.swift
+++ b/Sources/Teco/Rum/V20210622/client.swift
@@ -37,7 +37,7 @@ public struct Rum: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Rum``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Scf/V20180416/client.swift
+++ b/Sources/Teco/Scf/V20180416/client.swift
@@ -37,7 +37,7 @@ public struct Scf: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Scf``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Ses/V20201002/client.swift
+++ b/Sources/Teco/Ses/V20201002/client.swift
@@ -37,7 +37,7 @@ public struct Ses: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Ses``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Smh/V20210712/client.swift
+++ b/Sources/Teco/Smh/V20210712/client.swift
@@ -37,7 +37,7 @@ public struct Smh: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Smh``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Smop/V20201203/client.swift
+++ b/Sources/Teco/Smop/V20201203/client.swift
@@ -37,7 +37,7 @@ public struct Smop: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Smop``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Smpn/V20190822/client.swift
+++ b/Sources/Teco/Smpn/V20190822/client.swift
@@ -37,7 +37,7 @@ public struct Smpn: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Smpn``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Sms/V20190711/client.swift
+++ b/Sources/Teco/Sms/V20190711/client.swift
@@ -37,7 +37,7 @@ public struct Sms: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Sms``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Sms/V20210111/client.swift
+++ b/Sources/Teco/Sms/V20210111/client.swift
@@ -37,7 +37,7 @@ public struct Sms: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Sms``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Soe/V20180724/client.swift
+++ b/Sources/Teco/Soe/V20180724/client.swift
@@ -37,7 +37,7 @@ public struct Soe: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Soe``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Solar/V20181011/client.swift
+++ b/Sources/Teco/Solar/V20181011/client.swift
@@ -35,7 +35,7 @@ public struct Solar: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Solar``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Sqlserver/V20180328/client.swift
+++ b/Sources/Teco/Sqlserver/V20180328/client.swift
@@ -37,7 +37,7 @@ public struct Sqlserver: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Sqlserver``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Ssa/V20180608/client.swift
+++ b/Sources/Teco/Ssa/V20180608/client.swift
@@ -37,7 +37,7 @@ public struct Ssa: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Ssa``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Ssl/V20191205/client.swift
+++ b/Sources/Teco/Ssl/V20191205/client.swift
@@ -37,7 +37,7 @@ public struct Ssl: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Ssl``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Sslpod/V20190605/client.swift
+++ b/Sources/Teco/Sslpod/V20190605/client.swift
@@ -37,7 +37,7 @@ public struct Sslpod: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Sslpod``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Ssm/V20190923/client.swift
+++ b/Sources/Teco/Ssm/V20190923/client.swift
@@ -37,7 +37,7 @@ public struct Ssm: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Ssm``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Sts/V20180813/client.swift
+++ b/Sources/Teco/Sts/V20180813/client.swift
@@ -35,7 +35,7 @@ public struct Sts: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Sts``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Taf/V20200210/client.swift
+++ b/Sources/Teco/Taf/V20200210/client.swift
@@ -37,7 +37,7 @@ public struct Taf: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Taf``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Tag/V20180813/client.swift
+++ b/Sources/Teco/Tag/V20180813/client.swift
@@ -37,7 +37,7 @@ public struct Tag: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Tag``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Tan/V20220420/client.swift
+++ b/Sources/Teco/Tan/V20220420/client.swift
@@ -37,7 +37,7 @@ public struct Tan: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Tan``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Tat/V20201028/client.swift
+++ b/Sources/Teco/Tat/V20201028/client.swift
@@ -37,7 +37,7 @@ public struct Tat: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Tat``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Tav/V20190118/client.swift
+++ b/Sources/Teco/Tav/V20190118/client.swift
@@ -35,7 +35,7 @@ public struct Tav: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Tav``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Tbaas/V20180416/client.swift
+++ b/Sources/Teco/Tbaas/V20180416/client.swift
@@ -37,7 +37,7 @@ public struct Tbaas: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Tbaas``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Tbm/V20180129/client.swift
+++ b/Sources/Teco/Tbm/V20180129/client.swift
@@ -35,7 +35,7 @@ public struct Tbm: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Tbm``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Tbp/V20190311/client.swift
+++ b/Sources/Teco/Tbp/V20190311/client.swift
@@ -37,7 +37,7 @@ public struct Tbp: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Tbp``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Tbp/V20190627/client.swift
+++ b/Sources/Teco/Tbp/V20190627/client.swift
@@ -37,7 +37,7 @@ public struct Tbp: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Tbp``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Tcaplusdb/V20190823/client.swift
+++ b/Sources/Teco/Tcaplusdb/V20190823/client.swift
@@ -37,7 +37,7 @@ public struct Tcaplusdb: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Tcaplusdb``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Tcb/V20180608/client.swift
+++ b/Sources/Teco/Tcb/V20180608/client.swift
@@ -37,7 +37,7 @@ public struct Tcb: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Tcb``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Tcbr/V20220217/client.swift
+++ b/Sources/Teco/Tcbr/V20220217/client.swift
@@ -37,7 +37,7 @@ public struct Tcbr: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Tcbr``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Tcex/V20200727/client.swift
+++ b/Sources/Teco/Tcex/V20200727/client.swift
@@ -35,7 +35,7 @@ public struct Tcex: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Tcex``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Tchd/V20230306/client.swift
+++ b/Sources/Teco/Tchd/V20230306/client.swift
@@ -37,7 +37,7 @@ public struct Tchd: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Tchd``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Tci/V20190318/client.swift
+++ b/Sources/Teco/Tci/V20190318/client.swift
@@ -37,7 +37,7 @@ public struct Tci: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Tci``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Tcm/V20210413/client.swift
+++ b/Sources/Teco/Tcm/V20210413/client.swift
@@ -35,7 +35,7 @@ public struct Tcm: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Tcm``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Tcr/V20190924/client.swift
+++ b/Sources/Teco/Tcr/V20190924/client.swift
@@ -37,7 +37,7 @@ public struct Tcr: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Tcr``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Tcss/V20201101/client.swift
+++ b/Sources/Teco/Tcss/V20201101/client.swift
@@ -37,7 +37,7 @@ public struct Tcss: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Tcss``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Tdcpg/V20211118/client.swift
+++ b/Sources/Teco/Tdcpg/V20211118/client.swift
@@ -37,7 +37,7 @@ public struct Tdcpg: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Tdcpg``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Tdid/V20210519/client.swift
+++ b/Sources/Teco/Tdid/V20210519/client.swift
@@ -37,7 +37,7 @@ public struct Tdid: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Tdid``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Tdmq/V20200217/client.swift
+++ b/Sources/Teco/Tdmq/V20200217/client.swift
@@ -37,7 +37,7 @@ public struct Tdmq: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Tdmq``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Tds/V20220801/client.swift
+++ b/Sources/Teco/Tds/V20220801/client.swift
@@ -37,7 +37,7 @@ public struct Tds: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Tds``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Tem/V20201221/client.swift
+++ b/Sources/Teco/Tem/V20201221/client.swift
@@ -37,7 +37,7 @@ public struct Tem: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Tem``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Tem/V20210701/client.swift
+++ b/Sources/Teco/Tem/V20210701/client.swift
@@ -37,7 +37,7 @@ public struct Tem: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Tem``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Teo/V20220106/client.swift
+++ b/Sources/Teco/Teo/V20220106/client.swift
@@ -37,7 +37,7 @@ public struct Teo: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Teo``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Teo/V20220901/client.swift
+++ b/Sources/Teco/Teo/V20220901/client.swift
@@ -37,7 +37,7 @@ public struct Teo: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Teo``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Thpc/V20211109/client.swift
+++ b/Sources/Teco/Thpc/V20211109/client.swift
@@ -37,7 +37,7 @@ public struct Thpc: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Thpc``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Thpc/V20220401/client.swift
+++ b/Sources/Teco/Thpc/V20220401/client.swift
@@ -37,7 +37,7 @@ public struct Thpc: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Thpc``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Thpc/V20230321/client.swift
+++ b/Sources/Teco/Thpc/V20230321/client.swift
@@ -37,7 +37,7 @@ public struct Thpc: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Thpc``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Tia/V20180226/client.swift
+++ b/Sources/Teco/Tia/V20180226/client.swift
@@ -35,7 +35,7 @@ public struct Tia: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Tia``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Tic/V20201117/client.swift
+++ b/Sources/Teco/Tic/V20201117/client.swift
@@ -37,7 +37,7 @@ public struct Tic: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Tic``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Ticm/V20181127/client.swift
+++ b/Sources/Teco/Ticm/V20181127/client.swift
@@ -35,7 +35,7 @@ public struct Ticm: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Ticm``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Tics/V20181115/client.swift
+++ b/Sources/Teco/Tics/V20181115/client.swift
@@ -37,7 +37,7 @@ public struct Tics: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Tics``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Tiems/V20190416/client.swift
+++ b/Sources/Teco/Tiems/V20190416/client.swift
@@ -37,7 +37,7 @@ public struct Tiems: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Tiems``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Tiia/V20190529/client.swift
+++ b/Sources/Teco/Tiia/V20190529/client.swift
@@ -37,7 +37,7 @@ public struct Tiia: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Tiia``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Tione/V20191022/client.swift
+++ b/Sources/Teco/Tione/V20191022/client.swift
@@ -37,7 +37,7 @@ public struct Tione: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Tione``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Tione/V20211111/client.swift
+++ b/Sources/Teco/Tione/V20211111/client.swift
@@ -37,7 +37,7 @@ public struct Tione: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Tione``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Tiw/V20190919/client.swift
+++ b/Sources/Teco/Tiw/V20190919/client.swift
@@ -37,7 +37,7 @@ public struct Tiw: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Tiw``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Tke/V20180525/client.swift
+++ b/Sources/Teco/Tke/V20180525/client.swift
@@ -37,7 +37,7 @@ public struct Tke: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Tke``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Tkgdq/V20190411/client.swift
+++ b/Sources/Teco/Tkgdq/V20190411/client.swift
@@ -35,7 +35,7 @@ public struct Tkgdq: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Tkgdq``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Tms/V20200713/client.swift
+++ b/Sources/Teco/Tms/V20200713/client.swift
@@ -37,7 +37,7 @@ public struct Tms: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Tms``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Tms/V20201229/client.swift
+++ b/Sources/Teco/Tms/V20201229/client.swift
@@ -37,7 +37,7 @@ public struct Tms: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Tms``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Tmt/V20180321/client.swift
+++ b/Sources/Teco/Tmt/V20180321/client.swift
@@ -37,7 +37,7 @@ public struct Tmt: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Tmt``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Tourism/V20230215/client.swift
+++ b/Sources/Teco/Tourism/V20230215/client.swift
@@ -37,7 +37,7 @@ public struct Tourism: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Tourism``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Trdp/V20220726/client.swift
+++ b/Sources/Teco/Trdp/V20220726/client.swift
@@ -37,7 +37,7 @@ public struct Trdp: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Trdp``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Trocket/V20230308/client.swift
+++ b/Sources/Teco/Trocket/V20230308/client.swift
@@ -37,7 +37,7 @@ public struct Trocket: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Trocket``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Trp/V20210515/client.swift
+++ b/Sources/Teco/Trp/V20210515/client.swift
@@ -37,7 +37,7 @@ public struct Trp: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Trp``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Trro/V20220325/client.swift
+++ b/Sources/Teco/Trro/V20220325/client.swift
@@ -37,7 +37,7 @@ public struct Trro: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Trro``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Trtc/V20190722/client.swift
+++ b/Sources/Teco/Trtc/V20190722/client.swift
@@ -37,7 +37,7 @@ public struct Trtc: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Trtc``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Tse/V20201207/client.swift
+++ b/Sources/Teco/Tse/V20201207/client.swift
@@ -37,7 +37,7 @@ public struct Tse: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Tse``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Tsf/V20180326/client.swift
+++ b/Sources/Teco/Tsf/V20180326/client.swift
@@ -37,7 +37,7 @@ public struct Tsf: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Tsf``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Tsw/V20200924/client.swift
+++ b/Sources/Teco/Tsw/V20200924/client.swift
@@ -39,7 +39,7 @@ public struct Tsw: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Tsw``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Tsw/V20210412/client.swift
+++ b/Sources/Teco/Tsw/V20210412/client.swift
@@ -39,7 +39,7 @@ public struct Tsw: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Tsw``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Tts/V20190823/client.swift
+++ b/Sources/Teco/Tts/V20190823/client.swift
@@ -37,7 +37,7 @@ public struct Tts: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Tts``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Ump/V20200918/client.swift
+++ b/Sources/Teco/Ump/V20200918/client.swift
@@ -37,7 +37,7 @@ public struct Ump: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Ump``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Vm/V20200709/client.swift
+++ b/Sources/Teco/Vm/V20200709/client.swift
@@ -37,7 +37,7 @@ public struct Vm: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Vm``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Vm/V20201229/client.swift
+++ b/Sources/Teco/Vm/V20201229/client.swift
@@ -37,7 +37,7 @@ public struct Vm: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Vm``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Vm/V20210922/client.swift
+++ b/Sources/Teco/Vm/V20210922/client.swift
@@ -37,7 +37,7 @@ public struct Vm: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Vm``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Vms/V20200902/client.swift
+++ b/Sources/Teco/Vms/V20200902/client.swift
@@ -37,7 +37,7 @@ public struct Vms: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Vms``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Vod/V20180717/client.swift
+++ b/Sources/Teco/Vod/V20180717/client.swift
@@ -37,7 +37,7 @@ public struct Vod: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Vod``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Vpc/V20170312/client.swift
+++ b/Sources/Teco/Vpc/V20170312/client.swift
@@ -37,7 +37,7 @@ public struct Vpc: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Vpc``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Vrs/V20200824/client.swift
+++ b/Sources/Teco/Vrs/V20200824/client.swift
@@ -37,7 +37,7 @@ public struct Vrs: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Vrs``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Waf/V20180125/client.swift
+++ b/Sources/Teco/Waf/V20180125/client.swift
@@ -37,7 +37,7 @@ public struct Waf: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Waf``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Wav/V20210129/client.swift
+++ b/Sources/Teco/Wav/V20210129/client.swift
@@ -37,7 +37,7 @@ public struct Wav: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Wav``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Wedata/V20210820/client.swift
+++ b/Sources/Teco/Wedata/V20210820/client.swift
@@ -39,7 +39,7 @@ public struct Wedata: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Wedata``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Weilingwith/V20230427/client.swift
+++ b/Sources/Teco/Weilingwith/V20230427/client.swift
@@ -37,7 +37,7 @@ public struct Weilingwith: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Weilingwith``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Wss/V20180426/client.swift
+++ b/Sources/Teco/Wss/V20180426/client.swift
@@ -35,7 +35,7 @@ public struct Wss: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Wss``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Yinsuda/V20220527/client.swift
+++ b/Sources/Teco/Yinsuda/V20220527/client.swift
@@ -37,7 +37,7 @@ public struct Yinsuda: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Yinsuda``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Youmall/V20180228/client.swift
+++ b/Sources/Teco/Youmall/V20180228/client.swift
@@ -35,7 +35,7 @@ public struct Youmall: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Youmall``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Yunjing/V20180228/client.swift
+++ b/Sources/Teco/Yunjing/V20180228/client.swift
@@ -37,7 +37,7 @@ public struct Yunjing: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Yunjing``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Yunsou/V20180504/client.swift
+++ b/Sources/Teco/Yunsou/V20180504/client.swift
@@ -37,7 +37,7 @@ public struct Yunsou: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Yunsou``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Yunsou/V20191115/client.swift
+++ b/Sources/Teco/Yunsou/V20191115/client.swift
@@ -37,7 +37,7 @@ public struct Yunsou: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Yunsou``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,

--- a/Sources/Teco/Zj/V20190121/client.swift
+++ b/Sources/Teco/Zj/V20190121/client.swift
@@ -41,7 +41,7 @@ public struct Zj: TCService {
     ///    - timeout: Timeout value for HTTP requests.
     ///    - byteBufferAllocator: Byte buffer allocator used throughout ``Zj``.
     public init(
-        client: TCClient,
+        client: TCClient = .shared,
         region: TCRegion? = nil,
         language: TCServiceConfig.Language? = nil,
         endpoint: TCServiceConfig.Endpoint = .global,


### PR DESCRIPTION
This PR updates service initializers with default `client` as `TCClient.shared`, introduced in Teco Core v0.5.6.

Companioned by https://github.com/teco-project/teco-code-generators/pull/49.