### PR TITLE
Improves case-by-case documentation of wrapped date members

### DIFF
--- a/Sources/Teco/Ams/V20201229/actions/DescribeTasks.swift
+++ b/Sources/Teco/Ams/V20201229/actions/DescribeTasks.swift
@@ -36,16 +36,16 @@ extension Ams {
         ///
         /// 备注：该参数与Filter共同起到任务筛选作用，二者作用无先后顺序。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var startTime: Date?
 
         /// 该参数表示任务列表的结束时间，格式为ISO8601标准的时间戳。**默认值为空**，若传入该参数，则在这StartTime到这一时间之间的任务将会被筛选出来。
         ///
         /// 备注：该参数与Filter共同起到任务筛选作用，二者作用无先后顺序。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var endTime: Date?
 
         public init(limit: Int64? = nil, filter: TaskFilter? = nil, pageToken: String? = nil, startTime: Date? = nil, endTime: Date? = nil) {

--- a/Sources/Teco/Antiddos/V20200309/actions/DescribeBizMonitorTrend.swift
+++ b/Sources/Teco/Antiddos/V20200309/actions/DescribeBizMonitorTrend.swift
@@ -28,14 +28,14 @@ extension Antiddos {
 
         /// 统计开始时间。 例：“2020-09-22 00:00:00”
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 统计结束时间。 例：“2020-09-22 00:00:00”
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// 资源实例ID

--- a/Sources/Teco/Antiddos/V20200309/actions/DescribeBizTrend.swift
+++ b/Sources/Teco/Antiddos/V20200309/actions/DescribeBizTrend.swift
@@ -34,14 +34,14 @@ extension Antiddos {
 
         /// 统计开始时间。 例：“2020-09-22 00:00:00”
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 统计结束时间。 例：“2020-09-22 00:00:00”
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// 资源实例ID

--- a/Sources/Teco/Antiddos/V20200309/actions/DescribeCCTrend.swift
+++ b/Sources/Teco/Antiddos/V20200309/actions/DescribeCCTrend.swift
@@ -34,14 +34,14 @@ extension Antiddos {
 
         /// 统计开始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 统计结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// 指标，取值[inqps(总请求峰值，dropqps(攻击请求峰值))，incount(请求次数), dropcount(攻击次数)]
@@ -92,14 +92,14 @@ extension Antiddos {
 
         /// 统计开始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 统计结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// 值数组

--- a/Sources/Teco/Antiddos/V20200309/actions/DescribeDDoSTrend.swift
+++ b/Sources/Teco/Antiddos/V20200309/actions/DescribeDDoSTrend.swift
@@ -34,14 +34,14 @@ extension Antiddos {
 
         /// 统计开始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 统计结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// 指标，取值[bps(攻击流量带宽，pps(攻击包速率))]
@@ -87,14 +87,14 @@ extension Antiddos {
 
         /// 统计开始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 统计结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// 值数组，攻击流量带宽单位为Mbps，包速率单位为pps

--- a/Sources/Teco/Antiddos/V20200309/actions/DescribeOverviewCCTrend.swift
+++ b/Sources/Teco/Antiddos/V20200309/actions/DescribeOverviewCCTrend.swift
@@ -28,14 +28,14 @@ extension Antiddos {
 
         /// 统计开始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 统计结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// 指标，取值[inqps(总请求峰值，dropqps(攻击请求峰值))，incount(请求次数), dropcount(攻击次数)]

--- a/Sources/Teco/Antiddos/V20200309/actions/DescribeOverviewDDoSTrend.swift
+++ b/Sources/Teco/Antiddos/V20200309/actions/DescribeOverviewDDoSTrend.swift
@@ -28,14 +28,14 @@ extension Antiddos {
 
         /// 统计开始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 统计结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// 指标，取值[bps(攻击流量带宽，pps(攻击包速率))]

--- a/Sources/Teco/Antiddos/V20200309/models.swift
+++ b/Sources/Teco/Antiddos/V20200309/models.swift
@@ -129,14 +129,14 @@ extension Antiddos {
 
         /// 到期时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$expiredTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var expiredTime: Date
 
         /// 购买时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createdTime: Date
 
         /// 资产实例的名称
@@ -334,14 +334,14 @@ extension Antiddos {
 
         /// 购买时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createdTime: Date
 
         /// 到期时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$expiredTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var expiredTime: Date
 
         /// 资产实例的名称
@@ -583,14 +583,14 @@ extension Antiddos {
 
         /// 创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date
 
         /// 修改时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$modifyTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var modifyTime: Date
 
         enum CodingKeys: String, CodingKey {
@@ -658,14 +658,14 @@ extension Antiddos {
 
         /// 创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date
 
         /// 修改时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$modifyTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var modifyTime: Date
 
         enum CodingKeys: String, CodingKey {
@@ -703,14 +703,14 @@ extension Antiddos {
 
         /// 创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date
 
         /// 修改时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$modifyTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var modifyTime: Date
 
         enum CodingKeys: String, CodingKey {
@@ -793,14 +793,14 @@ extension Antiddos {
 
         /// 创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date
 
         /// 修改时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$modifyTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var modifyTime: Date
 
         enum CodingKeys: String, CodingKey {
@@ -1186,8 +1186,8 @@ extension Antiddos {
 
         /// 当前到期时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$curDeadline`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var curDeadline: Date
 
         enum CodingKeys: String, CodingKey {
@@ -1927,8 +1927,8 @@ extension Antiddos {
 
         /// 修改时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$modifyTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var modifyTime: Date?
 
         /// 是否开启Https协议使用Http回源，取值[0(关闭), 1(开启)]，不填写默认是关闭
@@ -2526,14 +2526,14 @@ extension Antiddos {
 
         /// 创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createdTime: Date
 
         /// 最后修改时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$modifyTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var modifyTime: Date
 
         /// 域名名称
@@ -2746,8 +2746,8 @@ extension Antiddos {
 
         /// 密钥生成时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date
 
         public init(keyVersion: String, keyContent: String, keyId: String, keyOpenStatus: Int64, createTime: Date) {

--- a/Sources/Teco/Apcas/V20201127/models.swift
+++ b/Sources/Teco/Apcas/V20201127/models.swift
@@ -29,8 +29,8 @@ extension Apcas {
 
         /// 调用时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$date`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var date: Date
 
         enum CodingKeys: String, CodingKey {
@@ -58,8 +58,8 @@ extension Apcas {
     public struct CallStatItem: TCOutputModel {
         /// 当前统计量的时间段
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$date`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var date: Date
 
         /// 当前时间段的调用量

--- a/Sources/Teco/Ape/V20200513/actions/DescribeDownloadInfos.swift
+++ b/Sources/Teco/Ape/V20200513/actions/DescribeDownloadInfos.swift
@@ -31,14 +31,14 @@ extension Ape {
 
         /// 开始时间晚于指定时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$beginTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var beginTime: Date?
 
         /// 结束时间早于指定时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var endTime: Date?
 
         /// 无效值，过滤结果为空

--- a/Sources/Teco/Ape/V20200513/models.swift
+++ b/Sources/Teco/Ape/V20200513/models.swift
@@ -61,8 +61,8 @@ extension Ape {
 
         /// 订单创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$orderCreateTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var orderCreateTime: Date
 
         /// 下载Id
@@ -70,8 +70,8 @@ extension Ape {
 
         /// 下载时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$downloadTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var downloadTime: Date
 
         /// 图片购买类型，单张/会员

--- a/Sources/Teco/Apigateway/V20180808/actions/CreateService.swift
+++ b/Sources/Teco/Apigateway/V20180808/actions/CreateService.swift
@@ -99,8 +99,8 @@ extension Apigateway {
 
         /// 服务创建时间。按照 ISO8601 标准表示，并且使用 UTC 时间。格式为：YYYY-MM-DDThh:mm:ssZ。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createdTime: Date
 
         /// 网络类型列表，INNER为内网访问，OUTER为外网访问。

--- a/Sources/Teco/Apigateway/V20180808/actions/DescribeLogSearch.swift
+++ b/Sources/Teco/Apigateway/V20180808/actions/DescribeLogSearch.swift
@@ -25,14 +25,14 @@ extension Apigateway {
     public struct DescribeLogSearchRequest: TCRequest {
         /// 日志开始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 日志结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// 服务id

--- a/Sources/Teco/Apigateway/V20180808/actions/DescribeService.swift
+++ b/Sources/Teco/Apigateway/V20180808/actions/DescribeService.swift
@@ -55,14 +55,14 @@ extension Apigateway {
 
         /// 服务创建时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createdTime: Date
 
         /// 服务修改时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$modifiedTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var modifiedTime: Date
 
         /// 网络类型列表，INNER为内网访问，OUTER为外网访问。

--- a/Sources/Teco/Apigateway/V20180808/actions/DescribeServiceForApiApp.swift
+++ b/Sources/Teco/Apigateway/V20180808/actions/DescribeServiceForApiApp.swift
@@ -63,15 +63,15 @@ extension Apigateway {
         /// 服务创建时间。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createdTime: Date?
 
         /// 服务修改时间。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$modifiedTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var modifiedTime: Date?
 
         /// 网络类型列表，INNER为内网访问，OUTER为外网访问。

--- a/Sources/Teco/Apigateway/V20180808/models.swift
+++ b/Sources/Teco/Apigateway/V20180808/models.swift
@@ -65,8 +65,8 @@ extension Apigateway {
 
         /// API文档更新时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updatedTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var updatedTime: Date
 
         /// 服务ID
@@ -140,8 +140,8 @@ extension Apigateway {
         /// 授权绑定时间，按照 ISO8601 标准表示，并且使用 UTC 时间。格式为：YYYY-MM-DDThh:mm:ssZ。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$authorizedTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var authorizedTime: Date?
 
         /// Api所属地域
@@ -200,15 +200,15 @@ extension Apigateway {
         /// 创建时间，按照 ISO8601 标准表示，并且使用 UTC 时间。格式为：YYYY-MM-DDThh:mm:ssZ。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createdTime: Date?
 
         /// 修改时间，按照 ISO8601 标准表示，并且使用 UTC 时间。格式为：YYYY-MM-DDThh:mm:ssZ。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$modifiedTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var modifiedTime: Date?
 
         /// 应用KEY
@@ -304,14 +304,14 @@ extension Apigateway {
 
         /// 服务创建时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createdTime: Date
 
         /// 服务修改时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$modifiedTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var modifiedTime: Date
 
         /// API名称。
@@ -406,15 +406,15 @@ extension Apigateway {
         /// 创建时间，按照 ISO8601 标准表示，并且使用 UTC 时间。格式为：YYYY-MM-DDThh:mm:ssZ。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createdTime: Date?
 
         /// 最后修改时间，按照 ISO8601 标准表示，并且使用 UTC 时间。格式为：YYYY-MM-DDThh:mm:ssZ。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$modifiedTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var modifiedTime: Date?
 
         /// API 接口的名称。
@@ -678,8 +678,8 @@ extension Apigateway {
 
         /// 最后一次修改时间。按照 ISO8601 标准表示，并且使用 UTC 时间。格式为：YYYY-MM-DDThh:mm:ssZ。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$modifiedTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var modifiedTime: Date
 
         /// 密钥状态。0表示禁用，1表示启用。
@@ -687,8 +687,8 @@ extension Apigateway {
 
         /// 创建时间。按照 ISO8601 标准表示，并且使用 UTC 时间。格式为：YYYY-MM-DDThh:mm:ssZ。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createdTime: Date
 
         enum CodingKeys: String, CodingKey {
@@ -790,15 +790,15 @@ extension Apigateway {
         /// 使用计划创建时间。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createdTime: Date?
 
         /// 使用计划最后修改时间。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$modifiedTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var modifiedTime: Date?
 
         /// 服务名称。
@@ -871,8 +871,8 @@ extension Apigateway {
 
         /// 插件和API绑定时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$attachedTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var attachedTime: Date
 
         enum CodingKeys: String, CodingKey {
@@ -1029,8 +1029,8 @@ extension Apigateway {
 
         /// 绑定时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$bindTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var bindTime: Date
 
         enum CodingKeys: String, CodingKey {
@@ -1134,8 +1134,8 @@ extension Apigateway {
         /// 创建时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createdTime: Date?
 
         enum CodingKeys: String, CodingKey {
@@ -1163,8 +1163,8 @@ extension Apigateway {
         /// 创建时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createdTime: Date?
 
         /// 导入状态
@@ -1219,15 +1219,15 @@ extension Apigateway {
         /// 创建时间。按照 ISO8601 标准表示，并且使用 UTC 时间。格式为：YYYY-MM-DDThh:mm:ssZ。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createdTime: Date?
 
         /// 最后修改时间。按照 ISO8601 标准表示，并且使用 UTC 时间。格式为：YYYY-MM-DDThh:mm:ssZ。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$modifiedTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var modifiedTime: Date?
 
         /// API 接口的名称。
@@ -1370,15 +1370,15 @@ extension Apigateway {
         /// 创建时间。按照 ISO8601 标准表示，并且使用 UTC 时间。格式为：YYYY-MM-DDThh:mm:ssZ。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createdTime: Date?
 
         /// 最后修改时间。按照 ISO8601 标准表示，并且使用 UTC 时间。格式为：YYYY-MM-DDThh:mm:ssZ。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$modifiedTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var modifiedTime: Date?
 
         /// API 接口的名称。
@@ -1741,15 +1741,15 @@ extension Apigateway {
         /// 创建时间。按照 ISO8601 标准表示，并且使用 UTC 时间。格式为：YYYY-MM-DDThh:mm:ssZ。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createdTime: Date?
 
         /// 修改时间。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$modifiedTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var modifiedTime: Date?
 
         /// 最后修改时间。按照 ISO8601 标准表示，并且使用 UTC 时间。格式为：YYYY-MM-DDThh:mm:ssZ。
@@ -1834,8 +1834,8 @@ extension Apigateway {
 
         /// 预付费到期时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$expiredTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var expiredTime: Date
 
         enum CodingKeys: String, CodingKey {
@@ -1884,14 +1884,14 @@ extension Apigateway {
 
         /// 独享实例隔离时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$isolationStartedTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var isolationStartedTime: Date
 
         /// 创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createdTime: Date
 
         /// 可用区列表
@@ -1938,8 +1938,8 @@ extension Apigateway {
 
         /// 独享实例创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createdTime: Date
 
         /// 订单号
@@ -2180,8 +2180,8 @@ extension Apigateway {
 
         /// 创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createdTime: Date
 
         /// 健康检查配置
@@ -2291,8 +2291,8 @@ extension Apigateway {
 
         /// 修改时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$modifedTime`) in case the synthesized encoding is incorrect.
         @available(*, deprecated)
         @TCTimestampISO8601Encoding public var modifedTime: Date?
 
@@ -2362,14 +2362,14 @@ extension Apigateway {
 
         /// 插件创建时间。按照 ISO8601 标准表示，并且使用 UTC 时间。格式为：YYYY-MM-DDThh:mm:ssZ。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createdTime: Date
 
         /// 插件修改时间。按照 ISO8601 标准表示，并且使用 UTC 时间。格式为：YYYY-MM-DDThh:mm:ssZ。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$modifiedTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var modifiedTime: Date
 
         /// 插件绑定的API总数。
@@ -2571,8 +2571,8 @@ extension Apigateway {
         /// 最后修改时间。按照 ISO8601 标准表示，并且使用 UTC 时间。格式为：YYYY-MM-DDThh:mm:ssZ。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$modifiedTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var modifiedTime: Date?
 
         /// 服务支持的网络类型。
@@ -2606,8 +2606,8 @@ extension Apigateway {
         /// 创建时间。按照 ISO8601 标准表示，并且使用 UTC 时间。格式为：YYYY-MM-DDThh:mm:ssZ。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createdTime: Date?
 
         /// 内网访问http端口。
@@ -3110,8 +3110,8 @@ extension Apigateway {
 
         /// 创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createdTime: Date
 
         /// 标签
@@ -3243,14 +3243,14 @@ extension Apigateway {
 
         /// 使用计划时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createdTime: Date
 
         /// 使用计划修改时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$modifiedTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var modifiedTime: Date
 
         enum CodingKeys: String, CodingKey {
@@ -3358,15 +3358,15 @@ extension Apigateway {
         /// 创建时间。按照 ISO8601 标准表示，并且使用 UTC 时间。格式为：YYYY-MM-DDThh:mm:ssZ。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createdTime: Date?
 
         /// 最后修改时间。按照 ISO8601 标准表示，并且使用 UTC 时间。格式为：YYYY-MM-DDThh:mm:ssZ。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$modifiedTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var modifiedTime: Date?
 
         /// 服务名称。
@@ -3430,15 +3430,15 @@ extension Apigateway {
         /// 创建时间。按照 ISO8601 标准表示，并且使用 UTC 时间。格式为：YYYY-MM-DDThh:mm:ssZ。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createdTime: Date?
 
         /// 最后修改时间。按照 ISO8601 标准表示，并且使用 UTC 时间。格式为：YYYY-MM-DDThh:mm:ssZ。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$modifiedTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var modifiedTime: Date?
 
         /// 绑定密钥的数量。
@@ -3497,15 +3497,15 @@ extension Apigateway {
         /// 创建时间。按照 ISO8601 标准表示，并且使用 UTC 时间。格式为：YYYY-MM-DDThh:mm:ssZ。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createdTime: Date?
 
         /// 最后修改时间。按照 ISO8601 标准表示，并且使用 UTC 时间。格式为：YYYY-MM-DDThh:mm:ssZ。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$modifiedTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var modifiedTime: Date?
 
         enum CodingKeys: String, CodingKey {

--- a/Sources/Teco/Asr/V20190614/actions/GetAsrVocab.swift
+++ b/Sources/Teco/Asr/V20190614/actions/GetAsrVocab.swift
@@ -51,14 +51,14 @@ extension Asr {
 
         /// 词表创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createTime: Date
 
         /// 词表更新时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updateTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var updateTime: Date
 
         /// 热词表状态，1为默认状态即在识别时默认加载该热词表进行识别，0为初始状态

--- a/Sources/Teco/Asr/V20190614/models.swift
+++ b/Sources/Teco/Asr/V20190614/models.swift
@@ -277,14 +277,14 @@ extension Asr {
 
         /// 词表创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createTime: Date
 
         /// 词表更新时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updateTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var updateTime: Date
 
         /// 热词表状态，1为默认状态即在识别时默认加载该热词表进行识别，0为初始状态

--- a/Sources/Teco/Autoscaling/V20180419/actions/CreateScheduledAction.swift
+++ b/Sources/Teco/Autoscaling/V20180419/actions/CreateScheduledAction.swift
@@ -40,16 +40,16 @@ extension As {
 
         /// 定时任务的首次触发时间，取值为`北京时间`（UTC+8），按照`ISO8601`标准，格式：`YYYY-MM-DDThh:mm:ss+08:00`。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var startTime: Date
 
         /// 定时任务的结束时间，取值为`北京时间`（UTC+8），按照`ISO8601`标准，格式：`YYYY-MM-DDThh:mm:ss+08:00`。
         ///
         /// 此参数与`Recurrence`需要同时指定，到达结束时间之后，定时任务将不再生效。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var endTime: Date?
 
         /// 定时任务的重复方式。为标准 Cron 格式

--- a/Sources/Teco/Autoscaling/V20180419/actions/DescribeAutoScalingActivities.swift
+++ b/Sources/Teco/Autoscaling/V20180419/actions/DescribeAutoScalingActivities.swift
@@ -43,14 +43,14 @@ extension As {
 
         /// 伸缩活动最早的开始时间，如果指定了ActivityIds，此参数将被忽略。取值为`UTC`时间，按照`ISO8601`标准，格式：`YYYY-MM-DDThh:mm:ssZ`。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var startTime: Date?
 
         /// 伸缩活动最晚的结束时间，如果指定了ActivityIds，此参数将被忽略。取值为`UTC`时间，按照`ISO8601`标准，格式：`YYYY-MM-DDThh:mm:ssZ`。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var endTime: Date?
 
         public init(activityIds: [String]? = nil, filters: [Filter]? = nil, limit: UInt64? = nil, offset: UInt64? = nil, startTime: Date? = nil, endTime: Date? = nil) {

--- a/Sources/Teco/Autoscaling/V20180419/actions/ModifyScheduledAction.swift
+++ b/Sources/Teco/Autoscaling/V20180419/actions/ModifyScheduledAction.swift
@@ -40,16 +40,16 @@ extension As {
 
         /// 定时任务的首次触发时间，取值为`北京时间`（UTC+8），按照`ISO8601`标准，格式：`YYYY-MM-DDThh:mm:ss+08:00`。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var startTime: Date?
 
         /// 定时任务的结束时间，取值为`北京时间`（UTC+8），按照`ISO8601`标准，格式：`YYYY-MM-DDThh:mm:ss+08:00`。
         ///
         /// 此参数与`Recurrence`需要同时指定，到达结束时间之后，定时任务将不再生效。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var endTime: Date?
 
         /// 定时任务的重复方式。为标准 Cron 格式

--- a/Sources/Teco/Autoscaling/V20180419/models.swift
+++ b/Sources/Teco/Autoscaling/V20180419/models.swift
@@ -62,20 +62,20 @@ extension As {
 
         /// 伸缩活动开始时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var startTime: Date
 
         /// 伸缩活动结束时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var endTime: Date
 
         /// 伸缩活动创建时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createdTime: Date
 
         /// 该参数已废弃，请勿使用。
@@ -206,8 +206,8 @@ extension As {
 
         /// 创建时间，采用UTC标准计时
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createdTime: Date
 
         /// 默认冷却时间，单位秒
@@ -723,8 +723,8 @@ extension As {
 
         /// 实例加入时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$addTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var addTime: Date
 
         /// 实例类型
@@ -975,8 +975,8 @@ extension As {
 
         /// 启动配置创建时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createdTime: Date
 
         /// 实例的增强服务启用情况与其设置。
@@ -1018,8 +1018,8 @@ extension As {
 
         /// 更新时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updatedTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var updatedTime: Date
 
         /// CAM角色名称。可通过DescribeRoleList接口返回值中的roleName获取。
@@ -1185,8 +1185,8 @@ extension As {
 
         /// 创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createdTime: Date
 
         /// 通知目标
@@ -1410,22 +1410,22 @@ extension As {
         /// 刷新活动开始时间。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var startTime: Date?
 
         /// 刷新活动结束时间。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var endTime: Date?
 
         /// 刷新活动创建时间。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createdTime: Date?
 
         enum CodingKeys: String, CodingKey {
@@ -1466,15 +1466,15 @@ extension As {
         /// 刷新批次开始时间。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var startTime: Date?
 
         /// 刷新批次结束时间。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var endTime: Date?
 
         enum CodingKeys: String, CodingKey {
@@ -1746,8 +1746,8 @@ extension As {
 
         /// 定时任务的开始时间。取值为`北京时间`（UTC+8），按照`ISO8601`标准，格式：`YYYY-MM-DDThh:mm:ss+08:00`。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var startTime: Date
 
         /// 定时任务的重复方式。
@@ -1755,8 +1755,8 @@ extension As {
 
         /// 定时任务的结束时间。取值为`北京时间`（UTC+8），按照`ISO8601`标准，格式：`YYYY-MM-DDThh:mm:ss+08:00`。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var endTime: Date
 
         /// 定时任务设置的最大实例数。
@@ -1770,8 +1770,8 @@ extension As {
 
         /// 定时任务的创建时间。取值为`UTC`时间，按照`ISO8601`标准，格式：`YYYY-MM-DDThh:mm:ssZ`。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createdTime: Date
 
         /// 定时任务的执行类型。取值范围：

--- a/Sources/Teco/Bi/V20220105/models.swift
+++ b/Sources/Teco/Bi/V20220105/models.swift
@@ -700,8 +700,8 @@ extension Bi {
         /// 最后一次登录时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$lastLogin`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var lastLogin: Date?
 
         /// 停启用状态
@@ -727,8 +727,8 @@ extension Bi {
         /// 创建时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdAt`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createdAt: Date?
 
         /// 更改人
@@ -738,8 +738,8 @@ extension Bi {
         /// 更改时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updatedAt`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var updatedAt: Date?
 
         /// 全局角色
@@ -926,8 +926,8 @@ extension Bi {
         /// 最后一次登录时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$lastLogin`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var lastLogin: Date?
 
         /// 账号状态

--- a/Sources/Teco/Billing/V20180709/actions/DescribeCostDetail.swift
+++ b/Sources/Teco/Billing/V20180709/actions/DescribeCostDetail.swift
@@ -31,14 +31,14 @@ extension Billing {
 
         /// 周期开始时间，格式为yyyy-mm-dd hh:ii:ss，Month和BeginTime&EndTime必传一个，如果有该字段则Month字段无效。BeginTime和EndTime必须一起传，且为同一月份，暂不支持跨月拉取。可拉取的数据是开通成本分析后，且距今 24 个月内的数据。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$beginTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var beginTime: Date?
 
         /// 周期结束时间，格式为yyyy-mm-dd hh:ii:ss，Month和BeginTime&EndTime必传一个，如果有该字段则Month字段无效。BeginTime和EndTime必须一起传，且为同一月份，暂不支持跨月拉取。可拉取的数据是开通成本分析后，且距今 24 个月内的数据。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date?
 
         /// 是否需要访问列表的总记录数，用于前端分页

--- a/Sources/Teco/Billing/V20180709/actions/DescribeDealsByCond.swift
+++ b/Sources/Teco/Billing/V20180709/actions/DescribeDealsByCond.swift
@@ -25,14 +25,14 @@ extension Billing {
     public struct DescribeDealsByCondRequest: TCPaginatedRequest {
         /// 开始时间 2016-01-01 00:00:00
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 结束时间 2016-02-01 00:00:00 建议跨度不超过3个月
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// 一页多少条数据，默认是20条，最大不超过1000

--- a/Sources/Teco/Billing/V20180709/models.swift
+++ b/Sources/Teco/Billing/V20180709/models.swift
@@ -117,20 +117,20 @@ extension Billing {
 
         /// 扣费时间：结算扣费时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$payTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var payTime: Date
 
         /// 开始使用时间：产品服务开始使用时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$feeBeginTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var feeBeginTime: Date
 
         /// 结束使用时间：产品服务结束使用时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$feeEndTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var feeEndTime: Date
 
         /// 组件列表
@@ -444,20 +444,20 @@ extension Billing {
 
         /// 扣费时间：结算扣费时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$payTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var payTime: Date
 
         /// 开始使用时间：产品服务开始使用时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$feeBeginTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var feeBeginTime: Date
 
         /// 结束使用时间：产品服务结束使用时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$feeEndTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var feeEndTime: Date
 
         /// 配置描述：该资源下的计费项名称和用量合并展示，仅在资源账单体现
@@ -610,20 +610,20 @@ extension Billing {
 
         /// 扣费时间：结算扣费时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$payTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var payTime: Date
 
         /// 开始使用时间：产品服务开始使用时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$feeBeginTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var feeBeginTime: Date
 
         /// 结束使用时间：产品服务结束使用时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$feeEndTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var feeEndTime: Date
 
         /// 配置描述：该资源下的计费项名称和用量合并展示，仅在资源账单体现
@@ -1523,8 +1523,8 @@ extension Billing {
 
         /// 创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date
 
         /// 创建人
@@ -1712,20 +1712,20 @@ extension Billing {
 
         /// 扣费时间：结算扣费时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$payTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var payTime: Date
 
         /// 开始使用时间：产品服务开始使用时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$feeBeginTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var feeBeginTime: Date
 
         /// 结束使用时间：产品服务结束使用时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$feeEndTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var feeEndTime: Date
 
         /// 组件列表

--- a/Sources/Teco/Bm/V20180423/actions/DescribeDeviceOperationLog.swift
+++ b/Sources/Teco/Bm/V20180423/actions/DescribeDeviceOperationLog.swift
@@ -28,14 +28,14 @@ extension Bm {
 
         /// 查询开始日期
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var startTime: Date?
 
         /// 查询结束日期
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var endTime: Date?
 
         /// 偏移量

--- a/Sources/Teco/Bm/V20180423/actions/DescribeDevices.swift
+++ b/Sources/Teco/Bm/V20180423/actions/DescribeDevices.swift
@@ -49,14 +49,14 @@ extension Bm {
 
         /// 设备到期时间查询的起始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$deadlineStartTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var deadlineStartTime: Date?
 
         /// 设备到期时间查询的结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$deadlineEndTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var deadlineEndTime: Date?
 
         /// 自动续费标志 0:不自动续费，1:自动续费

--- a/Sources/Teco/Bm/V20180423/actions/DescribeTaskInfo.swift
+++ b/Sources/Teco/Bm/V20180423/actions/DescribeTaskInfo.swift
@@ -31,14 +31,14 @@ extension Bm {
 
         /// 时间过滤下限
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var startDate: Date?
 
         /// 时间过滤上限
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var endDate: Date?
 
         /// 任务状态ID过滤

--- a/Sources/Teco/Bm/V20180423/models.swift
+++ b/Sources/Teco/Bm/V20180423/models.swift
@@ -66,8 +66,8 @@ extension Bm {
 
         /// 创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date
 
         /// 分区信息
@@ -105,8 +105,8 @@ extension Bm {
 
         /// 此步骤开始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 0: 已完成 1: 当前进行 2: 未开始
@@ -408,14 +408,14 @@ extension Bm {
 
         /// 设备交付时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$deliverTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var deliverTime: Date
 
         /// 设备到期时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$deadline`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var deadline: Date
 
         /// 自动续费标识。0: 不自动续费; 1:自动续费
@@ -505,14 +505,14 @@ extension Bm {
 
         /// 操作开始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 操作结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// 操作状态，0: 正在执行中；1：任务成功； 2: 任务失败。
@@ -607,14 +607,14 @@ extension Bm {
 
         /// 设备交付时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$deliverTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var deliverTime: Date
 
         /// 过期时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$deadline`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var deadline: Date
 
         enum CodingKeys: String, CodingKey {
@@ -840,8 +840,8 @@ extension Bm {
 
         /// 创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date
 
         /// 规则备注
@@ -973,20 +973,20 @@ extension Bm {
 
         /// 创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date
 
         /// 授权时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$authTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var authTime: Date
 
         /// 结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// 任务详情
@@ -1080,8 +1080,8 @@ extension Bm {
 
         /// 操作时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$operationTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var operationTime: Date
 
         enum CodingKeys: String, CodingKey {
@@ -1129,14 +1129,14 @@ extension Bm {
 
         /// 创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date
 
         /// 修改时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$modifyTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var modifyTime: Date
 
         /// 命令适用的操作系统类型
@@ -1179,14 +1179,14 @@ extension Bm {
 
         /// 执行开始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$runBeginTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var runBeginTime: Date
 
         /// 执行结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$runEndTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var runEndTime: Date
 
         enum CodingKeys: String, CodingKey {
@@ -1212,14 +1212,14 @@ extension Bm {
 
         /// 任务开始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$runBeginTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var runBeginTime: Date
 
         /// 任务结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$runEndTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var runEndTime: Date
 
         /// 任务状态ID，取值为 -1：进行中；0：成功；>0：失败错误码

--- a/Sources/Teco/Bmlb/V20180625/actions/DescribeCertDetail.swift
+++ b/Sources/Teco/Bmlb/V20180625/actions/DescribeCertDetail.swift
@@ -57,20 +57,20 @@ extension Bmlb {
 
         /// 证书上传时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$certUploadTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var certUploadTime: Date
 
         /// 证书生效时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$certBeginTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var certBeginTime: Date
 
         /// 证书失效时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$certEndTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var certEndTime: Date
 
         /// 该证书关联的黑石负载均衡对象列表。

--- a/Sources/Teco/Bmlb/V20180625/models.swift
+++ b/Sources/Teco/Bmlb/V20180625/models.swift
@@ -729,8 +729,8 @@ extension Bmlb {
 
         /// 创建时间戳。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$addTimestamp`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var addTimestamp: Date?
 
         /// 转发后端服务器调度类型。
@@ -828,8 +828,8 @@ extension Bmlb {
 
         /// 创建时间戳。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$addTimestamp`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var addTimestamp: Date?
 
         /// 是否开启自定义健康检查：1（开启）、0（关闭）。默认值0，表示关闭。（该字段在健康检查开启的情况下才生效）
@@ -990,8 +990,8 @@ extension Bmlb {
 
         /// 添加时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$addTimestamp`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var addTimestamp: Date
 
         /// 负载均衡名ID。
@@ -1075,8 +1075,8 @@ extension Bmlb {
 
         /// 创建时间戳。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$addTimestamp`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var addTimestamp: Date?
 
         /// https转发类型。0：https。1：spdy。2：http2。3：spdy+http2。
@@ -1147,8 +1147,8 @@ extension Bmlb {
 
         /// 创建时间戳。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$addTimestamp`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var addTimestamp: Date?
 
         /// 返回的转发规则列表。
@@ -1274,8 +1274,8 @@ extension Bmlb {
 
         /// 创建时间戳。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$addTimestamp`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var addTimestamp: Date?
 
         /// 该转发路径所绑定的主机列表。
@@ -1329,8 +1329,8 @@ extension Bmlb {
 
         /// 创建时间戳。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$addTimestamp`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var addTimestamp: Date?
 
         /// 该转发域名下面的转发路径列表。
@@ -1366,8 +1366,8 @@ extension Bmlb {
 
         /// 创建时间戳。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$addTimestamp`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var addTimestamp: Date?
 
         /// 该转发域名下面的转发路径列表。
@@ -1430,8 +1430,8 @@ extension Bmlb {
 
         /// 创建时间戳。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$addTimestamp`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var addTimestamp: Date?
 
         public init(url: String? = nil, locationId: String? = nil, sessionExpire: Int64? = nil, healthSwitch: Int64? = nil, httpCheckPath: String? = nil, httpCheckDomain: String? = nil, intervalTime: Int64? = nil, healthNum: Int64? = nil, unhealthNum: Int64? = nil, httpCodes: [UInt64]? = nil, balanceMode: String? = nil, status: Int64? = nil, addTimestamp: Date? = nil) {
@@ -1502,12 +1502,12 @@ extension Bmlb {
 
         public let latestPayMode: String?
 
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date?
 
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$statusTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var statusTime: Date?
 
         /// 私有网络名称。
@@ -1782,8 +1782,8 @@ extension Bmlb {
 
         /// 创建时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date?
 
         /// 流量镜像所在私有网络的Cidr。
@@ -1861,8 +1861,8 @@ extension Bmlb {
 
         /// 添加时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$addTimestamp`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var addTimestamp: Date
 
         /// 负载均衡ID。

--- a/Sources/Teco/Bmvpc/V20180625/models.swift
+++ b/Sources/Teco/Bmvpc/V20180625/models.swift
@@ -237,8 +237,8 @@ extension Bmvpc {
 
         /// 创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date
 
         /// 网关启用状态，1为禁用，0为启用。
@@ -369,8 +369,8 @@ extension Bmvpc {
 
         /// 创建时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date
 
         enum CodingKeys: String, CodingKey {
@@ -509,8 +509,8 @@ extension Bmvpc {
 
         /// 子网创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$subnetCreateTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var subnetCreateTime: Date
 
         /// 25G子网标识
@@ -574,8 +574,8 @@ extension Bmvpc {
 
         /// 创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date
 
         /// 整型私有网络ID。
@@ -647,8 +647,8 @@ extension Bmvpc {
 
         /// 创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date
 
         enum CodingKeys: String, CodingKey {
@@ -744,8 +744,8 @@ extension Bmvpc {
 
         /// 创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date
 
         /// 是否老专区VPC
@@ -1002,8 +1002,8 @@ extension Bmvpc {
 
         /// 创建时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date
 
         /// 可用区，如：ap-guangzhou

--- a/Sources/Teco/Cam/V20190116/actions/GetPolicy.swift
+++ b/Sources/Teco/Cam/V20190116/actions/GetPolicy.swift
@@ -52,15 +52,15 @@ extension Cam {
         /// 创建时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$addTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var addTime: Date?
 
         /// 最近更新时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updateTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var updateTime: Date?
 
         /// 策略文档

--- a/Sources/Teco/Cam/V20190116/actions/GetSAMLProvider.swift
+++ b/Sources/Teco/Cam/V20190116/actions/GetSAMLProvider.swift
@@ -45,14 +45,14 @@ extension Cam {
 
         /// SAML身份提供商创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date
 
         /// SAML身份提供商上次修改时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$modifyTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var modifyTime: Date
 
         /// SAML身份提供商元数据文档

--- a/Sources/Teco/Cam/V20190116/models.swift
+++ b/Sources/Teco/Cam/V20190116/models.swift
@@ -29,8 +29,8 @@ extension Cam {
 
         /// 创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date
 
         enum CodingKeys: String, CodingKey {
@@ -53,8 +53,8 @@ extension Cam {
 
         /// 创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date
 
         enum CodingKeys: String, CodingKey {
@@ -106,8 +106,8 @@ extension Cam {
         /// 创建时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$addTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var addTime: Date?
 
         /// 创建来源，1 通过控制台创建, 2 通过策略语法创建。
@@ -710,8 +710,8 @@ extension Cam {
         /// 最后访问日期(有1天延迟)
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$lastUsedDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var lastUsedDate: Date?
 
         /// 最后密钥访问日期
@@ -736,8 +736,8 @@ extension Cam {
         /// 策略创建时间。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$addTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var addTime: Date?
 
         /// 策略类型。1 表示自定义策略，2 表示预设策略。
@@ -784,8 +784,8 @@ extension Cam {
         /// 最后编辑时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updateTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var updateTime: Date?
 
         enum CodingKeys: String, CodingKey {
@@ -836,8 +836,8 @@ extension Cam {
         /// 创建时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date?
 
         /// 昵称
@@ -875,8 +875,8 @@ extension Cam {
         /// 创建时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date?
 
         /// 用户类型(2:子用户;3:企业微信子用户;4:协作者;5:消息接收人)
@@ -934,8 +934,8 @@ extension Cam {
         /// 创建时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date?
 
         enum CodingKeys: String, CodingKey {

--- a/Sources/Teco/Cbs/V20170312/actions/CreateSnapshot.swift
+++ b/Sources/Teco/Cbs/V20170312/actions/CreateSnapshot.swift
@@ -31,8 +31,8 @@ extension Cbs {
 
         /// 快照的到期时间，到期后该快照将会自动删除,需要传入UTC时间下的ISO-8601标准时间格式,例如:2022-01-08T09:47:55+00:00,。到期时间最小可设置为一天后的当前时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$deadline`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var deadline: Date?
 
         /// 云硬盘备份点ID。传入此参数时，将通过备份点创建快照。

--- a/Sources/Teco/Cbs/V20170312/actions/ModifySnapshotAttribute.swift
+++ b/Sources/Teco/Cbs/V20170312/actions/ModifySnapshotAttribute.swift
@@ -34,8 +34,8 @@ extension Cbs {
 
         /// 快照的到期时间；设置好快照将会被同时设置为非永久保留方式；超过到期时间后快照将会被自动删除。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$deadline`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var deadline: Date?
 
         public init(snapshotId: String, isPermanent: Bool? = nil, snapshotName: String? = nil, deadline: Date? = nil) {

--- a/Sources/Teco/Cbs/V20170312/models.swift
+++ b/Sources/Teco/Cbs/V20170312/models.swift
@@ -117,8 +117,8 @@ extension Cbs {
 
         /// 定期快照下次触发的时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$nextTriggerTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var nextTriggerTime: Date?
 
         /// 定期快照策略名称。
@@ -132,8 +132,8 @@ extension Cbs {
 
         /// 定期快照策略的创建时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date?
 
         /// 使用该定期快照策略创建出来的快照保留天数。
@@ -226,14 +226,14 @@ extension Cbs {
 
         /// 独享集群到期时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$expiredTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var expiredTime: Date
 
         /// 存储池创建时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createdTime: Date
 
         /// 当前集群中已创建的云盘数量。
@@ -451,8 +451,8 @@ extension Cbs {
 
         /// 云硬盘的到期时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$deadlineTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var deadlineTime: Date?
 
         /// 云盘是否挂载到云主机上。取值范围：
@@ -519,8 +519,8 @@ extension Cbs {
 
         /// 云硬盘的创建时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date?
 
         /// 销毁云盘时删除关联的非永久保留快照。0 表示非永久快照不随云盘销毁而销毁，1表示非永久快照随云盘销毁而销毁，默认取0。快照是否永久保留可以通过DescribeSnapshots接口返回的快照详情的IsPermanent字段来判断，true表示永久快照，false表示非永久快照。
@@ -628,8 +628,8 @@ extension Cbs {
 
         /// 云硬盘备份点的创建时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createTime: Date
 
         /// 云盘是否为加密盘。取值范围：
@@ -667,8 +667,8 @@ extension Cbs {
 
         /// 需要将云盘的到期时间与挂载的子机对齐时，可传入该参数。该参数表示子机当前的到期时间，此时Period如果传入，则表示子机需要续费的时长，云盘会自动按对齐到子机续费后的到期时间续费，示例取值：2018-03-30 20:15:03。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$curInstanceDeadline`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var curInstanceDeadline: Date?
 
         public init(period: UInt64, renewFlag: String? = nil, curInstanceDeadline: Date? = nil) {
@@ -980,8 +980,8 @@ extension Cbs {
     public struct SharePermission: TCOutputModel {
         /// 快照分享的时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createdTime: Date
 
         /// 分享的账号Id
@@ -1025,8 +1025,8 @@ extension Cbs {
 
         /// 快照到期时间。如果快照为永久保留，此字段为空。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$deadlineTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var deadlineTime: Date?
 
         /// 快照创建进度百分比，快照创建成功后此字段恒为100。
@@ -1058,8 +1058,8 @@ extension Cbs {
 
         /// 快照的创建时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date?
 
         /// 快照关联的镜像个数。
@@ -1076,8 +1076,8 @@ extension Cbs {
 
         /// 快照开始共享的时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$timeStartShare`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var timeStartShare: Date
 
         /// 快照绑定的标签列表。

--- a/Sources/Teco/Cdb/V20170320/models.swift
+++ b/Sources/Teco/Cdb/V20170320/models.swift
@@ -51,20 +51,20 @@ extension Cdb {
 
         /// 账号信息修改时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$modifyTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var modifyTime: Date
 
         /// 修改密码的时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$modifyPasswordTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var modifyPasswordTime: Date
 
         /// 该值已废弃
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date
 
         /// 用户最大可用实例连接数
@@ -689,8 +689,8 @@ extension Cdb {
 
         /// 文件存储时间，时间格式：2016-03-17 02:10:37
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$date`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var date: Date
 
         /// 下载地址
@@ -1127,8 +1127,8 @@ extension Cdb {
     public struct DBSwitchInfo: TCOutputModel {
         /// 切换时间，格式为：2017-09-03 01:34:31
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$switchTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var switchTime: Date
 
         /// 切换类型，可能的返回值为：TRANSFER - 数据迁移；MASTER2SLAVE - 主备切换；RECOVERY - 主从恢复
@@ -1388,8 +1388,8 @@ extension Cdb {
 
         /// 任务创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date
 
         /// 文件大小
@@ -1570,8 +1570,8 @@ extension Cdb {
 
         /// 实例到期时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$deadlineTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var deadlineTime: Date
 
         /// 可用区部署方式。可能的值为：0 - 单可用区；1 - 多可用区
@@ -3107,8 +3107,8 @@ extension Cdb {
     public struct SqlFileInfo: TCOutputModel {
         /// 上传时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$uploadTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var uploadTime: Date
 
         /// 上传进度

--- a/Sources/Teco/Cdc/V20201214/models.swift
+++ b/Sources/Teco/Cdc/V20201214/models.swift
@@ -95,8 +95,8 @@ extension Cdc {
 
         /// 专用集群的创建时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createTime: Date
 
         /// 专用集群所属的站点id。
@@ -210,8 +210,8 @@ extension Cdc {
 
         /// 订单创建的时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createTime: Date
 
         /// 大订单ID
@@ -305,8 +305,8 @@ extension Cdc {
 
         /// 订单创建的时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createTime: Date
 
         /// 子订单ID
@@ -382,8 +382,8 @@ extension Cdc {
 
         /// 创建配置的时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createTime: Date
 
         /// 支持的存储类型列表
@@ -651,8 +651,8 @@ extension Cdc {
 
         /// 站点创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createTime: Date
 
         enum CodingKeys: String, CodingKey {
@@ -676,8 +676,8 @@ extension Cdc {
 
         /// 站点创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createTime: Date
 
         /// 光纤类型

--- a/Sources/Teco/Cdn/V20180606/actions/CreateScdnLogTask.swift
+++ b/Sources/Teco/Cdn/V20180606/actions/CreateScdnLogTask.swift
@@ -32,14 +32,14 @@ extension Cdn {
 
         /// 查询起始时间，如：2018-09-04 10:40:00，返回结果大于等于指定时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 查询结束时间，如：2018-09-04 10:40:00，返回结果小于等于指定时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// 指定域名查询, 不填默认查询全部域名

--- a/Sources/Teco/Cdn/V20180606/actions/DescribeBillingData.swift
+++ b/Sources/Teco/Cdn/V20180606/actions/DescribeBillingData.swift
@@ -27,16 +27,16 @@ extension Cdn {
         /// 根据指定时间粒度参数不同，会进行向前取整，如指定起始时间为 2018-09-04 10:40:00 按小时粒度查询，返回的第一个数据对应时间点为 2018-09-04 10:00:00
         /// 起始时间与结束时间间隔小于等于 90 天
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 查询结束时间，如：2018-09-04 10:40:00，返回结果小于等于指定时间
         /// 根据指定时间粒度参数不同，会进行向前取整，如指定结束时间为  2018-09-04 10:40:00 按小时粒度查询时，返回的最后一个数据对应时间点为 2018-09-04 10:00:00
         /// 起始时间与结束时间间隔小于等于 90 天
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// 时间粒度，支持模式如下：

--- a/Sources/Teco/Cdn/V20180606/actions/DescribeCdnData.swift
+++ b/Sources/Teco/Cdn/V20180606/actions/DescribeCdnData.swift
@@ -27,16 +27,16 @@ extension Cdn {
         /// 根据指定时间粒度不同，会进行向前归整，如 2018-09-04 10:40:00 在按 1 小时的时间粒度查询时，返回的第一个数据对应时间点为 2018-09-04 10:00:00
         /// 起始时间与结束时间间隔小于等于 90 天
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 查询结束时间，如：2018-09-04 10:40:00，返回结果小于等于指定时间
         /// 根据指定时间粒度不同，会进行向前归整，如 2018-09-04 10:40:00 在按 1 小时的时间粒度查询时，返回的最后一个数据对应时间点为 2018-09-04 10:00:00
         /// 起始时间与结束时间间隔小于等于 90 天
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// 指定查询指标，支持的类型有：

--- a/Sources/Teco/Cdn/V20180606/actions/DescribeCdnDomainLogs.swift
+++ b/Sources/Teco/Cdn/V20180606/actions/DescribeCdnDomainLogs.swift
@@ -28,14 +28,14 @@ extension Cdn {
 
         /// 开始时间，如 2019-09-04 00:00:00
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 结束时间，如 2019-09-04 12:00:00
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// 分页查询偏移量，默认为 0

--- a/Sources/Teco/Cdn/V20180606/actions/DescribeDistrictIspData.swift
+++ b/Sources/Teco/Cdn/V20180606/actions/DescribeDistrictIspData.swift
@@ -29,15 +29,15 @@ extension Cdn {
         /// 查询起始时间，如：2018-09-04 10:40:00，返回结果大于等于指定时间
         /// 支持近 60 天内的数据查询，每次查询时间区间为 3 小时
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 查询结束时间，如：2018-09-04 10:40:00，返回结果小于等于指定时间
         /// 结束时间与起始时间区间最大为 3 小时
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// 指定查询指标，支持:

--- a/Sources/Teco/Cdn/V20180606/actions/DescribeEdgePackTaskStatus.swift
+++ b/Sources/Teco/Cdn/V20180606/actions/DescribeEdgePackTaskStatus.swift
@@ -25,14 +25,14 @@ extension Cdn {
     public struct DescribeEdgePackTaskStatusRequest: TCPaginatedRequest {
         /// 开始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var startTime: Date
 
         /// 结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var endTime: Date
 
         /// 分页查询限制数目，默认为 100，最大可设置为 1000

--- a/Sources/Teco/Cdn/V20180606/actions/DescribeIpVisit.swift
+++ b/Sources/Teco/Cdn/V20180606/actions/DescribeIpVisit.swift
@@ -26,15 +26,15 @@ extension Cdn {
         /// 查询起始时间，如：2018-09-04 10:40:10，返回结果大于等于指定时间
         /// 根据指定时间粒度不同，会进行向前归整，如 2018-09-04 10:40:10 在按 5 分钟的时间粒度查询时，返回的第一个数据对应时间点为 2018-09-04 10:40:00
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 查询结束时间，如：2018-09-04 10:40:10，返回结果小于等于指定时间
         /// 根据指定时间粒度不同，会进行向前归整，如 2018-09-04 10:40:10 在按 5 分钟的时间粒度查询时，返回的最后一个数据对应时间点为 2018-09-04 10:40:00
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// 指定查询域名列表，最多可一次性查询 30 个加速域名明细

--- a/Sources/Teco/Cdn/V20180606/actions/DescribeOriginData.swift
+++ b/Sources/Teco/Cdn/V20180606/actions/DescribeOriginData.swift
@@ -27,16 +27,16 @@ extension Cdn {
         /// 根据指定时间粒度不同，会进行向前归整，如 2018-09-04 10:40:00 在按 1 小时的时间粒度查询时，返回的第一个数据对应时间点为 2018-09-04 10:00:00
         /// 起始时间与结束时间间隔小于等于 90 天
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 查询结束时间，如：2018-09-04 10:40:00，返回结果小于等于指定时间
         /// 根据指定时间粒度不同，会进行向前归整，如 2018-09-04 10:40:00 在按 1 小时的时间粒度查询时，返回的最后一个数据对应时间点为 2018-09-04 10:00:00
         /// 起始时间与结束时间间隔小于等于 90 天
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// 指定查询指标，支持的类型有：

--- a/Sources/Teco/Cdn/V20180606/actions/DescribePurgeTasks.swift
+++ b/Sources/Teco/Cdn/V20180606/actions/DescribePurgeTasks.swift
@@ -30,14 +30,14 @@ extension Cdn {
 
         /// 根据时间区间查询时，填充开始时间，如 2018-08-08 00:00:00
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date?
 
         /// 根据时间区间查询时，填充结束时间，如 2018-08-08 23:59:59
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date?
 
         /// 根据任务 ID 查询时，填充任务 ID

--- a/Sources/Teco/Cdn/V20180606/actions/DescribePushTasks.swift
+++ b/Sources/Teco/Cdn/V20180606/actions/DescribePushTasks.swift
@@ -25,14 +25,14 @@ extension Cdn {
     public struct DescribePushTasksRequest: TCPaginatedRequest {
         /// 开始时间，如2018-08-08 00:00:00。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date?
 
         /// 结束时间，如2018-08-08 23:59:59。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date?
 
         /// 指定任务 ID 查询

--- a/Sources/Teco/Cdn/V20180606/actions/DescribeReportData.swift
+++ b/Sources/Teco/Cdn/V20180606/actions/DescribeReportData.swift
@@ -28,8 +28,8 @@ extension Cdn {
         /// 当报表类型为weekly，起始时间须为周一，结束时间须为同一周的周日
         /// 当报表类型为monthly，起始时间须为自然月第一天，即1号，结束时间须为该自然月最后一天
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var startTime: Date
 
         /// 查询结束时间：yyyy-MM-dd
@@ -37,8 +37,8 @@ extension Cdn {
         /// 当报表类型为weekly，起始时间须为周一，结束时间须为同一周的周日
         /// 当报表类型为monthly，起始时间须为自然月第一天，即1号，结束时间须为该自然月最后一天
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var endTime: Date
 
         /// 报表类型

--- a/Sources/Teco/Cdn/V20180606/actions/DescribeScdnBotData.swift
+++ b/Sources/Teco/Cdn/V20180606/actions/DescribeScdnBotData.swift
@@ -25,14 +25,14 @@ extension Cdn {
     public struct DescribeScdnBotDataRequest: TCRequest {
         /// 开始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// mainland 大陆地区 overseas境外地区

--- a/Sources/Teco/Cdn/V20180606/actions/DescribeScdnBotRecords.swift
+++ b/Sources/Teco/Cdn/V20180606/actions/DescribeScdnBotRecords.swift
@@ -31,14 +31,14 @@ extension Cdn {
 
         /// 开始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// 分页参数

--- a/Sources/Teco/Cdn/V20180606/actions/DescribeScdnTopData.swift
+++ b/Sources/Teco/Cdn/V20180606/actions/DescribeScdnTopData.swift
@@ -25,14 +25,14 @@ extension Cdn {
     public struct DescribeScdnTopDataRequest: TCRequest {
         /// 查询起始时间，如：2018-09-04 10:40:00，返回结果大于等于指定时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 查询结束时间，如：2018-09-04 10:40:00，返回结果小于等于指定时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// 查询的SCDN TOP攻击数据类型：

--- a/Sources/Teco/Cdn/V20180606/actions/EnableCaches.swift
+++ b/Sources/Teco/Cdn/V20180606/actions/EnableCaches.swift
@@ -28,8 +28,8 @@ extension Cdn {
 
         /// URL封禁日期
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$date`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var date: Date?
 
         public init(urls: [String], date: Date? = nil) {

--- a/Sources/Teco/Cdn/V20180606/actions/GetDisableRecords.swift
+++ b/Sources/Teco/Cdn/V20180606/actions/GetDisableRecords.swift
@@ -28,14 +28,14 @@ extension Cdn {
 
         /// 开始时间，如：2018-12-12 10:24:00。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date?
 
         /// 结束时间，如：2018-12-14 10:24:00。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date?
 
         /// URL 当前状态

--- a/Sources/Teco/Cdn/V20180606/actions/ListClsTopicDomains.swift
+++ b/Sources/Teco/Cdn/V20180606/actions/ListClsTopicDomains.swift
@@ -68,8 +68,8 @@ extension Cdn {
         /// 日志主题最近更新时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updateTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var updateTime: Date?
 
         /// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。

--- a/Sources/Teco/Cdn/V20180606/actions/ListScdnTopBotData.swift
+++ b/Sources/Teco/Cdn/V20180606/actions/ListScdnTopBotData.swift
@@ -28,14 +28,14 @@ extension Cdn {
 
         /// 开始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// mainland 大陆地区 overseas境外地区

--- a/Sources/Teco/Cdn/V20180606/actions/ListTopBotData.swift
+++ b/Sources/Teco/Cdn/V20180606/actions/ListTopBotData.swift
@@ -28,14 +28,14 @@ extension Cdn {
 
         /// 开始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// session表示查询BOT会话的Top信息

--- a/Sources/Teco/Cdn/V20180606/actions/ListTopData.swift
+++ b/Sources/Teco/Cdn/V20180606/actions/ListTopData.swift
@@ -27,16 +27,16 @@ extension Cdn {
         /// 仅支持按分钟粒度的数据查询，按入参抹去秒位作为起始时间，如 StartTime为2018-09-04 10:40:23，返回数据的起始时间为2018-09-04 10:40:00
         /// 仅支持 90 天内数据查询
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 查询结束时间：yyyy-MM-dd HH:mm:ss
         /// 仅支持按天粒度的数据查询，取入参中的天信息作为结束日期 返回小于等于结束日期当天 23:59:59 产生的数据，如EndTime为2018-09-05 22:40:00，返回数据的结束时间为2018-09-05 23:59:59
         /// EndTime 需要大于等于 StartTime
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// 排序对象，支持以下几种形式：

--- a/Sources/Teco/Cdn/V20180606/actions/ModifyPurgeFetchTaskStatus.swift
+++ b/Sources/Teco/Cdn/V20180606/actions/ModifyPurgeFetchTaskStatus.swift
@@ -25,8 +25,8 @@ extension Cdn {
     public struct ModifyPurgeFetchTaskStatusRequest: TCRequest {
         /// 执行时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$executionTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var executionTime: Date
 
         /// 执行状态

--- a/Sources/Teco/Cdn/V20180606/actions/SearchClsLog.swift
+++ b/Sources/Teco/Cdn/V20180606/actions/SearchClsLog.swift
@@ -31,14 +31,14 @@ extension Cdn {
 
         /// 需要查询的日志的起始时间，格式 YYYY-mm-dd HH:MM:SS
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 需要查询的日志的结束时间，格式 YYYY-mm-dd HH:MM:SS
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// 单次要返回的日志条数，单次返回的最大条数为100

--- a/Sources/Teco/Cdn/V20180606/models.swift
+++ b/Sources/Teco/Cdn/V20180606/models.swift
@@ -1242,8 +1242,8 @@ extension Cdn {
         /// 境内区域上次触发用量封顶阈值的时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$lastTriggerTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var lastTriggerTime: Date?
 
         /// 用量封顶提醒配置开关，取值有：
@@ -1259,8 +1259,8 @@ extension Cdn {
         /// 海外区域上次触发用量封顶阈值的时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$lastTriggerTimeOverseas`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var lastTriggerTimeOverseas: Date?
 
         /// 用量阈值触发的维度
@@ -1321,8 +1321,8 @@ extension Cdn {
         /// 更新时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updateTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var updateTime: Date?
 
         public init(switch: String, ruleType: String, ruleValue: [String], action: String, redirectUrl: String? = nil, updateTime: Date? = nil) {
@@ -1367,8 +1367,8 @@ extension Cdn {
         /// 更新时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updateTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var updateTime: Date?
 
         public init(switch: String, ruleType: String, ruleValue: [String], action: String, redirectUrl: String? = nil, updateTime: Date? = nil) {
@@ -1438,8 +1438,8 @@ extension Cdn {
 
         /// 最新检测时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$time`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var time: Date
 
         /// BOT得分
@@ -1538,8 +1538,8 @@ extension Cdn {
     public struct BotStatsDetailData: TCOutputModel {
         /// 时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$time`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var time: Date
 
         /// 数据值
@@ -1584,14 +1584,14 @@ extension Cdn {
 
         /// 域名创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date?
 
         /// 域名更新时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updateTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var updateTime: Date?
 
         /// 源站配置详情
@@ -2033,8 +2033,8 @@ extension Cdn {
         /// 当该值为 null 时表示无历史状态变更记录
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$datetime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var datetime: Date?
 
         enum CodingKeys: String, CodingKey {
@@ -2058,16 +2058,16 @@ extension Cdn {
         /// 作为入参时无需填充
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$expireTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var expireTime: Date?
 
         /// 证书颁发时间
         /// 作为入参时无需填充
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$deployTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var deployTime: Date?
 
         public init(certificate: String, certName: String? = nil, expireTime: Date? = nil, deployTime: Date? = nil) {
@@ -2351,8 +2351,8 @@ extension Cdn {
     public struct DDoSStatsData: TCOutputModel {
         /// 时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$time`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var time: Date
 
         /// 带宽数值，单位bps
@@ -2414,14 +2414,14 @@ extension Cdn {
 
         /// 域名创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date
 
         /// 域名更新时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updateTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var updateTime: Date
 
         /// 源站配置
@@ -2770,15 +2770,15 @@ extension Cdn {
         /// 诊断创建时间。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date?
 
         /// 诊断链接过期时间。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$expireDate`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var expireDate: Date?
 
         /// 诊断链接当前访问次数，一个诊断链接最多可访问10次。
@@ -2830,8 +2830,8 @@ extension Cdn {
         /// 诊断任务创建时间。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date?
 
         enum CodingKeys: String, CodingKey {
@@ -2882,14 +2882,14 @@ extension Cdn {
 
         /// 起始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// 时间间隔，单位为分钟
@@ -3022,14 +3022,14 @@ extension Cdn {
     public struct DomainLog: TCOutputModel {
         /// 日志包起始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 日志包结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// 日志包下载链接
@@ -3116,8 +3116,8 @@ extension Cdn {
 
         /// 上传时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$uploadTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var uploadTime: Date
 
         /// 任务状态
@@ -3981,8 +3981,8 @@ extension Cdn {
 
         /// 创建日期
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date
 
         /// 区域
@@ -5002,8 +5002,8 @@ extension Cdn {
 
         /// 刷新任务提交时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date
 
         enum CodingKeys: String, CodingKey {
@@ -5036,8 +5036,8 @@ extension Cdn {
 
         /// 预热任务提交时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date
 
         /// 预热区域
@@ -5049,8 +5049,8 @@ extension Cdn {
         /// 预热任务更新时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updateTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var updateTime: Date?
 
         enum CodingKeys: String, CodingKey {
@@ -6055,8 +6055,8 @@ extension Cdn {
 
         /// 更新时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updateTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var updateTime: Date
 
         /// 备注
@@ -6116,20 +6116,20 @@ extension Cdn {
 
         /// 查询任务开始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 查询任务结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// 任务创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date
 
         /// 日志包下载链接
@@ -6259,8 +6259,8 @@ extension Cdn {
     public struct ScdnTopData: TCOutputModel {
         /// 时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$time`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var time: Date
 
         /// 数值
@@ -6312,8 +6312,8 @@ extension Cdn {
 
         /// 时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$time`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var time: Date
 
         /// 域名
@@ -6490,16 +6490,16 @@ extension Cdn {
         /// 作为入参配置时无需填充
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$expireTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var expireTime: Date?
 
         /// 证书颁发时间
         /// 作为入参配置时无需填充
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$deployTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var deployTime: Date?
 
         /// 证书备注信息
@@ -6848,8 +6848,8 @@ extension Cdn {
         /// 数据统计时间点，采用向前汇总模式
         /// 以 5 分钟粒度为例，13:35:00 时间点代表的统计数据区间为 13:35:00 至 13:39:59
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$time`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var time: Date
 
         /// 数据值
@@ -6940,8 +6940,8 @@ extension Cdn {
         /// 创建时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date?
 
         /// 归属于cdn或ecdn
@@ -7001,20 +7001,20 @@ extension Cdn {
 
         /// 流量包发放时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date
 
         /// 流量包生效时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$enableTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var enableTime: Date
 
         /// 流量包过期时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$expireTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var expireTime: Date
 
         /// 流量包是否续订
@@ -7272,14 +7272,14 @@ extension Cdn {
 
         /// 创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date
 
         /// 更新时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updateTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var updateTime: Date
 
         enum CodingKeys: String, CodingKey {

--- a/Sources/Teco/Chdfs/V20190718/models.swift
+++ b/Sources/Teco/Chdfs/V20190718/models.swift
@@ -32,8 +32,8 @@ extension Chdfs {
 
         /// 创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createTime: Date
 
         enum CodingKeys: String, CodingKey {
@@ -60,8 +60,8 @@ extension Chdfs {
 
         /// 创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createTime: Date?
 
         public init(accessRuleId: UInt64? = nil, address: String? = nil, accessMode: UInt64? = nil, priority: UInt64? = nil, createTime: Date? = nil) {
@@ -100,8 +100,8 @@ extension Chdfs {
 
         /// 创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createTime: Date
 
         /// 文件系统块大小（byte）
@@ -164,8 +164,8 @@ extension Chdfs {
 
         /// 创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createTime: Date?
 
         public init(lifeCycleRuleId: UInt64? = nil, lifeCycleRuleName: String? = nil, path: String? = nil, transitions: [Transition]? = nil, status: UInt64? = nil, createTime: Date? = nil) {
@@ -209,8 +209,8 @@ extension Chdfs {
 
         /// 创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createTime: Date
 
         /// VPC网络类型
@@ -247,8 +247,8 @@ extension Chdfs {
 
         /// 创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createTime: Date?
 
         public init(restoreTaskId: UInt64? = nil, filePath: String? = nil, type: UInt64? = nil, days: UInt64? = nil, status: UInt64? = nil, createTime: Date? = nil) {

--- a/Sources/Teco/Chdfs/V20201112/models.swift
+++ b/Sources/Teco/Chdfs/V20201112/models.swift
@@ -32,8 +32,8 @@ extension Chdfs {
 
         /// 创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createTime: Date
 
         /// VPC网络类型（1：CVM；2：黑石1.0）
@@ -68,8 +68,8 @@ extension Chdfs {
 
         /// 创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createTime: Date?
 
         public init(accessRuleId: UInt64? = nil, address: String? = nil, accessMode: UInt64? = nil, priority: UInt64? = nil, createTime: Date? = nil) {
@@ -108,8 +108,8 @@ extension Chdfs {
 
         /// 创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createTime: Date
 
         /// 文件系统块大小（byte）
@@ -171,8 +171,8 @@ extension Chdfs {
 
         /// 创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createTime: Date?
 
         /// 生命周期规则当前路径具体存储量
@@ -180,8 +180,8 @@ extension Chdfs {
 
         /// Summary更新时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$lastSummaryTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var lastSummaryTime: Date?
 
         public init(lifeCycleRuleId: UInt64? = nil, lifeCycleRuleName: String? = nil, path: String? = nil, transitions: [Transition]? = nil, status: UInt64? = nil, createTime: Date? = nil, summary: Summary? = nil, lastSummaryTime: Date? = nil) {
@@ -223,8 +223,8 @@ extension Chdfs {
 
         /// 创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createTime: Date
 
         /// 绑定的权限组ID列表
@@ -259,8 +259,8 @@ extension Chdfs {
 
         /// 创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createTime: Date?
 
         public init(restoreTaskId: UInt64? = nil, filePath: String? = nil, type: UInt64? = nil, days: UInt64? = nil, status: UInt64? = nil, createTime: Date? = nil) {

--- a/Sources/Teco/Ciam/V20220331/models.swift
+++ b/Sources/Teco/Ciam/V20220331/models.swift
@@ -163,8 +163,8 @@ extension Ciam {
 
         /// 生日
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$birthdate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var birthdate: Date?
 
         /// 姓名

--- a/Sources/Teco/Cis/V20180408/models.swift
+++ b/Sources/Teco/Cis/V20180408/models.swift
@@ -113,14 +113,14 @@ extension Cis {
 
         /// 创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date?
 
         /// 启动时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date?
 
         /// 可用区
@@ -200,8 +200,8 @@ extension Cis {
     public struct ContainerState: TCOutputModel {
         /// 容器运行开始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 容器状态
@@ -212,8 +212,8 @@ extension Cis {
 
         /// 容器运行结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$finishTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var finishTime: Date
 
         /// 容器运行退出码

--- a/Sources/Teco/Ckafka/V20190819/actions/DescribeTopicFlowRanking.swift
+++ b/Sources/Teco/Ckafka/V20190819/actions/DescribeTopicFlowRanking.swift
@@ -31,14 +31,14 @@ extension Ckafka {
 
         /// 排行起始日期
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$beginDate`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var beginDate: Date?
 
         /// 排行结束日期
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endDate`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var endDate: Date?
 
         /// Broker IP 地址

--- a/Sources/Teco/Ckafka/V20190819/models.swift
+++ b/Sources/Teco/Ckafka/V20190819/models.swift
@@ -6029,14 +6029,14 @@ extension Ckafka {
 
         /// 创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date
 
         /// 最后更新时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updateTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var updateTime: Date
 
         enum CodingKeys: String, CodingKey {

--- a/Sources/Teco/Clb/V20180317/models.swift
+++ b/Sources/Teco/Clb/V20180317/models.swift
@@ -2687,8 +2687,8 @@ extension Clb {
         /// 后端服务被绑定的时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$registeredTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var registeredTime: Date?
 
         /// 弹性网卡唯一ID
@@ -2731,14 +2731,14 @@ extension Clb {
 
         /// 目标组的创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createdTime: Date
 
         /// 目标组的修改时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updatedTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var updatedTime: Date
 
         /// 关联到的规则数组

--- a/Sources/Teco/Cls/V20201016/models.swift
+++ b/Sources/Teco/Cls/V20201016/models.swift
@@ -615,14 +615,14 @@ extension Cls {
         /// 更新时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updateTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var updateTime: Date?
 
         /// 创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date
 
         /// 用户自定义解析字符串

--- a/Sources/Teco/Cpdp/V20190820/actions/QueryAgentStatements.swift
+++ b/Sources/Teco/Cpdp/V20190820/actions/QueryAgentStatements.swift
@@ -25,8 +25,8 @@ extension Cpdp {
     public struct QueryAgentStatementsRequest: TCRequest {
         /// 结算单日期，月结算单填每月1日
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$date`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var date: Date
 
         /// 日结算单:daily

--- a/Sources/Teco/Cpdp/V20190820/models.swift
+++ b/Sources/Teco/Cpdp/V20190820/models.swift
@@ -9185,8 +9185,8 @@ extension Cpdp {
 
         /// 提现日期
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$date`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var date: Date
 
         /// 提现金额，单位： 分

--- a/Sources/Teco/Cr/V20180321/actions/ApplyCreditAudit.swift
+++ b/Sources/Teco/Cr/V20180321/actions/ApplyCreditAudit.swift
@@ -69,8 +69,8 @@ extension Cr {
     public struct ApplyCreditAuditResponse: TCResponse {
         /// 请求日期
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$requestDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var requestDate: Date
 
         /// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。

--- a/Sources/Teco/Cr/V20180321/actions/ChangeBotCallStatus.swift
+++ b/Sources/Teco/Cr/V20180321/actions/ChangeBotCallStatus.swift
@@ -38,8 +38,8 @@ extension Cr {
 
         /// 业务日期
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$bizDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var bizDate: Date
 
         /// 任务ID，二者必填一个

--- a/Sources/Teco/Cr/V20180321/actions/DescribeCreditResult.swift
+++ b/Sources/Teco/Cr/V20180321/actions/DescribeCreditResult.swift
@@ -40,8 +40,8 @@ extension Cr {
 
         /// 请求日期，格式为YYYY-MM-DD
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$requestDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var requestDate: Date
 
         public init(module: String, operation: String, instId: String, productId: String, caseId: String, requestDate: Date) {
@@ -86,8 +86,8 @@ extension Cr {
         /// 开始振铃时间，ResultCode为NON或DAD时才有此字段。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$ringStartTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var ringStartTime: Date?
 
         /// 振铃时长

--- a/Sources/Teco/Cr/V20180321/actions/DescribeRecords.swift
+++ b/Sources/Teco/Cr/V20180321/actions/DescribeRecords.swift
@@ -40,14 +40,14 @@ extension Cr {
 
         /// 查询起始日期，格式为YYYY-MM-DD
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startBizDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var startBizDate: Date?
 
         /// 查询结束日期，格式为YYYY-MM-DD
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endBizDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var endBizDate: Date?
 
         /// 分页参数，索引，默认为0

--- a/Sources/Teco/Cr/V20180321/actions/DownloadBotRecord.swift
+++ b/Sources/Teco/Cr/V20180321/actions/DownloadBotRecord.swift
@@ -31,8 +31,8 @@ extension Cr {
 
         /// 业务日期
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$bizDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var bizDate: Date
 
         public init(module: String, operation: String, bizDate: Date) {

--- a/Sources/Teco/Cr/V20180321/actions/DownloadDialogueText.swift
+++ b/Sources/Teco/Cr/V20180321/actions/DownloadDialogueText.swift
@@ -31,8 +31,8 @@ extension Cr {
 
         /// 报告日期，格式为YYYY-MM-DD
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$reportDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var reportDate: Date
 
         /// 实例ID

--- a/Sources/Teco/Cr/V20180321/actions/DownloadRecordList.swift
+++ b/Sources/Teco/Cr/V20180321/actions/DownloadRecordList.swift
@@ -31,8 +31,8 @@ extension Cr {
 
         /// 录音日期，格式为YYYY-MM-DD
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$bizDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var bizDate: Date
 
         /// 实例ID

--- a/Sources/Teco/Cr/V20180321/actions/DownloadReport.swift
+++ b/Sources/Teco/Cr/V20180321/actions/DownloadReport.swift
@@ -31,8 +31,8 @@ extension Cr {
 
         /// 报告日期，格式为YYYY-MM-DD
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$reportDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var reportDate: Date
 
         /// 实例ID，不传默认为系统分配的初始实例。

--- a/Sources/Teco/Cr/V20180321/actions/ExportBotData.swift
+++ b/Sources/Teco/Cr/V20180321/actions/ExportBotData.swift
@@ -31,8 +31,8 @@ extension Cr {
 
         /// 业务日期。YYYY-MM-DD
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$bizDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var bizDate: Date
 
         /// 任务ID，二者必填一个

--- a/Sources/Teco/Cr/V20180321/actions/QueryBlackListData.swift
+++ b/Sources/Teco/Cr/V20180321/actions/QueryBlackListData.swift
@@ -37,14 +37,14 @@ extension Cr {
 
         /// 开始日期
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startBizDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var startBizDate: Date?
 
         /// 结束日期
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endBizDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var endBizDate: Date?
 
         /// 电话号码、手机

--- a/Sources/Teco/Cr/V20180321/actions/QueryCallList.swift
+++ b/Sources/Teco/Cr/V20180321/actions/QueryCallList.swift
@@ -31,8 +31,8 @@ extension Cr {
 
         /// 业务日期
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$bizDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var bizDate: Date
 
         /// 任务ID，二者必填一个

--- a/Sources/Teco/Cr/V20180321/actions/QueryRecordList.swift
+++ b/Sources/Teco/Cr/V20180321/actions/QueryRecordList.swift
@@ -46,14 +46,14 @@ extension Cr {
 
         /// 开始日期
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startBizDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var startBizDate: Date?
 
         /// 结束日期
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endBizDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var endBizDate: Date?
 
         public init(module: String, operation: String, offset: Int64, limit: Int64, botId: String? = nil, botName: String? = nil, calledPhone: String? = nil, startBizDate: Date? = nil, endBizDate: Date? = nil) {

--- a/Sources/Teco/Cr/V20180321/actions/UploadFile.swift
+++ b/Sources/Teco/Cr/V20180321/actions/UploadFile.swift
@@ -37,8 +37,8 @@ extension Cr {
 
         /// 文件日期
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$fileDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var fileDate: Date
 
         public init(module: String, operation: String, fileUrl: String, fileName: String, fileDate: Date) {

--- a/Sources/Teco/Cr/V20180321/models.swift
+++ b/Sources/Teco/Cr/V20180321/models.swift
@@ -38,15 +38,15 @@ extension Cr {
         /// 黑名单生效截止日期，格式为YYYY-MM-DD，不填默认为永久。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$blackValidDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var blackValidDate: Date?
 
         /// 黑名单加入日期
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$blackAddDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var blackAddDate: Date?
 
         /// 0-生效 1-失效
@@ -127,8 +127,8 @@ extension Cr {
     public struct CallInfo: TCOutputModel {
         /// 业务日期
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$bizDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var bizDate: Date
 
         /// 状态 WAIT：待执行；DOING：执行中；ERROR：执行错误；DONE：已完成；
@@ -273,8 +273,8 @@ extension Cr {
 
         /// 任务日期
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$bizDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var bizDate: Date
 
         /// 被叫号码
@@ -282,8 +282,8 @@ extension Cr {
 
         /// 开始通话时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$callStartTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var callStartTime: Date
 
         /// 通话时长
@@ -327,8 +327,8 @@ extension Cr {
 
         /// 黑名单生效截止日期，格式为YYYY-MM-DD，不填默认为永久。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$blackValidDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var blackValidDate: Date?
 
         public init(blackType: String, operationType: String, blackValue: String, blackDescription: String, blackValidDate: Date? = nil) {
@@ -355,14 +355,14 @@ extension Cr {
 
         /// 外呼日期。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$bizDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var bizDate: Date
 
         /// 开始呼叫时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$callStartTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var callStartTime: Date
 
         /// 主叫号码。

--- a/Sources/Teco/Cvm/V20170312/actions/CreateDisasterRecoverGroup.swift
+++ b/Sources/Teco/Cvm/V20170312/actions/CreateDisasterRecoverGroup.swift
@@ -74,8 +74,8 @@ extension Cvm {
 
         /// 置放群组创建时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date
 
         /// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。

--- a/Sources/Teco/Cvm/V20170312/actions/DescribeTaskInfo.swift
+++ b/Sources/Teco/Cvm/V20170312/actions/DescribeTaskInfo.swift
@@ -77,14 +77,14 @@ extension Cvm {
 
         /// 时间查询区间的起始位置，会根据任务创建时间`CreateTime`进行过滤。未传入时默认为当天`00:00:00`。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startDate`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startDate: Date?
 
         /// 时间查询区间的终止位置，会根据任务创建时间`CreateTime`进行过滤。未传入时默认为当前时刻。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endDate`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endDate: Date?
 
         /// 指定返回维修任务列表的排序字段，目前支持：

--- a/Sources/Teco/Cvm/V20170312/models.swift
+++ b/Sources/Teco/Cvm/V20170312/models.swift
@@ -372,8 +372,8 @@ extension Cvm {
         /// 分散置放群组创建时间。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createTime: Date?
 
         enum CodingKeys: String, CodingKey {
@@ -541,14 +541,14 @@ extension Cvm {
 
         /// 专用宿主机实例创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createdTime: Date
 
         /// 专用宿主机实例过期时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$expiredTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var expiredTime: Date
 
         /// 专用宿主机实例上已创建云子机的实例id列表
@@ -671,8 +671,8 @@ extension Cvm {
         /// 集群创建时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createTime: Date?
 
         /// 集群内实例ID列表
@@ -704,8 +704,8 @@ extension Cvm {
 
         /// 镜像创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createdTime: Date
 
         /// 镜像名称
@@ -876,14 +876,14 @@ extension Cvm {
 
         /// 创建时间。按照`ISO8601`标准表示，并且使用`UTC`时间。格式为：`YYYY-MM-DDThh:mm:ssZ`。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createdTime: Date?
 
         /// 到期时间。按照`ISO8601`标准表示，并且使用`UTC`时间。格式为：`YYYY-MM-DDThh:mm:ssZ`。注意：后付费模式本项为null
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$expiredTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var expiredTime: Date?
 
         /// 操作系统名称。
@@ -1357,14 +1357,14 @@ extension Cvm {
     public struct InternetBandwidthConfig: TCOutputModel {
         /// 开始时间。按照`ISO8601`标准表示，并且使用`UTC`时间。格式为：`YYYY-MM-DDThh:mm:ssZ`。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var startTime: Date?
 
         /// 结束时间。按照`ISO8601`标准表示，并且使用`UTC`时间。格式为：`YYYY-MM-DDThh:mm:ssZ`。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var endTime: Date?
 
         /// 实例带宽信息。
@@ -1541,8 +1541,8 @@ extension Cvm {
 
         /// 创建时间。按照`ISO8601`标准表示，并且使用`UTC`时间。格式为：`YYYY-MM-DDThh:mm:ssZ`。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createdTime: Date?
 
         /// 密钥关联的标签列表。
@@ -1610,8 +1610,8 @@ extension Cvm {
         /// 创建该模板的时间。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$creationTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var creationTime: Date?
 
         enum CodingKeys: String, CodingKey {
@@ -1773,8 +1773,8 @@ extension Cvm {
 
         /// 实例启动模板版本创建时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$creationTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var creationTime: Date
 
         /// 实例启动模板ID。
@@ -2081,22 +2081,22 @@ extension Cvm {
 
         /// 任务创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date
 
         /// 任务授权时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$authTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var authTime: Date?
 
         /// 任务结束时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date?
 
         /// 任务详情
@@ -2361,14 +2361,14 @@ extension Cvm {
 
         /// 预留实例计费开始时间。形如：1949-10-01 00:00:00
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 预留实例计费到期时间。形如：1949-10-01 00:00:00
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// 预留实例计费【有效期】即预留实例计费购买时长。形如：31536000。
@@ -2534,8 +2534,8 @@ extension Cvm {
     public struct SharePermission: TCOutputModel {
         /// 镜像分享时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createdTime: Date
 
         /// 镜像分享的账户ID

--- a/Sources/Teco/Cwp/V20180228/actions/DescribeAgentInstallCommand.swift
+++ b/Sources/Teco/Cwp/V20180228/actions/DescribeAgentInstallCommand.swift
@@ -40,8 +40,8 @@ extension Cwp {
 
         /// 命令有效期，非腾讯云时必填
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$expireDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var expireDate: Date?
 
         /// 代理方式接入的vip

--- a/Sources/Teco/Cwp/V20180228/actions/DescribeAssetRecentMachineInfo.swift
+++ b/Sources/Teco/Cwp/V20180228/actions/DescribeAssetRecentMachineInfo.swift
@@ -25,14 +25,14 @@ extension Cwp {
     public struct DescribeAssetRecentMachineInfoRequest: TCRequest {
         /// 开始时间，如：2020-09-22
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$beginDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var beginDate: Date
 
         /// 结束时间，如：2020-09-22
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var endDate: Date
 
         public init(beginDate: Date, endDate: Date) {

--- a/Sources/Teco/Cwp/V20180228/actions/DescribeSecurityTrends.swift
+++ b/Sources/Teco/Cwp/V20180228/actions/DescribeSecurityTrends.swift
@@ -25,14 +25,14 @@ extension Cwp {
     public struct DescribeSecurityTrendsRequest: TCRequest {
         /// 开始时间，如：2021-07-10
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$beginDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var beginDate: Date
 
         /// 结束时间，如：2021-07-10
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var endDate: Date
 
         public init(beginDate: Date, endDate: Date) {

--- a/Sources/Teco/Cwp/V20180228/actions/ExportSecurityTrends.swift
+++ b/Sources/Teco/Cwp/V20180228/actions/ExportSecurityTrends.swift
@@ -25,14 +25,14 @@ extension Cwp {
     public struct ExportSecurityTrendsRequest: TCRequest {
         /// 开始时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$beginDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var beginDate: Date
 
         /// 结束时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var endDate: Date
 
         public init(beginDate: Date, endDate: Date) {

--- a/Sources/Teco/Cwp/V20180228/models.swift
+++ b/Sources/Teco/Cwp/V20180228/models.swift
@@ -2231,14 +2231,14 @@ extension Cwp {
 
         /// 修改白名单时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$modifyTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var modifyTime: Date
 
         /// 创建白名单时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date
 
         /// 白名单是否全局
@@ -4408,8 +4408,8 @@ extension Cwp {
 
         /// 变更时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$modifyTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var modifyTime: Date
 
         enum CodingKeys: String, CodingKey {
@@ -5040,14 +5040,14 @@ extension Cwp {
 
         /// 创建白名单时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date
 
         /// 修改白名单时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$modifyTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var modifyTime: Date
 
         /// 机器名
@@ -6968,8 +6968,8 @@ extension Cwp {
 
         /// 安全事件发生时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$eventTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var eventTime: Date
 
         /// 安全事件类型。
@@ -7018,8 +7018,8 @@ extension Cwp {
     public struct SecurityTrend: TCOutputModel {
         /// 事件时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$date`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var date: Date
 
         /// 事件数量。

--- a/Sources/Teco/Cws/V20180312/actions/CreateMonitors.swift
+++ b/Sources/Teco/Cws/V20180312/actions/CreateMonitors.swift
@@ -40,8 +40,8 @@ extension Cws {
 
         /// 首次扫描开始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$firstScanStartTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var firstScanStartTime: Date
 
         public init(urls: [String], name: String, scannerType: String, crontab: UInt64, rateLimit: UInt64, firstScanStartTime: Date) {

--- a/Sources/Teco/Cws/V20180312/actions/DescribeConfig.swift
+++ b/Sources/Teco/Cws/V20180312/actions/DescribeConfig.swift
@@ -37,14 +37,14 @@ extension Cws {
 
         /// 记录创建时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdAt`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createdAt: Date
 
         /// 记录更新新建。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updatedAt`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var updatedAt: Date
 
         /// 云用户appid。

--- a/Sources/Teco/Cws/V20180312/actions/ModifyMonitorAttribute.swift
+++ b/Sources/Teco/Cws/V20180312/actions/ModifyMonitorAttribute.swift
@@ -43,8 +43,8 @@ extension Cws {
 
         /// 首次扫描开始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$firstScanStartTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var firstScanStartTime: Date
 
         /// 监测状态：1-监测中；2-暂停监测

--- a/Sources/Teco/Cws/V20180312/models.swift
+++ b/Sources/Teco/Cws/V20180312/models.swift
@@ -80,8 +80,8 @@ extension Cws {
 
         /// 首次扫描开始时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$firstScanStartTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var firstScanStartTime: Date?
 
         /// 扫描状态：0-待扫描（无任何扫描结果）；1-扫描中（正在进行扫描）；2-已扫描（有扫描结果且不正在扫描）；3-扫描完成待同步结果。
@@ -89,26 +89,26 @@ extension Cws {
 
         /// 上一次扫描完成时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$lastScanFinishTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var lastScanFinishTime: Date?
 
         /// 当前扫描开始时间，如扫描完成则为上一次扫描的开始时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$currentScanStartTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var currentScanStartTime: Date?
 
         /// CreatedAt。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdAt`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createdAt: Date?
 
         /// UpdatedAt。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updatedAt`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var updatedAt: Date?
 
         /// 云用户appid。
@@ -232,20 +232,20 @@ extension Cws {
 
         /// 最近一次扫描开始时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$lastScanStartTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var lastScanStartTime: Date?
 
         /// 最近一次扫描完成时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$lastScanFinishTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var lastScanFinishTime: Date?
 
         /// 最近一次取消时间，取消即使用上一次扫描结果。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$lastScanCancelTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var lastScanCancelTime: Date?
 
         /// 最近一次扫描扫描的页面数。
@@ -268,14 +268,14 @@ extension Cws {
 
         /// 记录添加时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdAt`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createdAt: Date?
 
         /// 记录最近修改时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updatedAt`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var updatedAt: Date?
 
         /// 速率限制，每秒发送X个HTTP请求。
@@ -374,8 +374,8 @@ extension Cws {
 
         /// 验证有效期，在此之前有效。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$validTo`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var validTo: Date?
 
         /// 验证状态：0-未验证；1-已验证；2-验证失效，待重新验证。
@@ -383,14 +383,14 @@ extension Cws {
 
         /// CreatedAt。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdAt`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createdAt: Date?
 
         /// UpdatedAt。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updatedAt`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var updatedAt: Date?
 
         /// ID。
@@ -463,14 +463,14 @@ extension Cws {
 
         /// CreatedAt。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdAt`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createdAt: Date?
 
         /// UpdatedAt。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updatedAt`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var updatedAt: Date?
 
         /// 是否已经添加误报，0-否，1-是。
@@ -514,8 +514,8 @@ extension Cws {
 
         /// 日期。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$date`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var date: Date
 
         /// 扫描页面总数量。
@@ -541,14 +541,14 @@ extension Cws {
 
         /// 记录添加时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdAt`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createdAt: Date
 
         /// 记录最近修改时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updatedAt`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var updatedAt: Date
 
         enum CodingKeys: String, CodingKey {

--- a/Sources/Teco/Cynosdb/V20190107/models.swift
+++ b/Sources/Teco/Cynosdb/V20190107/models.swift
@@ -53,14 +53,14 @@ extension Cynosdb {
 
         /// 创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date
 
         /// 更新时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updateTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var updateTime: Date
 
         /// 主机
@@ -591,14 +591,14 @@ extension Cynosdb {
 
         /// 创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createTime: Date
 
         /// 更新时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updateTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var updateTime: Date
 
         /// 集群ID
@@ -1202,14 +1202,14 @@ extension Cynosdb {
 
         /// 更新时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updateTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var updateTime: Date
 
         /// 创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date
 
         /// VPC网络ID
@@ -1229,8 +1229,8 @@ extension Cynosdb {
 
         /// 实例过期时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$periodEndTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var periodEndTime: Date
 
         /// 销毁期限
@@ -1238,8 +1238,8 @@ extension Cynosdb {
 
         /// 隔离时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$isolateTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var isolateTime: Date
 
         /// 网络类型
@@ -1436,14 +1436,14 @@ extension Cynosdb {
 
         /// 更新时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updateTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var updateTime: Date
 
         /// 创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date
 
         /// 付费模式
@@ -1451,8 +1451,8 @@ extension Cynosdb {
 
         /// 实例过期时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$periodEndTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var periodEndTime: Date
 
         /// 网络类型
@@ -1541,14 +1541,14 @@ extension Cynosdb {
 
         /// 创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createdTime: Date?
 
         /// 删除时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$deletedTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var deletedTime: Date?
 
         /// 实例组ID
@@ -1562,8 +1562,8 @@ extension Cynosdb {
 
         /// 更新时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updatedTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var updatedTime: Date?
 
         /// 内网IP
@@ -1704,15 +1704,15 @@ extension Cynosdb {
         /// 创建时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createTime: Date?
 
         /// 更新时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updateTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var updateTime: Date?
 
         /// 用户appid

--- a/Sources/Teco/Dasb/V20191018/actions/CreateAcl.swift
+++ b/Sources/Teco/Dasb/V20191018/actions/CreateAcl.swift
@@ -95,15 +95,15 @@ extension Dasb {
         /// 访问权限生效时间，如:"2021-09-22T00:00:00+00:00"
         /// 生效、失效时间不填则访问权限长期有效
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$validateFrom`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var validateFrom: Date?
 
         /// 访问权限失效时间，如:"2021-09-23T00:00:00+00:00"
         /// 生效、失效时间不填则访问权限长期有效
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$validateTo`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var validateTo: Date?
 
         /// 访问权限所属部门的ID

--- a/Sources/Teco/Dasb/V20191018/actions/CreateUser.swift
+++ b/Sources/Teco/Dasb/V20191018/actions/CreateUser.swift
@@ -38,15 +38,15 @@ extension Dasb {
         /// 用户生效时间，如:"2021-09-22T00:00:00+00:00"
         /// 生效、失效时间不填则用户长期有效
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$validateFrom`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var validateFrom: Date?
 
         /// 用户失效时间，如:"2021-09-23T00:00:00+00:00"
         /// 生效、失效时间不填则用户长期有效
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$validateTo`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var validateTo: Date?
 
         /// 所属用户组ID集合

--- a/Sources/Teco/Dasb/V20191018/actions/DescribeLoginEvent.swift
+++ b/Sources/Teco/Dasb/V20191018/actions/DescribeLoginEvent.swift
@@ -31,14 +31,14 @@ extension Dasb {
 
         /// 查询时间范围，起始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var startTime: Date?
 
         /// 查询时间范围，结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var endTime: Date?
 
         /// 来源IP，模糊查询

--- a/Sources/Teco/Dasb/V20191018/actions/DescribeOperationEvent.swift
+++ b/Sources/Teco/Dasb/V20191018/actions/DescribeOperationEvent.swift
@@ -31,14 +31,14 @@ extension Dasb {
 
         /// 查询时间范围，起始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var startTime: Date?
 
         /// 查询时间范围，结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var endTime: Date?
 
         /// 来源IP，模糊查询

--- a/Sources/Teco/Dasb/V20191018/actions/ModifyAcl.swift
+++ b/Sources/Teco/Dasb/V20191018/actions/ModifyAcl.swift
@@ -98,15 +98,15 @@ extension Dasb {
         /// 访问权限生效时间，如:"2021-09-22T00:00:00+00:00"
         /// 生效、失效时间不填则访问权限长期有效
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$validateFrom`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var validateFrom: Date?
 
         /// 访问权限失效时间，如:"2021-09-23T00:00:00+00:00"
         /// 生效、失效时间不填则访问权限长期有效
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$validateTo`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var validateTo: Date?
 
         /// 权限所属部门的ID，如：1.2.3

--- a/Sources/Teco/Dasb/V20191018/actions/ModifyUser.swift
+++ b/Sources/Teco/Dasb/V20191018/actions/ModifyUser.swift
@@ -38,15 +38,15 @@ extension Dasb {
         /// 用户生效时间，如:"2021-09-22T00:00:00+00:00"
         /// 生效、失效时间不填则用户长期有效
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$validateFrom`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var validateFrom: Date?
 
         /// 用户失效时间，如:"2021-09-23T00:00:00+00:00"
         /// 生效、失效时间不填则用户长期有效
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$validateTo`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var validateTo: Date?
 
         /// 所属用户组ID集合

--- a/Sources/Teco/Dasb/V20191018/actions/SearchAuditLog.swift
+++ b/Sources/Teco/Dasb/V20191018/actions/SearchAuditLog.swift
@@ -25,14 +25,14 @@ extension Dasb {
     public struct SearchAuditLogRequest: TCPaginatedRequest {
         /// 开始时间，不得早于当前时间的180天前
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var startTime: Date
 
         /// 结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var endTime: Date?
 
         /// 偏移量

--- a/Sources/Teco/Dasb/V20191018/actions/SearchCommand.swift
+++ b/Sources/Teco/Dasb/V20191018/actions/SearchCommand.swift
@@ -25,14 +25,14 @@ extension Dasb {
     public struct SearchCommandRequest: TCPaginatedRequest {
         /// 搜索区间的开始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var startTime: Date
 
         /// 搜索区间的结束时间，不填默认为开始时间到现在为止
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var endTime: Date?
 
         /// 用户名

--- a/Sources/Teco/Dasb/V20191018/actions/SearchFile.swift
+++ b/Sources/Teco/Dasb/V20191018/actions/SearchFile.swift
@@ -25,14 +25,14 @@ extension Dasb {
     public struct SearchFileRequest: TCPaginatedRequest {
         /// 查询开始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var startTime: Date
 
         /// 查询结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var endTime: Date?
 
         /// 用户名

--- a/Sources/Teco/Dasb/V20191018/actions/SearchSession.swift
+++ b/Sources/Teco/Dasb/V20191018/actions/SearchSession.swift
@@ -40,14 +40,14 @@ extension Dasb {
 
         /// 搜索区间的开始时间。若入参是Id，则非必传，否则为必传。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var startTime: Date?
 
         /// 搜索区间的结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var endTime: Date?
 
         /// 会话协议类型，只能是1、2、3或4 对应关系为1-tui 2-gui 3-file 4-数据库。若入参是Id，则非必传，否则为必传。

--- a/Sources/Teco/Dasb/V20191018/actions/SearchSessionCommand.swift
+++ b/Sources/Teco/Dasb/V20191018/actions/SearchSessionCommand.swift
@@ -28,8 +28,8 @@ extension Dasb {
 
         /// 开始时间，不得早于当前时间的180天前
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var startTime: Date
 
         /// 分页偏移位置，默认值为0
@@ -44,8 +44,8 @@ extension Dasb {
 
         /// 结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var endTime: Date?
 
         public init(cmd: String, startTime: Date, offset: UInt64? = nil, limit: UInt64? = nil, encoding: UInt64? = nil, endTime: Date? = nil) {

--- a/Sources/Teco/Dasb/V20191018/models.swift
+++ b/Sources/Teco/Dasb/V20191018/models.swift
@@ -120,15 +120,15 @@ extension Dasb {
         /// 访问权限生效时间，如:"2021-09-22T00:00:00+00:00"
         /// 生效、失效时间不填则访问权限长期有效
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$validateFrom`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var validateFrom: Date
 
         /// 访问权限失效时间，如:"2021-09-23T00:00:00+00:00"
         /// 生效、失效时间不填则访问权限长期有效
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$validateTo`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var validateTo: Date
 
         /// 访问权限状态，1 - 已生效，2 - 未生效，3 - 已过期
@@ -580,8 +580,8 @@ extension Dasb {
 
         /// 操作时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$time`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var time: Date
 
         /// 来源IP
@@ -613,8 +613,8 @@ extension Dasb {
 
         /// 操作时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$time`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var time: Date
 
         /// 来源IP
@@ -662,8 +662,8 @@ extension Dasb {
 
         /// 过期时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$expireTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var expireTime: Date
 
         /// 资源状态，0 - 未初始化，1 - 正常，2 - 隔离，3 - 销毁，4 - 初始化失败，5 - 初始化中
@@ -677,8 +677,8 @@ extension Dasb {
 
         /// 资源创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createTime: Date
 
         /// 商品码, p_cds_dasb
@@ -1135,15 +1135,15 @@ extension Dasb {
         /// 用户生效时间，如:"2021-09-22T00:00:00+00:00"
         /// 生效、失效时间不填则用户长期有效
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$validateFrom`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var validateFrom: Date?
 
         /// 用户失效时间，如:"2021-09-22T00:00:00+00:00"
         /// 生效、失效时间不填则用户长期有效
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$validateTo`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var validateTo: Date?
 
         /// 所属用户组列表

--- a/Sources/Teco/Dayu/V20180709/actions/CreateUnblockIp.swift
+++ b/Sources/Teco/Dayu/V20180709/actions/CreateUnblockIp.swift
@@ -50,8 +50,8 @@ extension Dayu {
 
         /// 解封时间（预计解封时间）
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$unblockTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var unblockTime: Date
 
         /// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。

--- a/Sources/Teco/Dayu/V20180709/actions/DescribeActionLog.swift
+++ b/Sources/Teco/Dayu/V20180709/actions/DescribeActionLog.swift
@@ -25,14 +25,14 @@ extension Dayu {
     public struct DescribeActionLogRequest: TCPaginatedRequest {
         /// 开始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// 大禹子产品代号（bgpip表示高防IP；bgp表示独享包；bgp-multip表示共享包；net表示高防IP专业版）

--- a/Sources/Teco/Dayu/V20180709/actions/DescribeBaradData.swift
+++ b/Sources/Teco/Dayu/V20180709/actions/DescribeBaradData.swift
@@ -45,14 +45,14 @@ extension Dayu {
 
         /// 统计开始时间，秒部分保持为0，分钟部分为5的倍数
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 统计结束时间，秒部分保持为0，分钟部分为5的倍数
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// 统计方式，取值：

--- a/Sources/Teco/Dayu/V20180709/actions/DescribeBizTrend.swift
+++ b/Sources/Teco/Dayu/V20180709/actions/DescribeBizTrend.swift
@@ -34,14 +34,14 @@ extension Dayu {
 
         /// 统计开始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 统计结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// 统计方式，可取值max, min, avg, sum, 如统计纬度是流量速率或包量速率，仅可取值max

--- a/Sources/Teco/Dayu/V20180709/actions/DescribeCCEvList.swift
+++ b/Sources/Teco/Dayu/V20180709/actions/DescribeCCEvList.swift
@@ -28,14 +28,14 @@ extension Dayu {
 
         /// 开始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// 资源实例ID
@@ -85,14 +85,14 @@ extension Dayu {
 
         /// 开始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// CC攻击事件列表

--- a/Sources/Teco/Dayu/V20180709/actions/DescribeCCTrend.swift
+++ b/Sources/Teco/Dayu/V20180709/actions/DescribeCCTrend.swift
@@ -37,14 +37,14 @@ extension Dayu {
 
         /// 统计开始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 统计结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// 资源实例ID，当Business为basic时，此字段不用填写（因为基础防护没有资源实例）
@@ -96,14 +96,14 @@ extension Dayu {
 
         /// 统计开始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 统计结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// 值数组

--- a/Sources/Teco/Dayu/V20180709/actions/DescribeDDoSAttackIPRegionMap.swift
+++ b/Sources/Teco/Dayu/V20180709/actions/DescribeDDoSAttackIPRegionMap.swift
@@ -31,14 +31,14 @@ extension Dayu {
 
         /// 统计开始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 统计结束时间，最大可统计的时间范围是半年；
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// 指定资源的特定IP的攻击源，可选

--- a/Sources/Teco/Dayu/V20180709/actions/DescribeDDoSAttackSource.swift
+++ b/Sources/Teco/Dayu/V20180709/actions/DescribeDDoSAttackSource.swift
@@ -31,14 +31,14 @@ extension Dayu {
 
         /// 起始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// 一页条数，填0表示不分页

--- a/Sources/Teco/Dayu/V20180709/actions/DescribeDDoSCount.swift
+++ b/Sources/Teco/Dayu/V20180709/actions/DescribeDDoSCount.swift
@@ -34,14 +34,14 @@ extension Dayu {
 
         /// 统计开始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 统计结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// 指标，取值[traffic（攻击协议流量, 单位KB）, pkg（攻击协议报文数）, classnum（攻击事件次数）]
@@ -79,14 +79,14 @@ extension Dayu {
 
         /// 统计开始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 统计结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// 指标，取值[traffic（攻击协议流量, 单位KB）, pkg（攻击协议报文数）, classnum（攻击事件次数）]

--- a/Sources/Teco/Dayu/V20180709/actions/DescribeDDoSEvInfo.swift
+++ b/Sources/Teco/Dayu/V20180709/actions/DescribeDDoSEvInfo.swift
@@ -34,14 +34,14 @@ extension Dayu {
 
         /// 攻击开始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 攻击结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         public init(business: String, id: String, ip: String, startTime: Date, endTime: Date) {
@@ -74,14 +74,14 @@ extension Dayu {
 
         /// 攻击开始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 攻击结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// TCP报文攻击包数

--- a/Sources/Teco/Dayu/V20180709/actions/DescribeDDoSEvList.swift
+++ b/Sources/Teco/Dayu/V20180709/actions/DescribeDDoSEvList.swift
@@ -28,14 +28,14 @@ extension Dayu {
 
         /// 开始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// 资源实例ID，当Business为basic时，此字段不用填写（因为基础防护没有资源实例）

--- a/Sources/Teco/Dayu/V20180709/actions/DescribeDDoSIpLog.swift
+++ b/Sources/Teco/Dayu/V20180709/actions/DescribeDDoSIpLog.swift
@@ -34,14 +34,14 @@ extension Dayu {
 
         /// 攻击开始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 攻击结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         public init(business: String, id: String, ip: String, startTime: Date, endTime: Date) {
@@ -74,14 +74,14 @@ extension Dayu {
 
         /// 攻击开始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 攻击结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// IP攻击日志，KeyValue数组，Key-Value取值说明：

--- a/Sources/Teco/Dayu/V20180709/actions/DescribeDDoSNetCount.swift
+++ b/Sources/Teco/Dayu/V20180709/actions/DescribeDDoSNetCount.swift
@@ -31,14 +31,14 @@ extension Dayu {
 
         /// 统计开始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 统计结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// 指标，取值[traffic（攻击协议流量, 单位KB）, pkg（攻击协议报文数）, classnum（攻击事件次数）]
@@ -71,14 +71,14 @@ extension Dayu {
 
         /// 统计开始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 统计结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// 指标，取值[traffic（攻击协议流量, 单位KB）, pkg（攻击协议报文数）, classnum（攻击事件次数）]

--- a/Sources/Teco/Dayu/V20180709/actions/DescribeDDoSNetEvInfo.swift
+++ b/Sources/Teco/Dayu/V20180709/actions/DescribeDDoSNetEvInfo.swift
@@ -31,14 +31,14 @@ extension Dayu {
 
         /// 攻击开始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 攻击结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         public init(business: String, id: String, startTime: Date, endTime: Date) {

--- a/Sources/Teco/Dayu/V20180709/actions/DescribeDDoSNetEvList.swift
+++ b/Sources/Teco/Dayu/V20180709/actions/DescribeDDoSNetEvList.swift
@@ -31,14 +31,14 @@ extension Dayu {
 
         /// 开始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// 一页条数，填0表示不分页
@@ -84,14 +84,14 @@ extension Dayu {
 
         /// 开始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// DDoS攻击事件列表

--- a/Sources/Teco/Dayu/V20180709/actions/DescribeDDoSNetIpLog.swift
+++ b/Sources/Teco/Dayu/V20180709/actions/DescribeDDoSNetIpLog.swift
@@ -31,14 +31,14 @@ extension Dayu {
 
         /// 攻击开始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 攻击结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         public init(business: String, id: String, startTime: Date, endTime: Date) {
@@ -66,14 +66,14 @@ extension Dayu {
 
         /// 攻击开始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 攻击结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// IP攻击日志，KeyValue数组，Key-Value取值说明：

--- a/Sources/Teco/Dayu/V20180709/actions/DescribeDDoSNetTrend.swift
+++ b/Sources/Teco/Dayu/V20180709/actions/DescribeDDoSNetTrend.swift
@@ -37,14 +37,14 @@ extension Dayu {
 
         /// 统计开始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 统计结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         public init(business: String, id: String, metricName: String, period: UInt64, startTime: Date, endTime: Date) {
@@ -82,14 +82,14 @@ extension Dayu {
 
         /// 统计开始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 统计结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// 值数组

--- a/Sources/Teco/Dayu/V20180709/actions/DescribeDDoSTrend.swift
+++ b/Sources/Teco/Dayu/V20180709/actions/DescribeDDoSTrend.swift
@@ -37,14 +37,14 @@ extension Dayu {
 
         /// 统计开始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 统计结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// 资源实例ID，当Business为basic时，此字段不用填写（因为基础防护没有资源实例）
@@ -91,14 +91,14 @@ extension Dayu {
 
         /// 统计开始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 统计结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// 值数组，攻击流量带宽单位为Mbps，包速率单位为pps

--- a/Sources/Teco/Dayu/V20180709/actions/DescribeIpUnBlockList.swift
+++ b/Sources/Teco/Dayu/V20180709/actions/DescribeIpUnBlockList.swift
@@ -25,14 +25,14 @@ extension Dayu {
     public struct DescribeIpUnBlockListRequest: TCPaginatedRequest {
         /// 开始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$beginTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var beginTime: Date
 
         /// 结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// IP（不为空时，进行IP过滤）

--- a/Sources/Teco/Dayu/V20180709/actions/DescribePcap.swift
+++ b/Sources/Teco/Dayu/V20180709/actions/DescribePcap.swift
@@ -31,14 +31,14 @@ extension Dayu {
 
         /// 攻击事件的开始时间，格式为"2018-08-28 07:00:00"
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 攻击事件的结束时间，格式为"2018-08-28 07:02:00"
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// 资源的IP，只有当Business为net时才需要填写资源实例下的IP；

--- a/Sources/Teco/Dayu/V20180709/actions/DescribeSecIndex.swift
+++ b/Sources/Teco/Dayu/V20180709/actions/DescribeSecIndex.swift
@@ -39,14 +39,14 @@ extension Dayu {
 
         /// 本月开始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$beginDate`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var beginDate: Date
 
         /// 本月结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endDate`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endDate: Date
 
         /// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。

--- a/Sources/Teco/Dayu/V20180709/actions/DescribeTransmitStatis.swift
+++ b/Sources/Teco/Dayu/V20180709/actions/DescribeTransmitStatis.swift
@@ -39,14 +39,14 @@ extension Dayu {
 
         /// 统计开始时间，秒部分保持为0，分钟部分为5的倍数
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 统计结束时间，秒部分保持为0，分钟部分为5的倍数
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// 资源的IP（当Business为bgp-multip时必填，且仅支持一个IP）；当不填写时，默认统计资源实例的所有IP；资源实例有多个IP（比如高防IP专业版）时，统计方式是求和；

--- a/Sources/Teco/Dayu/V20180709/actions/DescribeUnBlockStatis.swift
+++ b/Sources/Teco/Dayu/V20180709/actions/DescribeUnBlockStatis.swift
@@ -37,14 +37,14 @@ extension Dayu {
 
         /// 统计起始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$beginTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var beginTime: Date
 
         /// 统计结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。

--- a/Sources/Teco/Dayu/V20180709/models.swift
+++ b/Sources/Teco/Dayu/V20180709/models.swift
@@ -101,14 +101,14 @@ extension Dayu {
 
         /// 攻击开始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 攻击结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// 总请求QPS峰值
@@ -369,14 +369,14 @@ extension Dayu {
 
         /// 攻击开始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 攻击结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// 攻击最大带宽
@@ -789,14 +789,14 @@ extension Dayu {
 
         /// 封堵时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$blockTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var blockTime: Date
 
         /// 解封时间（预计解封时间）
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$unBlockTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var unBlockTime: Date
 
         /// 解封类型（user：自助解封；auto：自动解封； update：升级解封；bind：绑定高防包解封）
@@ -822,14 +822,14 @@ extension Dayu {
 
         /// 封堵时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$blockTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var blockTime: Date
 
         /// 解封时间（实际解封时间）
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$unBlockTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var unBlockTime: Date
 
         /// 解封类型（user：自助解封；auto：自动解封； update：升级解封；bind：绑定高防包解封）
@@ -1318,8 +1318,8 @@ extension Dayu {
 
         /// 规则修改时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$modifyTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var modifyTime: Date?
 
         /// 对应地区信息
@@ -1435,8 +1435,8 @@ extension Dayu {
 
         /// 修改时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$modifyTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var modifyTime: Date?
 
         /// 是否开启Https协议使用Http回源，取值[0(关闭), 1(开启)]，不填写默认是关闭
@@ -1623,8 +1623,8 @@ extension Dayu {
 
         /// 创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date
 
         /// ttl
@@ -1637,8 +1637,8 @@ extension Dayu {
         /// 修改时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$modifyTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var modifyTime: Date?
 
         enum CodingKeys: String, CodingKey {
@@ -1686,8 +1686,8 @@ extension Dayu {
 
         /// 密钥生成时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date
 
         enum CodingKeys: String, CodingKey {

--- a/Sources/Teco/Dbbrain/V20191016/actions/CreateDBDiagReportTask.swift
+++ b/Sources/Teco/Dbbrain/V20191016/actions/CreateDBDiagReportTask.swift
@@ -28,14 +28,14 @@ extension Dbbrain {
 
         /// 开始时间，如“2020-11-08T14:00:00+08:00”。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var startTime: Date
 
         /// 结束时间，如“2020-11-09T14:00:00+08:00”。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var endTime: Date
 
         /// 是否发送邮件: 0 - 否，1 - 是。

--- a/Sources/Teco/Dbbrain/V20191016/actions/CreateSecurityAuditLogExportTask.swift
+++ b/Sources/Teco/Dbbrain/V20191016/actions/CreateSecurityAuditLogExportTask.swift
@@ -28,14 +28,14 @@ extension Dbbrain {
 
         /// 导出日志开始时间，例如2020-12-28 00:00:00。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var startTime: Date
 
         /// 导出日志结束时间，例如2020-12-28 01:00:00。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var endTime: Date
 
         /// 服务产品类型，支持值："mysql" - 云数据库 MySQL。

--- a/Sources/Teco/Dbbrain/V20191016/actions/DescribeDBDiagEvent.swift
+++ b/Sources/Teco/Dbbrain/V20191016/actions/DescribeDBDiagEvent.swift
@@ -70,8 +70,8 @@ extension Dbbrain {
 
         /// 开始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 建议。
@@ -83,8 +83,8 @@ extension Dbbrain {
 
         /// 结束时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。

--- a/Sources/Teco/Dbbrain/V20191016/actions/DescribeDBDiagHistory.swift
+++ b/Sources/Teco/Dbbrain/V20191016/actions/DescribeDBDiagHistory.swift
@@ -28,14 +28,14 @@ extension Dbbrain {
 
         /// 开始时间，如“2019-09-10 12:13:14”。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 结束时间，如“2019-09-11 12:13:14”，结束时间与开始时间的间隔最大可为2天。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// 服务产品类型，支持值包括： "mysql" - 云数据库 MySQL， "cynosdb" - 云数据库 CynosDB  for MySQL，默认为"mysql"。

--- a/Sources/Teco/Dbbrain/V20191016/actions/DescribeDBDiagReportTasks.swift
+++ b/Sources/Teco/Dbbrain/V20191016/actions/DescribeDBDiagReportTasks.swift
@@ -25,14 +25,14 @@ extension Dbbrain {
     public struct DescribeDBDiagReportTasksRequest: TCPaginatedRequest {
         /// 第一个任务的开始时间，用于范围查询，时间格式如：2019-09-10 12:13:14。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var startTime: Date?
 
         /// 最后一个任务的开始时间，用于范围查询，时间格式如：2019-09-10 12:13:14。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var endTime: Date?
 
         /// 实例ID数组，用于筛选指定实例的任务列表。

--- a/Sources/Teco/Dbbrain/V20191016/actions/DescribeHealthScore.swift
+++ b/Sources/Teco/Dbbrain/V20191016/actions/DescribeHealthScore.swift
@@ -28,8 +28,8 @@ extension Dbbrain {
 
         /// 获取健康得分的时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$time`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var time: Date
 
         /// 服务产品类型，支持值包括： "mysql" - 云数据库 MySQL， "cynosdb" - 云数据库 TDSQL-C for MySQL，默认为"mysql"。

--- a/Sources/Teco/Dbbrain/V20191016/actions/DescribeSlowLogTimeSeriesStats.swift
+++ b/Sources/Teco/Dbbrain/V20191016/actions/DescribeSlowLogTimeSeriesStats.swift
@@ -28,14 +28,14 @@ extension Dbbrain {
 
         /// 开始时间，如“2019-09-10 12:13:14”。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 结束时间，如“2019-09-10 12:13:14”，结束时间与开始时间的间隔最大可为7天。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// 服务产品类型，支持值包括： "mysql" - 云数据库 MySQL， "cynosdb" - 云数据库 CynosDB  for MySQL，默认为"mysql"。

--- a/Sources/Teco/Dbbrain/V20191016/actions/DescribeSlowLogTopSqls.swift
+++ b/Sources/Teco/Dbbrain/V20191016/actions/DescribeSlowLogTopSqls.swift
@@ -28,14 +28,14 @@ extension Dbbrain {
 
         /// 开始时间，如“2019-09-10 12:13:14”。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 截止时间，如“2019-09-10 12:13:14”，截止时间与开始时间的间隔最大可为7天。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// 排序键，目前支持 QueryTime,ExecTimes,RowsSent,LockTime以及RowsExamined 等排序键。

--- a/Sources/Teco/Dbbrain/V20191016/actions/DescribeSlowLogUserHostStats.swift
+++ b/Sources/Teco/Dbbrain/V20191016/actions/DescribeSlowLogUserHostStats.swift
@@ -28,14 +28,14 @@ extension Dbbrain {
 
         /// 查询范围的开始时间，时间格式如：2019-09-10 12:13:14。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var startTime: Date
 
         /// 查询范围的结束时间，时间格式如：2019-09-10 12:13:14。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var endTime: Date
 
         /// 服务产品类型，支持值："mysql" - 云数据库 MySQL；"cynosdb" - 云数据库 TDSQL-C for MySQL，默认为"mysql"。

--- a/Sources/Teco/Dbbrain/V20191016/actions/DescribeTopSpaceSchemaTimeSeries.swift
+++ b/Sources/Teco/Dbbrain/V20191016/actions/DescribeTopSpaceSchemaTimeSeries.swift
@@ -34,14 +34,14 @@ extension Dbbrain {
 
         /// 开始日期，如“2021-01-01”，最早为当日的前第29天，默认为截止日期的前第6天。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var startDate: Date?
 
         /// 截止日期，如“2021-01-01”，最早为当日的前第29天，默认为当日。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var endDate: Date?
 
         /// 服务产品类型，支持值包括： "mysql" - 云数据库 MySQL， "cynosdb" - 云数据库 CynosDB  for MySQL，默认为"mysql"。

--- a/Sources/Teco/Dbbrain/V20191016/actions/DescribeTopSpaceTableTimeSeries.swift
+++ b/Sources/Teco/Dbbrain/V20191016/actions/DescribeTopSpaceTableTimeSeries.swift
@@ -34,14 +34,14 @@ extension Dbbrain {
 
         /// 开始日期，如“2021-01-01”，最早为当日的前第29天，默认为截止日期的前第6天。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var startDate: Date?
 
         /// 截止日期，如“2021-01-01”，最早为当日的前第29天，默认为当日。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var endDate: Date?
 
         /// 服务产品类型，支持值包括： "mysql" - 云数据库 MySQL， "cynosdb" - 云数据库 CynosDB  for MySQL，默认为"mysql"。

--- a/Sources/Teco/Dbbrain/V20191016/models.swift
+++ b/Sources/Teco/Dbbrain/V20191016/models.swift
@@ -44,14 +44,14 @@ extension Dbbrain {
 
         /// 结束时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// 开始时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 事件 ID 。
@@ -102,14 +102,14 @@ extension Dbbrain {
 
         /// 开始时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var startTime: Date
 
         /// 结束时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var endTime: Date
 
         /// 概要。
@@ -171,20 +171,20 @@ extension Dbbrain {
 
         /// 任务创建时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date
 
         /// 任务开始执行时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 任务完成执行时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// 任务所属实例的基础信息。
@@ -378,8 +378,8 @@ extension Dbbrain {
 
         /// 资源到期时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$deadlineTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var deadlineTime: Date
 
         /// 是否是DBbrain支持的实例。
@@ -711,21 +711,21 @@ extension Dbbrain {
         /// 任务开始时间。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date?
 
         /// 任务结束时间。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date?
 
         /// 任务创建时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date
 
         /// 任务状态。
@@ -737,15 +737,15 @@ extension Dbbrain {
         /// 导出日志开始时间。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$logStartTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var logStartTime: Date?
 
         /// 导出日志结束时间。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$logEndTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var logEndTime: Date?
 
         /// 日志文件总大小，单位KB。

--- a/Sources/Teco/Dbbrain/V20210527/actions/CreateAuditLogFile.swift
+++ b/Sources/Teco/Dbbrain/V20210527/actions/CreateAuditLogFile.swift
@@ -34,14 +34,14 @@ extension Dbbrain {
 
         /// 开始时间，如“2019-09-10 12:13:14”。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var startTime: Date
 
         /// 截止时间，如“2019-09-11 10:13:14”。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var endTime: Date
 
         /// 过滤条件。可按设置的过滤条件过滤日志。

--- a/Sources/Teco/Dbbrain/V20210527/actions/CreateDBDiagReportTask.swift
+++ b/Sources/Teco/Dbbrain/V20210527/actions/CreateDBDiagReportTask.swift
@@ -28,14 +28,14 @@ extension Dbbrain {
 
         /// 开始时间，如“2020-11-08T14:00:00+08:00”。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var startTime: Date
 
         /// 结束时间，如“2020-11-09T14:00:00+08:00”。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var endTime: Date
 
         /// 是否发送邮件: 0 - 否，1 - 是。

--- a/Sources/Teco/Dbbrain/V20210527/actions/CreateSecurityAuditLogExportTask.swift
+++ b/Sources/Teco/Dbbrain/V20210527/actions/CreateSecurityAuditLogExportTask.swift
@@ -28,14 +28,14 @@ extension Dbbrain {
 
         /// 导出日志开始时间，例如2020-12-28 00:00:00。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var startTime: Date
 
         /// 导出日志结束时间，例如2020-12-28 01:00:00。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var endTime: Date
 
         /// 服务产品类型，支持值："mysql" - 云数据库 MySQL。

--- a/Sources/Teco/Dbbrain/V20210527/actions/DescribeDBDiagEvent.swift
+++ b/Sources/Teco/Dbbrain/V20210527/actions/DescribeDBDiagEvent.swift
@@ -70,8 +70,8 @@ extension Dbbrain {
 
         /// 开始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 诊断建议，若无建议则输出为空。
@@ -83,8 +83,8 @@ extension Dbbrain {
 
         /// 结束时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。

--- a/Sources/Teco/Dbbrain/V20210527/actions/DescribeDBDiagEvents.swift
+++ b/Sources/Teco/Dbbrain/V20210527/actions/DescribeDBDiagEvents.swift
@@ -25,14 +25,14 @@ extension Dbbrain {
     public struct DescribeDBDiagEventsRequest: TCPaginatedRequest {
         /// 开始时间，如“2021-05-27 00:00:00”，支持的最早查询时间为当前时间的前30天。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var startTime: Date
 
         /// 结束时间，如“2021-05-27 01:00:00”，结束时间与开始时间的间隔最大可为7天。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var endTime: Date
 
         /// 风险等级列表，取值按影响程度从高至低分别为：1 - 致命、2 -严重、3 - 告警、4 - 提示、5 -健康。

--- a/Sources/Teco/Dbbrain/V20210527/actions/DescribeDBDiagHistory.swift
+++ b/Sources/Teco/Dbbrain/V20210527/actions/DescribeDBDiagHistory.swift
@@ -28,14 +28,14 @@ extension Dbbrain {
 
         /// 开始时间，如“2019-09-10 12:13:14”。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 结束时间，如“2019-09-11 12:13:14”，结束时间与开始时间的间隔最大可为2天。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// 服务产品类型，支持值包括： "mysql" - 云数据库 MySQL， "cynosdb" - 云数据库 CynosDB  for MySQL，默认为"mysql"。

--- a/Sources/Teco/Dbbrain/V20210527/actions/DescribeDBDiagReportTasks.swift
+++ b/Sources/Teco/Dbbrain/V20210527/actions/DescribeDBDiagReportTasks.swift
@@ -25,14 +25,14 @@ extension Dbbrain {
     public struct DescribeDBDiagReportTasksRequest: TCPaginatedRequest {
         /// 第一个任务的开始时间，用于范围查询，时间格式如：2019-09-10 12:13:14。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var startTime: Date?
 
         /// 最后一个任务的开始时间，用于范围查询，时间格式如：2019-09-10 12:13:14。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var endTime: Date?
 
         /// 实例ID数组，用于筛选指定实例的任务列表。

--- a/Sources/Teco/Dbbrain/V20210527/actions/DescribeHealthScore.swift
+++ b/Sources/Teco/Dbbrain/V20210527/actions/DescribeHealthScore.swift
@@ -28,8 +28,8 @@ extension Dbbrain {
 
         /// 获取健康得分的时间，时间格式如：2019-09-10 12:13:14。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$time`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var time: Date
 
         /// 服务产品类型，支持值包括： "mysql" - 云数据库 MySQL， "cynosdb" - 云数据库 TDSQL-C for MySQL，默认为"mysql"。

--- a/Sources/Teco/Dbbrain/V20210527/actions/DescribeNoPrimaryKeyTables.swift
+++ b/Sources/Teco/Dbbrain/V20210527/actions/DescribeNoPrimaryKeyTables.swift
@@ -28,8 +28,8 @@ extension Dbbrain {
 
         /// 查询日期，如2021-05-27，最早为30天前的日期。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$date`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var date: Date
 
         /// 查询数目，默认为20，最大为100。

--- a/Sources/Teco/Dbbrain/V20210527/actions/DescribeRedisTopBigKeys.swift
+++ b/Sources/Teco/Dbbrain/V20210527/actions/DescribeRedisTopBigKeys.swift
@@ -28,8 +28,8 @@ extension Dbbrain {
 
         /// 查询日期，如2021-05-27，最早可为前30天的日期。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$date`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var date: Date
 
         /// 服务产品类型，支持值包括 "redis" - 云数据库 Redis。

--- a/Sources/Teco/Dbbrain/V20210527/actions/DescribeRedisTopKeyPrefixList.swift
+++ b/Sources/Teco/Dbbrain/V20210527/actions/DescribeRedisTopKeyPrefixList.swift
@@ -28,8 +28,8 @@ extension Dbbrain {
 
         /// 查询日期，如2021-05-27，最早可为前30天的日期。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$date`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var date: Date
 
         /// 服务产品类型，支持值包括 "redis" - 云数据库 Redis。

--- a/Sources/Teco/Dbbrain/V20210527/actions/DescribeSlowLogTimeSeriesStats.swift
+++ b/Sources/Teco/Dbbrain/V20210527/actions/DescribeSlowLogTimeSeriesStats.swift
@@ -28,14 +28,14 @@ extension Dbbrain {
 
         /// 开始时间，如“2019-09-10 12:13:14”。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 结束时间，如“2019-09-10 12:13:14”，结束时间与开始时间的间隔最大可为7天。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// 服务产品类型，支持值包括： "mysql" - 云数据库 MySQL， "cynosdb" - 云数据库 CynosDB  for MySQL，默认为"mysql"。

--- a/Sources/Teco/Dbbrain/V20210527/actions/DescribeSlowLogTopSqls.swift
+++ b/Sources/Teco/Dbbrain/V20210527/actions/DescribeSlowLogTopSqls.swift
@@ -28,14 +28,14 @@ extension Dbbrain {
 
         /// 开始时间，如“2019-09-10 12:13:14”。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 截止时间，如“2019-09-11 10:13:14”，截止时间与开始时间的间隔小于7天。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// 排序键，目前支持 QueryTime,ExecTimes,RowsSent,LockTime以及RowsExamined 等排序键，默认为QueryTime。

--- a/Sources/Teco/Dbbrain/V20210527/actions/DescribeSlowLogUserHostStats.swift
+++ b/Sources/Teco/Dbbrain/V20210527/actions/DescribeSlowLogUserHostStats.swift
@@ -28,14 +28,14 @@ extension Dbbrain {
 
         /// 查询范围的开始时间，时间格式如：2019-09-10 12:13:14。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var startTime: Date
 
         /// 查询范围的结束时间，时间格式如：2019-09-10 12:13:14。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var endTime: Date
 
         /// 服务产品类型，支持值："mysql" - 云数据库 MySQL；"cynosdb" - 云数据库 TDSQL-C for MySQL，默认为"mysql"。

--- a/Sources/Teco/Dbbrain/V20210527/actions/DescribeSlowLogs.swift
+++ b/Sources/Teco/Dbbrain/V20210527/actions/DescribeSlowLogs.swift
@@ -34,14 +34,14 @@ extension Dbbrain {
 
         /// 开始时间，如“2019-09-10 12:13:14”。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var startTime: Date
 
         /// 截止时间，如“2019-09-11 10:13:14”，截止时间与开始时间的间隔小于7天。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var endTime: Date
 
         /// 偏移量，默认为0。

--- a/Sources/Teco/Dbbrain/V20210527/actions/DescribeTopSpaceSchemaTimeSeries.swift
+++ b/Sources/Teco/Dbbrain/V20210527/actions/DescribeTopSpaceSchemaTimeSeries.swift
@@ -34,14 +34,14 @@ extension Dbbrain {
 
         /// 开始日期，如“2021-01-01”，最早为当日的前第29天，默认为截止日期的前第6天。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var startDate: Date?
 
         /// 截止日期，如“2021-01-01”，最早为当日的前第29天，默认为当日。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var endDate: Date?
 
         /// 服务产品类型，支持值包括： "mysql" - 云数据库 MySQL， "cynosdb" - 云数据库 CynosDB  for MySQL，默认为"mysql"。

--- a/Sources/Teco/Dbbrain/V20210527/actions/DescribeTopSpaceTableTimeSeries.swift
+++ b/Sources/Teco/Dbbrain/V20210527/actions/DescribeTopSpaceTableTimeSeries.swift
@@ -34,14 +34,14 @@ extension Dbbrain {
 
         /// 开始日期，如“2021-01-01”，最早为当日的前第29天，默认为截止日期的前第6天。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var startDate: Date?
 
         /// 截止日期，如“2021-01-01”，最早为当日的前第29天，默认为当日。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var endDate: Date?
 
         /// 服务产品类型，支持值包括： "mysql" - 云数据库 MySQL， "cynosdb" - 云数据库 CynosDB  for MySQL，默认为"mysql"。

--- a/Sources/Teco/Dbbrain/V20210527/models.swift
+++ b/Sources/Teco/Dbbrain/V20210527/models.swift
@@ -381,14 +381,14 @@ extension Dbbrain {
 
         /// 结束时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// 开始时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 事件唯一ID 。
@@ -437,14 +437,14 @@ extension Dbbrain {
 
         /// 开始时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var startTime: Date
 
         /// 结束时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var endTime: Date
 
         /// 概要。
@@ -506,20 +506,20 @@ extension Dbbrain {
 
         /// 任务创建时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date
 
         /// 任务开始执行时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 任务完成执行时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// 任务所属实例的基础信息。
@@ -787,8 +787,8 @@ extension Dbbrain {
 
         /// 资源到期时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$deadlineTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var deadlineTime: Date
 
         /// 是否是DBbrain支持的实例。
@@ -1286,20 +1286,20 @@ extension Dbbrain {
 
         /// 任务创建时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createTime: Date
 
         /// 当前时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$currentTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var currentTime: Date
 
         /// 限流过期时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$expireTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var expireTime: Date
 
         enum CodingKeys: String, CodingKey {
@@ -1441,21 +1441,21 @@ extension Dbbrain {
         /// 任务开始时间。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date?
 
         /// 任务结束时间。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date?
 
         /// 任务创建时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date
 
         /// 任务状态。
@@ -1467,15 +1467,15 @@ extension Dbbrain {
         /// 导出日志开始时间。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$logStartTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var logStartTime: Date?
 
         /// 导出日志结束时间。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$logEndTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var logEndTime: Date?
 
         /// 日志文件总大小，单位KB。
@@ -1814,14 +1814,14 @@ extension Dbbrain {
 
         /// 任务创建时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createTime: Date
 
         /// 任务启动时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var startTime: Date
 
         /// 任务的状态，支持的取值包括："created" - 新建；"chosen" - 待执行； "running" - 执行中；"failed" - 失败；"finished" - 已完成。
@@ -1835,8 +1835,8 @@ extension Dbbrain {
 
         /// 任务结束时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var endTime: Date
 
         /// 任务执行进度。

--- a/Sources/Teco/Dc/V20180410/models.swift
+++ b/Sources/Teco/Dc/V20180410/models.swift
@@ -164,14 +164,14 @@ extension Dc {
 
         /// 物理专线创建时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createdTime: Date
 
         /// 物理专线的开通时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$enabledTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var enabledTime: Date
 
         /// 提供接入物理专线的运营商。ChinaTelecom：中国电信， ChinaMobile：中国移动，ChinaUnicom：中国联通， In-houseWiring：楼内线，ChinaOther：中国其他， InternationalOperator：境外其他。
@@ -220,8 +220,8 @@ extension Dc {
         /// 物理专线的过期时间。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$expiredTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var expiredTime: Date?
 
         /// 物理专线计费类型。 NON_RECURRING_CHARGE：一次性接入费用；PREPAID_BY_YEAR：按年预付费。
@@ -373,8 +373,8 @@ extension Dc {
 
         /// 专用通道创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createdTime: Date
 
         /// 专用通道带宽值
@@ -529,8 +529,8 @@ extension Dc {
 
         /// 专用通道创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createdTime: Date
 
         /// 专用通道带宽值

--- a/Sources/Teco/Dcdb/V20180411/actions/DescribeDBSlowLogs.swift
+++ b/Sources/Teco/Dcdb/V20180411/actions/DescribeDBSlowLogs.swift
@@ -34,8 +34,8 @@ extension Dcdb {
 
         /// 查询的起始时间，形如2016-07-23 14:55:20
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 实例的分片ID，形如shard-53ima8ln
@@ -43,8 +43,8 @@ extension Dcdb {
 
         /// 查询的结束时间，形如2016-08-22 14:55:20。如果不填，那么查询结束时间就是当前时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date?
 
         /// 要查询的具体数据库名称

--- a/Sources/Teco/Dcdb/V20180411/actions/DescribeDCDBInstanceDetail.swift
+++ b/Sources/Teco/Dcdb/V20180411/actions/DescribeDCDBInstanceDetail.swift
@@ -93,14 +93,14 @@ extension Dcdb {
 
         /// 实例创建时间，格式为 2006-01-02 15:04:05
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date
 
         /// 实例到期时间，格式为 2006-01-02 15:04:05
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$periodEndTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var periodEndTime: Date
 
         /// 数据库版本信息

--- a/Sources/Teco/Dcdb/V20180411/actions/UpgradeHourDCDBInstance.swift
+++ b/Sources/Teco/Dcdb/V20180411/actions/UpgradeHourDCDBInstance.swift
@@ -43,14 +43,14 @@ extension Dcdb {
 
         /// 切换开始时间，格式如: "2019-12-12 07:00:00"。开始时间必须在当前时间一个小时以后，3天以内。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$switchStartTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var switchStartTime: Date?
 
         /// 切换结束时间,  格式如: "2019-12-12 07:15:00"，结束时间必须大于开始时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$switchEndTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var switchEndTime: Date?
 
         /// 是否自动重试。 0：不自动重试  1：自动重试

--- a/Sources/Teco/Dcdb/V20180411/models.swift
+++ b/Sources/Teco/Dcdb/V20180411/models.swift
@@ -155,14 +155,14 @@ extension Dcdb {
 
         /// 创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date
 
         /// 最后更新时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updateTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var updateTime: Date
 
         /// 只读标记，0：否， 1：该账号的sql请求优先选择备机执行，备机不可用时选择主机执行，2：优先选择备机执行，备机不可用时操作失败。
@@ -250,8 +250,8 @@ extension Dcdb {
 
         /// 创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date
 
         /// 自动续费标志
@@ -268,14 +268,14 @@ extension Dcdb {
 
         /// 到期时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$periodEndTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var periodEndTime: Date
 
         /// 隔离时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$isolatedTimestamp`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var isolatedTimestamp: Date
 
         /// 账号ID
@@ -316,8 +316,8 @@ extension Dcdb {
 
         /// 实例最后更新时间，格式为 2006-01-02 15:04:05
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updateTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var updateTime: Date
 
         /// 数据库引擎
@@ -459,8 +459,8 @@ extension Dcdb {
 
         /// 创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date
 
         /// 字符串格式的私有网络Id
@@ -486,8 +486,8 @@ extension Dcdb {
 
         /// 到期时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$periodEndTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var periodEndTime: Date
 
         /// 节点数，2 为一主一从， 3 为一主二从
@@ -953,8 +953,8 @@ extension Dcdb {
 
         /// 创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date
 
         /// 是否默认项目，1 是，0 不是
@@ -1121,8 +1121,8 @@ extension Dcdb {
 
         /// 分片创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date
 
         /// 分片内存大小，单位GB
@@ -1447,8 +1447,8 @@ extension Dcdb {
         /// 创建时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date?
 
         /// 实例备注
@@ -1478,8 +1478,8 @@ extension Dcdb {
         /// 有效期结束时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$periodEndTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var periodEndTime: Date?
 
         /// 源实例 ID，形如：tdsql-ow728lmc。
@@ -1541,14 +1541,14 @@ extension Dcdb {
 
         /// 任务创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date
 
         /// 任务结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// 任务错误信息

--- a/Sources/Teco/Dlc/V20210125/actions/AlterDMSTable.swift
+++ b/Sources/Teco/Dlc/V20210125/actions/AlterDMSTable.swift
@@ -49,20 +49,20 @@ extension Dlc {
 
         /// 数据更新时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$dataUpdateTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var dataUpdateTime: Date?
 
         /// 结构更新时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$structUpdateTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var structUpdateTime: Date?
 
         /// 最后访问时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$lastAccessTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var lastAccessTime: Date?
 
         /// 存储对象

--- a/Sources/Teco/Dlc/V20210125/actions/CreateDMSTable.swift
+++ b/Sources/Teco/Dlc/V20210125/actions/CreateDMSTable.swift
@@ -43,20 +43,20 @@ extension Dlc {
 
         /// 数据更新时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$dataUpdateTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var dataUpdateTime: Date?
 
         /// 结构更新时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$structUpdateTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var structUpdateTime: Date?
 
         /// 最后访问时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$lastAccessTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var lastAccessTime: Date?
 
         /// 存储对象

--- a/Sources/Teco/Dlc/V20210125/actions/DescribeDMSTable.swift
+++ b/Sources/Teco/Dlc/V20210125/actions/DescribeDMSTable.swift
@@ -122,22 +122,22 @@ extension Dlc {
         /// 最后访问时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$lastAccessTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var lastAccessTime: Date?
 
         /// 数据更新时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$dataUpdateTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var dataUpdateTime: Date?
 
         /// 结构更新时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$structUpdateTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var structUpdateTime: Date?
 
         /// 列

--- a/Sources/Teco/Dlc/V20210125/models.swift
+++ b/Sources/Teco/Dlc/V20210125/models.swift
@@ -60,14 +60,14 @@ extension Dlc {
 
         /// 创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createTime: Date?
 
         /// 修改时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$modifiedTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var modifiedTime: Date?
 
         /// 数据源主键
@@ -459,20 +459,20 @@ extension Dlc {
 
         /// 创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createTime: Date?
 
         /// 修改时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$modifiedTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var modifiedTime: Date?
 
         /// 最后访问时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$lastAccessTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var lastAccessTime: Date?
 
         /// 附件属性
@@ -660,22 +660,22 @@ extension Dlc {
         /// 最后访问时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$lastAccessTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var lastAccessTime: Date?
 
         /// 数据更新时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$dataUpdateTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var dataUpdateTime: Date?
 
         /// 结构更新时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$structUpdateTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var structUpdateTime: Date?
 
         /// 列

--- a/Sources/Teco/Dnspod/V20210323/models.swift
+++ b/Sources/Teco/Dnspod/V20210323/models.swift
@@ -674,14 +674,14 @@ extension Dnspod {
 
         /// 域名创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdOn`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createdOn: Date
 
         /// 最后操作时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updatedOn`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var updatedOn: Date
 
         /// 腾讯云账户Uin
@@ -818,14 +818,14 @@ extension Dnspod {
 
         /// 付费套餐开通时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$vipStartAt`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var vipStartAt: Date
 
         /// 付费套餐到期时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$vipEndAt`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var vipEndAt: Date
 
         /// 域名是否开通VIP自动续费，是：YES，否：NO，默认：DEFAULT
@@ -836,14 +836,14 @@ extension Dnspod {
 
         /// 域名添加时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdOn`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createdOn: Date
 
         /// 域名更新时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updatedOn`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var updatedOn: Date
 
         /// 域名所属账号
@@ -986,8 +986,8 @@ extension Dnspod {
 
         /// 域名自动解锁日期
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$lockEnd`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var lockEnd: Date
 
         enum CodingKeys: String, CodingKey {
@@ -1238,8 +1238,8 @@ extension Dnspod {
 
         /// 记录最后更新时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updatedOn`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var updatedOn: Date
 
         /// 域名 ID 。
@@ -1276,8 +1276,8 @@ extension Dnspod {
 
         /// 更新时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updatedOn`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var updatedOn: Date
 
         /// 主机名

--- a/Sources/Teco/Dts/V20180330/models.swift
+++ b/Sources/Teco/Dts/V20180330/models.swift
@@ -169,20 +169,20 @@ extension Dts {
 
         /// 任务创建(提交)时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date
 
         /// 任务开始执行时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 任务执行结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// 任务状态,取值为：1-创建中(Creating),3-校验中(Checking)4-校验通过(CheckPass),5-校验不通过（CheckNotPass）,7-任务运行(Running),8-准备完成（ReadyComplete）,9-任务成功（Success）,10-任务失败（Failed）,11-撤销中（Stopping）,12-完成中（Completing）
@@ -231,8 +231,8 @@ extension Dts {
 
         /// 期望执行时间，当runMode=2时，该字段必填，时间格式：yyyy-mm-dd hh:mm:ss
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$expectTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var expectTime: Date?
 
         /// 数据迁移类型，值包括：1-结构迁移,2-全量迁移,3-全量+增量迁移

--- a/Sources/Teco/Eb/V20210416/actions/GetEventBus.swift
+++ b/Sources/Teco/Eb/V20210416/actions/GetEventBus.swift
@@ -39,8 +39,8 @@ extension Eb {
     public struct GetEventBusResponse: TCResponse {
         /// 更新时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$modTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var modTime: Date
 
         /// 事件集描述
@@ -51,8 +51,8 @@ extension Eb {
 
         /// 创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$addTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var addTime: Date
 
         /// 日志集ID

--- a/Sources/Teco/Eb/V20210416/actions/GetRule.swift
+++ b/Sources/Teco/Eb/V20210416/actions/GetRule.swift
@@ -65,14 +65,14 @@ extension Eb {
 
         /// 创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$addTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var addTime: Date
 
         /// 更新时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$modTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var modTime: Date
 
         /// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。

--- a/Sources/Teco/Eb/V20210416/models.swift
+++ b/Sources/Teco/Eb/V20210416/models.swift
@@ -102,8 +102,8 @@ extension Eb {
 
         /// 更新时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$modTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var modTime: Date
 
         /// 使能开关
@@ -114,8 +114,8 @@ extension Eb {
 
         /// 创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$addTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var addTime: Date
 
         /// 连接器ID
@@ -313,8 +313,8 @@ extension Eb {
     public struct EventBus: TCOutputModel {
         /// 更新时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$modTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var modTime: Date
 
         /// 事件集描述，不限字符类型，200字符描述以内
@@ -322,8 +322,8 @@ extension Eb {
 
         /// 创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$addTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var addTime: Date
 
         /// 事件集名称，只能包含字母、数字、下划线、连字符，以字母开头，以数字或字母结尾，2~60个字符
@@ -560,8 +560,8 @@ extension Eb {
 
         /// 修改时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$modTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var modTime: Date
 
         /// 使能开关
@@ -575,8 +575,8 @@ extension Eb {
 
         /// 创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$addTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var addTime: Date
 
         /// 事件集ID

--- a/Sources/Teco/Ecdn/V20191012/actions/DescribeEcdnDomainLogs.swift
+++ b/Sources/Teco/Ecdn/V20191012/actions/DescribeEcdnDomainLogs.swift
@@ -28,14 +28,14 @@ extension Ecdn {
 
         /// 日志起始时间。如：2019-10-01 00:00:00
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 日志结束时间，只支持最近30天内日志查询。2019-10-02 00:00:00
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// 日志链接列表分页起始地址，默认0。

--- a/Sources/Teco/Ecdn/V20191012/actions/DescribeEcdnDomainStatistics.swift
+++ b/Sources/Teco/Ecdn/V20191012/actions/DescribeEcdnDomainStatistics.swift
@@ -26,15 +26,15 @@ extension Ecdn {
         /// 查询起始时间，如：2019-12-13 00:00:00。
         /// 起止时间不超过90天。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 查询结束时间，如：2019-12-13 23:59:59。
         /// 起止时间不超过90天。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// 统计指标名称:

--- a/Sources/Teco/Ecdn/V20191012/actions/DescribeEcdnStatistics.swift
+++ b/Sources/Teco/Ecdn/V20191012/actions/DescribeEcdnStatistics.swift
@@ -25,14 +25,14 @@ extension Ecdn {
     public struct DescribeEcdnStatisticsRequest: TCRequest {
         /// 查询起始时间，如：2019-12-13 00:00:00
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 查询结束时间，如：2019-12-13 23:59:59
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// 指定查询指标，支持的类型有：

--- a/Sources/Teco/Ecdn/V20191012/actions/DescribePurgeTasks.swift
+++ b/Sources/Teco/Ecdn/V20191012/actions/DescribePurgeTasks.swift
@@ -28,14 +28,14 @@ extension Ecdn {
 
         /// 开始时间，如2018-08-08 00:00:00。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date?
 
         /// 结束时间，如2018-08-08 23:59:59。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date?
 
         /// 提交时返回的任务 Id，查询时 TaskId 和起始时间必须指定一项。

--- a/Sources/Teco/Ecdn/V20191012/models.swift
+++ b/Sources/Teco/Ecdn/V20191012/models.swift
@@ -141,15 +141,15 @@ extension Ecdn {
         /// 证书过期时间。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$expireTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var expireTime: Date?
 
         /// 证书颁发时间。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$deployTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var deployTime: Date?
 
         public init(certificate: String, certName: String? = nil, expireTime: Date? = nil, deployTime: Date? = nil) {
@@ -203,14 +203,14 @@ extension Ecdn {
 
         /// 域名创建时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date
 
         /// 域名更新时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updateTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var updateTime: Date
 
         /// 源站配置详情。
@@ -283,14 +283,14 @@ extension Ecdn {
 
         /// 域名创建时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date
 
         /// 域名更新时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updateTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var updateTime: Date
 
         /// 源站配置。
@@ -408,14 +408,14 @@ extension Ecdn {
     public struct DomainLogs: TCOutputModel {
         /// 日志起始时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 日志结束时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// 日志下载路径。
@@ -665,8 +665,8 @@ extension Ecdn {
 
         /// 节点 IP 添加时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date
 
         enum CodingKeys: String, CodingKey {
@@ -750,8 +750,8 @@ extension Ecdn {
 
         /// 刷新任务提交时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date
 
         enum CodingKeys: String, CodingKey {
@@ -841,15 +841,15 @@ extension Ecdn {
         /// 证书过期时间。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$expireTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var expireTime: Date?
 
         /// 证书颁发时间。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$deployTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var deployTime: Date?
 
         /// 证书备注信息。
@@ -924,8 +924,8 @@ extension Ecdn {
         /// 数据统计时间点，采用向前汇总模式
         /// 以 5 分钟粒度为例，13:35:00 时间点代表的统计数据区间为 13:35:00 至 13:39:59
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$time`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var time: Date
 
         /// 数据值

--- a/Sources/Teco/Ecm/V20190719/models.swift
+++ b/Sources/Teco/Ecm/V20190719/models.swift
@@ -194,8 +194,8 @@ extension Ecm {
         /// 后端服务被绑定的时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$registeredTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var registeredTime: Date?
 
         /// 弹性网卡唯一ID
@@ -483,14 +483,14 @@ extension Ecm {
 
         /// 云硬盘的创建时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date?
 
         /// 云硬盘的到期时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$deadlineTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var deadlineTime: Date
 
         /// 云盘的挂载类型。取值范围：
@@ -556,8 +556,8 @@ extension Ecm {
 
         /// 需要将云盘的到期时间与挂载的子机对齐时，可传入该参数。该参数表示子机当前的到期时间，此时Period如果传入，则表示子机需要续费的时长，云盘会自动按对齐到子机续费后的到期时间续费，示例取值：2018-03-30 20:15:03。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$curInstanceDeadline`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var curInstanceDeadline: Date?
 
         public init(period: UInt64, renewFlag: String? = nil, curInstanceDeadline: Date? = nil) {
@@ -1479,8 +1479,8 @@ extension Ecm {
         /// 创建时间。按照ISO8601标准表示，并且使用UTC时间。格式为：YYYY-MM-DDThh:mm:ssZ。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createdTime: Date?
 
         enum CodingKeys: String, CodingKey {
@@ -1642,15 +1642,15 @@ extension Ecm {
         /// 负载均衡实例的创建时间。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date?
 
         /// 负载均衡实例的上次状态转换时间。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$statusTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var statusTime: Date?
 
         /// 私有网络的 ID。
@@ -3025,8 +3025,8 @@ extension Ecm {
 
         /// 快照的创建时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date?
 
         /// 快照关联的镜像个数。

--- a/Sources/Teco/Essbasic/V20210526/actions/DescribeUsage.swift
+++ b/Sources/Teco/Essbasic/V20210526/actions/DescribeUsage.swift
@@ -28,15 +28,15 @@ extension Essbasic {
 
         /// 开始时间，例如：2021-03-21
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var startDate: Date
 
         /// 结束时间，例如：2021-06-21；
         /// 开始时间到结束时间的区间长度小于等于90天。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var endDate: Date
 
         /// 是否汇总数据，默认不汇总。

--- a/Sources/Teco/Essbasic/V20210526/models.swift
+++ b/Sources/Teco/Essbasic/V20210526/models.swift
@@ -2640,8 +2640,8 @@ extension Essbasic {
         /// 日期，当需要汇总数据时日期为空
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$date`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var date: Date?
 
         /// 消耗数量

--- a/Sources/Teco/Faceid/V20180301/actions/GetWeChatBillDetails.swift
+++ b/Sources/Teco/Faceid/V20180301/actions/GetWeChatBillDetails.swift
@@ -25,8 +25,8 @@ extension Faceid {
     public struct GetWeChatBillDetailsRequest: TCPaginatedRequest {
         /// 拉取的日期（YYYY-MM-DD）。最大可追溯到365天前。当天6点后才能拉取前一天的数据。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$date`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var date: Date
 
         /// 游标。用于分页，取第一页时传0，取后续页面时，传入本接口响应中返回的NextCursor字段的值。

--- a/Sources/Teco/Gaap/V20180529/actions/DescribeListenerStatistics.swift
+++ b/Sources/Teco/Gaap/V20180529/actions/DescribeListenerStatistics.swift
@@ -28,14 +28,14 @@ extension Gaap {
 
         /// 起始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// 统计指标名称列表，支持: 入带宽:InBandwidth, 出带宽:OutBandwidth, 并发:Concurrent, 入包量:InPackets, 出包量:OutPackets。

--- a/Sources/Teco/Gaap/V20180529/actions/DescribeProxyGroupStatistics.swift
+++ b/Sources/Teco/Gaap/V20180529/actions/DescribeProxyGroupStatistics.swift
@@ -28,14 +28,14 @@ extension Gaap {
 
         /// 起始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// 统计指标名称列表，支持: 入带宽:InBandwidth, 出带宽:OutBandwidth, 并发:Concurrent, 入包量:InPackets, 出包量:OutPackets

--- a/Sources/Teco/Gaap/V20180529/actions/DescribeProxyStatistics.swift
+++ b/Sources/Teco/Gaap/V20180529/actions/DescribeProxyStatistics.swift
@@ -28,14 +28,14 @@ extension Gaap {
 
         /// 起始时间(2019-03-25 12:00:00)
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 结束时间(2019-03-25 12:00:00)
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// 统计指标名称列表，支持: 入带宽:InBandwidth, 出带宽:OutBandwidth, 并发:Concurrent, 入包量:InPackets, 出包量:OutPackets, 丢包率:PacketLoss, 延迟:Latency，http请求量：HttpQPS, Https请求量：HttpsQPS

--- a/Sources/Teco/Gme/V20180711/actions/DescribeAppStatistics.swift
+++ b/Sources/Teco/Gme/V20180711/actions/DescribeAppStatistics.swift
@@ -28,14 +28,14 @@ extension Gme {
 
         /// 数据开始时间，东八区时间，格式: 年-月-日，如: 2018-07-13
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var startDate: Date
 
         /// 数据结束时间，东八区时间，格式: 年-月-日，如: 2018-07-13
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var endDate: Date
 
         /// 要查询的服务列表，取值：RealTimeSpeech/VoiceMessage/VoiceFilter/SpeechToText

--- a/Sources/Teco/Gme/V20180711/actions/DescribeApplicationData.swift
+++ b/Sources/Teco/Gme/V20180711/actions/DescribeApplicationData.swift
@@ -28,14 +28,14 @@ extension Gme {
 
         /// 数据开始时间，格式为 年-月-日，如: 2018-07-13
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var startDate: Date
 
         /// 数据结束时间，格式为 年-月-日，如: 2018-07-13
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var endDate: Date
 
         public init(bizId: UInt64, startDate: Date, endDate: Date) {

--- a/Sources/Teco/Gme/V20180711/models.swift
+++ b/Sources/Teco/Gme/V20180711/models.swift
@@ -76,8 +76,8 @@ extension Gme {
 
         /// 统计时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$date`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var date: Date
 
         /// 录音转文本用量统计数据
@@ -702,8 +702,8 @@ extension Gme {
     public struct StatisticsItem: TCOutputModel {
         /// 日期，格式为年-月-日，如2018-07-13
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$statDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var statDate: Date
 
         /// 统计值

--- a/Sources/Teco/Goosefs/V20220519/models.swift
+++ b/Sources/Teco/Goosefs/V20220519/models.swift
@@ -113,8 +113,8 @@ extension Goosefs {
 
         /// 创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createTime: Date
 
         /// GooseFSx文件系统属性
@@ -145,8 +145,8 @@ extension Goosefs {
 
         /// 更新属性时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$modifyTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var modifyTime: Date
 
         enum CodingKeys: String, CodingKey {

--- a/Sources/Teco/Gse/V20191112/actions/DescribeFleetEvents.swift
+++ b/Sources/Teco/Gse/V20191112/actions/DescribeFleetEvents.swift
@@ -37,14 +37,14 @@ extension Gse {
 
         /// 发生事件的开始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var startTime: Date?
 
         /// 发生事件的结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var endTime: Date?
 
         public init(fleetId: String, limit: UInt64? = nil, offset: UInt64? = nil, eventCode: String? = nil, startTime: Date? = nil, endTime: Date? = nil) {

--- a/Sources/Teco/Gse/V20191112/actions/DescribeFleetStatisticDetails.swift
+++ b/Sources/Teco/Gse/V20191112/actions/DescribeFleetStatisticDetails.swift
@@ -28,14 +28,14 @@ extension Gse {
 
         /// 查询开始时间，时间格式：YYYY-MM-DD hh:mm:ss
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$beginTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var beginTime: Date?
 
         /// 查询结束时间，时间格式：YYYY-MM-DD hh:mm:ss
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date?
 
         /// 结果返回最大数量，最小值0，最大值100

--- a/Sources/Teco/Gse/V20191112/actions/DescribeFleetStatisticFlows.swift
+++ b/Sources/Teco/Gse/V20191112/actions/DescribeFleetStatisticFlows.swift
@@ -28,14 +28,14 @@ extension Gse {
 
         /// 查询开始时间，时间格式：YYYY-MM-DD hh:mm:ss
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$beginTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var beginTime: Date?
 
         /// 查询结束时间，时间格式：YYYY-MM-DD hh:mm:ss
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date?
 
         /// 结果返回最大数量，最小值0，最大值100

--- a/Sources/Teco/Gse/V20191112/actions/DescribeFleetStatisticSummary.swift
+++ b/Sources/Teco/Gse/V20191112/actions/DescribeFleetStatisticSummary.swift
@@ -28,14 +28,14 @@ extension Gse {
 
         /// 查询开始时间，时间格式: YYYY-MM-DD hh:mm:ss
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$beginTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var beginTime: Date?
 
         /// 查询结束时间，时间格式: YYYY-MM-DD hh:mm:ss
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date?
 
         public init(fleetId: String? = nil, beginTime: Date? = nil, endTime: Date? = nil) {

--- a/Sources/Teco/Gse/V20191112/models.swift
+++ b/Sources/Teco/Gse/V20191112/models.swift
@@ -81,8 +81,8 @@ extension Gse {
 
         /// 生成包创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createTime: Date
 
         /// 生成包绑定的Fleet个数，最小值为0

--- a/Sources/Teco/Ic/V20190307/models.swift
+++ b/Sources/Teco/Ic/V20190307/models.swift
@@ -121,14 +121,14 @@ extension Ic {
 
         /// 创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createdTime: Date
 
         /// 修改时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$modifiedTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var modifiedTime: Date
 
         /// 套餐周期

--- a/Sources/Teco/Iot/V20180123/actions/GetDataHistory.swift
+++ b/Sources/Teco/Iot/V20180123/actions/GetDataHistory.swift
@@ -31,14 +31,14 @@ extension Iot {
 
         /// 查询开始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 查询结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// 查询数据量

--- a/Sources/Teco/Iot/V20180123/actions/GetDebugLog.swift
+++ b/Sources/Teco/Iot/V20180123/actions/GetDebugLog.swift
@@ -31,14 +31,14 @@ extension Iot {
 
         /// 查询开始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 查询结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// 查询数据量

--- a/Sources/Teco/Iot/V20180123/actions/GetDeviceLog.swift
+++ b/Sources/Teco/Iot/V20180123/actions/GetDeviceLog.swift
@@ -31,14 +31,14 @@ extension Iot {
 
         /// 查询开始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 查询结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// 查询数据量

--- a/Sources/Teco/Iot/V20180123/actions/GetDeviceStatistics.swift
+++ b/Sources/Teco/Iot/V20180123/actions/GetDeviceStatistics.swift
@@ -28,14 +28,14 @@ extension Iot {
 
         /// 开始日期
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var startDate: Date?
 
         /// 结束日期
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var endDate: Date?
 
         public init(products: [String]? = nil, startDate: Date? = nil, endDate: Date? = nil) {

--- a/Sources/Teco/Iot/V20180123/models.swift
+++ b/Sources/Teco/Iot/V20180123/models.swift
@@ -65,14 +65,14 @@ extension Iot {
 
         /// 创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date
 
         /// 更新时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updateTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var updateTime: Date
 
         enum CodingKeys: String, CodingKey {
@@ -105,14 +105,14 @@ extension Iot {
 
         /// 创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date
 
         /// 更新时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updateTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var updateTime: Date
 
         /// 设备信息（json）
@@ -147,14 +147,14 @@ extension Iot {
 
         /// 创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var createTime: Date
 
         /// 修改时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updateTime`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var updateTime: Date
 
         enum CodingKeys: String, CodingKey {
@@ -325,14 +325,14 @@ extension Iot {
 
         /// 更新时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updateTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var updateTime: Date
 
         /// 创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date
 
         /// 设备信息（json）
@@ -361,8 +361,8 @@ extension Iot {
 
         /// 创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date
 
         enum CodingKeys: String, CodingKey {
@@ -421,8 +421,8 @@ extension Iot {
     public struct DeviceStatData: TCOutputModel {
         /// 时间点
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$datetime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var datetime: Date
 
         /// 在线设备数
@@ -453,15 +453,15 @@ extension Iot {
         /// 首次上线时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$firstOnline`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var firstOnline: Date?
 
         /// 最后上线时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$lastOnline`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var lastOnline: Date?
 
         /// 上线次数
@@ -568,14 +568,14 @@ extension Iot {
 
         /// 创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date
 
         /// 更新时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updateTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var updateTime: Date
 
         /// 数据模版
@@ -664,8 +664,8 @@ extension Iot {
 
         /// 创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date
 
         /// 通信方式
@@ -723,14 +723,14 @@ extension Iot {
 
         /// 创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date
 
         /// 更新时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updateTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var updateTime: Date
 
         /// 消息顺序
@@ -857,14 +857,14 @@ extension Iot {
 
         /// 创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date
 
         /// 更新时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updateTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var updateTime: Date
 
         enum CodingKeys: String, CodingKey {

--- a/Sources/Teco/Iotexplorer/V20190423/models.swift
+++ b/Sources/Teco/Iotexplorer/V20190423/models.swift
@@ -642,20 +642,20 @@ extension Iotexplorer {
 
         /// 创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createTime: Date
 
         /// 更新时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updateTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var updateTime: Date
 
         /// 过期时间，公共实例过期时间 0001-01-01T00:00:00Z，公共实例是永久有效
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$expireTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var expireTime: Date
 
         /// 总设备数

--- a/Sources/Teco/Iotvideo/V20211125/actions/DescribeCloudStoragePackageConsumeDetails.swift
+++ b/Sources/Teco/Iotvideo/V20211125/actions/DescribeCloudStoragePackageConsumeDetails.swift
@@ -25,14 +25,14 @@ extension Iotvideo {
     public struct DescribeCloudStoragePackageConsumeDetailsRequest: TCRequest {
         /// 开始日期
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var startDate: Date
 
         /// 结束日期
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var endDate: Date
 
         public init(startDate: Date, endDate: Date) {

--- a/Sources/Teco/Iotvideo/V20211125/actions/DescribeCloudStoragePackageConsumeStats.swift
+++ b/Sources/Teco/Iotvideo/V20211125/actions/DescribeCloudStoragePackageConsumeStats.swift
@@ -25,14 +25,14 @@ extension Iotvideo {
     public struct DescribeCloudStoragePackageConsumeStatsRequest: TCRequest {
         /// 开始日期
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var startDate: Date
 
         /// 结束日期，开始与结束日期间隔不可超过一年
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var endDate: Date
 
         public init(startDate: Date, endDate: Date) {

--- a/Sources/Teco/Lighthouse/V20200324/models.swift
+++ b/Sources/Teco/Lighthouse/V20200324/models.swift
@@ -101,8 +101,8 @@ extension Lighthouse {
         /// 格式为： YYYY-MM-DDThh:mm:ssZ。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createdTime: Date?
 
         /// 镜像名称。
@@ -307,8 +307,8 @@ extension Lighthouse {
         /// 关联时间。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$attachedTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var attachedTime: Date?
 
         /// 备注
@@ -510,24 +510,24 @@ extension Lighthouse {
         /// 格式为： YYYY-MM-DDThh:mm:ssZ。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createdTime: Date?
 
         /// 到期时间。按照 ISO8601 标准表示，并且使用 UTC 时间。
         /// 格式为： YYYY-MM-DDThh:mm:ssZ。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$expiredTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var expiredTime: Date?
 
         /// 隔离时间。按照 ISO8601 标准表示，并且使用 UTC 时间。
         /// 格式为： YYYY-MM-DDThh:mm:ssZ。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$isolatedTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var isolatedTime: Date?
 
         /// 云硬盘的已有备份点数量。
@@ -603,8 +603,8 @@ extension Lighthouse {
         /// 创建时间。按照 ISO8601 标准表示，并且使用 UTC 时间。
         /// 格式为： YYYY-MM-DDThh:mm:ssZ。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createdTime: Date
 
         enum CodingKeys: String, CodingKey {
@@ -781,15 +781,15 @@ extension Lighthouse {
 
         /// 创建时间。按照 ISO8601 标准表示，并且使用 UTC 时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createdTime: Date
 
         /// 结束时间。按照 ISO8601 标准表示，并且使用 UTC 时间。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var endTime: Date?
 
         enum CodingKeys: String, CodingKey {
@@ -831,8 +831,8 @@ extension Lighthouse {
 
         /// 创建时间。按照 ISO8601 标准表示，并且使用 UTC 时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createdTime: Date
 
         enum CodingKeys: String, CodingKey {
@@ -1051,8 +1051,8 @@ extension Lighthouse {
 
         /// 模板创建时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createdTime: Date
 
         enum CodingKeys: String, CodingKey {
@@ -1071,8 +1071,8 @@ extension Lighthouse {
 
         /// 应用模板的时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$applyTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var applyTime: Date
 
         /// 模板规则列表。
@@ -1253,24 +1253,24 @@ extension Lighthouse {
         /// 格式为： YYYY-MM-DDThh:mm:ssZ。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$isolatedTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var isolatedTime: Date?
 
         /// 创建时间。按照 ISO8601 标准表示，并且使用 UTC 时间。
         /// 格式为： YYYY-MM-DDThh:mm:ssZ。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createdTime: Date?
 
         /// 到期时间。按照 ISO8601 标准表示，并且使用 UTC 时间。
         /// 格式为： YYYY-MM-DDThh:mm:ssZ 。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$expiredTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var expiredTime: Date?
 
         /// 操作系统平台类型，如 LINUX_UNIX、WINDOWS。
@@ -1505,8 +1505,8 @@ extension Lighthouse {
         /// 创建时间。按照 ISO8601 标准表示，并且使用 UTC 时间。格式为：YYYY-MM-DDThh:mm:ssZ
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createdTime: Date?
 
         /// 密钥对私钥。
@@ -1793,8 +1793,8 @@ extension Lighthouse {
         /// 快照的创建时间。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createdTime: Date?
 
         enum CodingKeys: String, CodingKey {
@@ -1946,24 +1946,24 @@ extension Lighthouse {
         /// 格式为： YYYY-MM-DDThh:mm:ssZ。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var startTime: Date?
 
         /// 流量包生效周期结束时间。按照 ISO8601 标准表示，并且使用 UTC 时间。
         /// 格式为： YYYY-MM-DDThh:mm:ssZ。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var endTime: Date?
 
         /// 流量包到期时间。按照 ISO8601 标准表示，并且使用 UTC 时间。
         /// 格式为： YYYY-MM-DDThh:mm:ssZ。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$deadline`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var deadline: Date?
 
         /// 流量包状态：

--- a/Sources/Teco/Live/V20180801/models.swift
+++ b/Sources/Teco/Live/V20180801/models.swift
@@ -1034,8 +1034,8 @@ extension Live {
         /// 证书过期时间。
         /// 注：此字段为北京时间（UTC+8时区）。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$certExpireTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var certExpireTime: Date?
 
         /// 证书Id。
@@ -1048,8 +1048,8 @@ extension Live {
         /// 注：此字段为北京时间（UTC+8时区）。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updateTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var updateTime: Date?
 
         enum CodingKeys: String, CodingKey {

--- a/Sources/Teco/Mariadb/V20170312/actions/DescribeDBInstanceDetail.swift
+++ b/Sources/Teco/Mariadb/V20170312/actions/DescribeDBInstanceDetail.swift
@@ -114,8 +114,8 @@ extension Mariadb {
 
         /// 实例创建时间，格式为 2006-01-02 15:04:05
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date
 
         /// 实例是否支持审计
@@ -123,8 +123,8 @@ extension Mariadb {
 
         /// 实例到期时间，格式为 2006-01-02 15:04:05
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$periodEndTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var periodEndTime: Date
 
         /// 机型信息

--- a/Sources/Teco/Mariadb/V20170312/actions/DescribeDBSlowLogs.swift
+++ b/Sources/Teco/Mariadb/V20170312/actions/DescribeDBSlowLogs.swift
@@ -34,14 +34,14 @@ extension Mariadb {
 
         /// 查询的起始时间，形如2016-07-23 14:55:20
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 查询的结束时间，形如2016-08-22 14:55:20
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date?
 
         /// 要查询的具体数据库名称

--- a/Sources/Teco/Mariadb/V20170312/models.swift
+++ b/Sources/Teco/Mariadb/V20170312/models.swift
@@ -94,14 +94,14 @@ extension Mariadb {
 
         /// 创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date
 
         /// 最后更新时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updateTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var updateTime: Date
 
         /// 只读标记，0：否， 1：该账号的sql请求优先选择备机执行，备机不可用时选择主机执行，2：优先选择备机执行，备机不可用时操作失败。
@@ -194,14 +194,14 @@ extension Mariadb {
 
         /// 实例创建时间，格式为 2006-01-02 15:04:05
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date
 
         /// 实例最后更新时间，格式为 2006-01-02 15:04:05
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updateTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var updateTime: Date
 
         /// 自动续费标志：0 否，1 是
@@ -209,8 +209,8 @@ extension Mariadb {
 
         /// 实例到期时间，格式为 2006-01-02 15:04:05
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$periodEndTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var periodEndTime: Date
 
         /// 实例所属账号
@@ -1165,8 +1165,8 @@ extension Mariadb {
         /// 创建时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date?
 
         /// 实例备注
@@ -1196,8 +1196,8 @@ extension Mariadb {
         /// 有效期结束时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$periodEndTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var periodEndTime: Date?
 
         /// 源实例 ID，形如：tdsql-ow728lmc。

--- a/Sources/Teco/Memcached/V20190318/models.swift
+++ b/Sources/Teco/Memcached/V20190318/models.swift
@@ -23,14 +23,14 @@ extension Memcached {
     public struct InstanceListInfo: TCInputModel, TCOutputModel {
         /// 实例修改时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$modTimeStamp`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var modTimeStamp: Date?
 
         /// 实例隔离时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$isolateTimeStamp`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var isolateTimeStamp: Date?
 
         /// 实例是否设置自动续费标识，1：设置自动续费；0：未设置自动续费
@@ -69,8 +69,8 @@ extension Memcached {
 
         /// 实例创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$addTimeStamp`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var addTimeStamp: Date?
 
         /// 区域ID
@@ -87,8 +87,8 @@ extension Memcached {
 
         /// 实例截止时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$deadlineTimeStamp`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var deadlineTimeStamp: Date?
 
         /// vpc网络id 如：vpc-fk33jsf43kgv

--- a/Sources/Teco/Mongodb/V20180408/actions/DescribeSlowLog.swift
+++ b/Sources/Teco/Mongodb/V20180408/actions/DescribeSlowLog.swift
@@ -28,14 +28,14 @@ extension Mongodb {
 
         /// 慢日志起始时间，格式：yyyy-mm-dd hh:mm:ss，如：2019-06-01 10:00:00。查询起止时间间隔不能超过24小时，只允许查询最近7天内慢日志。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 慢日志终止时间，格式：yyyy-mm-dd hh:mm:ss，如：2019-06-02 12:00:00。查询起止时间间隔不能超过24小时，只允许查询最近7天内慢日志。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// 慢日志执行时间阈值，返回执行时间超过该阈值的慢日志，单位为毫秒(ms)，最小为100毫秒。

--- a/Sources/Teco/Mongodb/V20180408/models.swift
+++ b/Sources/Teco/Mongodb/V20180408/models.swift
@@ -90,14 +90,14 @@ extension Mongodb {
 
         /// 实例创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date
 
         /// 实例到期时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$deadLine`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var deadLine: Date
 
         /// 实例版本信息

--- a/Sources/Teco/Mongodb/V20190725/actions/DescribeSlowLogPatterns.swift
+++ b/Sources/Teco/Mongodb/V20190725/actions/DescribeSlowLogPatterns.swift
@@ -28,14 +28,14 @@ extension Mongodb {
 
         /// 慢日志起始时间，格式：yyyy-mm-dd hh:mm:ss，如：2019-06-01 10:00:00。查询起止时间间隔不能超过24小时，只允许查询最近7天内慢日志。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 慢日志终止时间，格式：yyyy-mm-dd hh:mm:ss，如：2019-06-02 12:00:00。查询起止时间间隔不能超过24小时，只允许查询最近7天内慢日志。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// 慢日志执行时间阈值，返回执行时间超过该阈值的慢日志，单位为毫秒(ms)，最小为100毫秒。

--- a/Sources/Teco/Mongodb/V20190725/actions/DescribeSlowLogs.swift
+++ b/Sources/Teco/Mongodb/V20190725/actions/DescribeSlowLogs.swift
@@ -28,14 +28,14 @@ extension Mongodb {
 
         /// 慢日志起始时间，格式：yyyy-mm-dd hh:mm:ss，如：2019-06-01 10:00:00。查询起止时间间隔不能超过24小时，只允许查询最近7天内慢日志。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 慢日志终止时间，格式：yyyy-mm-dd hh:mm:ss，如：2019-06-02 12:00:00。查询起止时间间隔不能超过24小时，只允许查询最近7天内慢日志。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// 慢日志执行时间阈值，返回执行时间超过该阈值的慢日志，单位为毫秒(ms)，最小为100毫秒。

--- a/Sources/Teco/Mongodb/V20190725/models.swift
+++ b/Sources/Teco/Mongodb/V20190725/models.swift
@@ -327,14 +327,14 @@ extension Mongodb {
 
         /// 实例创建时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date
 
         /// 实例到期时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$deadLine`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var deadLine: Date
 
         /// 实例版本信息。

--- a/Sources/Teco/Monitor/V20180724/actions/GetMonitorData.swift
+++ b/Sources/Teco/Monitor/V20180724/actions/GetMonitorData.swift
@@ -37,14 +37,14 @@ extension Monitor {
 
         /// 起始时间，如2018-09-22T19:51:23+08:00
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var startTime: Date?
 
         /// 结束时间，如2018-09-22T20:51:23+08:00，默认为当前时间。 EndTime不能小于StartTime
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var endTime: Date?
 
         public init(namespace: String, metricName: String, instances: [Instance], period: UInt64? = nil, startTime: Date? = nil, endTime: Date? = nil) {
@@ -79,14 +79,14 @@ extension Monitor {
 
         /// 开始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var startTime: Date
 
         /// 结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var endTime: Date
 
         /// 返回信息

--- a/Sources/Teco/Monitor/V20180724/models.swift
+++ b/Sources/Teco/Monitor/V20180724/models.swift
@@ -2218,8 +2218,8 @@ extension Monitor {
 
         /// 创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createAt`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createAt: Date
 
         /// 实例 ID
@@ -2271,14 +2271,14 @@ extension Monitor {
 
         /// 创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdAt`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createdAt: Date
 
         /// 更新时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updatedAt`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var updatedAt: Date
 
         /// 告警渠道的所有生效组织
@@ -2320,8 +2320,8 @@ extension Monitor {
 
         /// 创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdAt`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createdAt: Date
 
         /// 运行状态（1:正在创建；2:运行中；3:异常；4:重启中；5:停机中； 6:已停机； 7: 已删除）
@@ -2421,14 +2421,14 @@ extension Monitor {
 
         /// 创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdAt`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createdAt: Date
 
         /// 更新时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updatedAt`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var updatedAt: Date
 
         /// 默认生效组织，已废弃，请使用 OrganizationIds

--- a/Sources/Teco/Msp/V20180319/actions/RegisterMigrationTask.swift
+++ b/Sources/Teco/Msp/V20180319/actions/RegisterMigrationTask.swift
@@ -34,14 +34,14 @@ extension Msp {
 
         /// 迁移任务创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date
 
         /// 迁移任务更新时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updateTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var updateTime: Date
 
         /// 迁移类别，如数据库迁移中mysql:mysql代表从mysql迁移到mysql，文件迁移中oss:cos代表从阿里云oss迁移到腾讯云cos

--- a/Sources/Teco/Msp/V20180319/models.swift
+++ b/Sources/Teco/Msp/V20180319/models.swift
@@ -119,8 +119,8 @@ extension Msp {
 
         /// 状态更新时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updated`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var updated: Date
 
         /// 迁移目的信息
@@ -150,8 +150,8 @@ extension Msp {
 
         /// 迁移日期
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updateTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var updateTime: Date
 
         enum CodingKeys: String, CodingKey {
@@ -165,14 +165,14 @@ extension Msp {
     public struct TimeObj: TCOutputModel {
         /// 创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date
 
         /// 结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         enum CodingKeys: String, CodingKey {

--- a/Sources/Teco/Omics/V20221128/models.swift
+++ b/Sources/Teco/Omics/V20221128/models.swift
@@ -116,8 +116,8 @@ extension Omics {
         /// 创建时间。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$creationTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var creationTime: Date?
 
         enum CodingKeys: String, CodingKey {
@@ -174,22 +174,22 @@ extension Omics {
         /// 提交时间。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$submitTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var submitTime: Date?
 
         /// 开始时间。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var startTime: Date?
 
         /// 结束时间。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var endTime: Date?
 
         enum CodingKeys: String, CodingKey {
@@ -317,14 +317,14 @@ extension Omics {
 
         /// 创建时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createTime: Date?
 
         /// 更新时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updateTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var updateTime: Date?
 
         enum CodingKeys: String, CodingKey {
@@ -405,14 +405,14 @@ extension Omics {
 
         /// 创建时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createTime: Date?
 
         /// 更新时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updateTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var updateTime: Date?
 
         enum CodingKeys: String, CodingKey {
@@ -484,22 +484,22 @@ extension Omics {
         /// 开始时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var startTime: Date?
 
         /// 提交时间。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$submitTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var submitTime: Date?
 
         /// 结束时间。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var endTime: Date?
 
         /// 命令行。

--- a/Sources/Teco/Organization/V20181225/actions/GetOrganizationMember.swift
+++ b/Sources/Teco/Organization/V20181225/actions/GetOrganizationMember.swift
@@ -48,8 +48,8 @@ extension Organization {
 
         /// 加入时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$joinTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var joinTime: Date
 
         /// 组织单元ID

--- a/Sources/Teco/Organization/V20181225/models.swift
+++ b/Sources/Teco/Organization/V20181225/models.swift
@@ -50,14 +50,14 @@ extension Organization {
 
         /// 邀请时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$inviteTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var inviteTime: Date
 
         /// 过期时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$expireTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var expireTime: Date
 
         enum CodingKeys: String, CodingKey {
@@ -88,8 +88,8 @@ extension Organization {
 
         /// 加入时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$joinTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var joinTime: Date
 
         enum CodingKeys: String, CodingKey {

--- a/Sources/Teco/Partners/V20180321/actions/DescribeAgentDealsByCache.swift
+++ b/Sources/Teco/Partners/V20180321/actions/DescribeAgentDealsByCache.swift
@@ -31,14 +31,14 @@ extension Partners {
 
         /// 下单时间范围起始点【请保持时间范围最大90天】
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$creatTimeRangeStart`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var creatTimeRangeStart: Date?
 
         /// 下单时间范围终止点【请保持时间范围最大90天】
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$creatTimeRangeEnd`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var creatTimeRangeEnd: Date?
 
         /// 0:下单时间降序；其他：下单时间升序

--- a/Sources/Teco/Partners/V20180321/actions/DescribeAgentPayDealsV2.swift
+++ b/Sources/Teco/Partners/V20180321/actions/DescribeAgentPayDealsV2.swift
@@ -31,14 +31,14 @@ extension Partners {
 
         /// 下单时间范围起始点(不传时会默认查15天内订单，传值时需要传15天内的起始时间)
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$creatTimeRangeStart`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var creatTimeRangeStart: Date?
 
         /// 下单时间范围终止点
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$creatTimeRangeEnd`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var creatTimeRangeEnd: Date?
 
         /// 0:下单时间降序；其他：下单时间升序

--- a/Sources/Teco/Partners/V20180321/actions/DescribeAgentSelfPayDealsV2.swift
+++ b/Sources/Teco/Partners/V20180321/actions/DescribeAgentSelfPayDealsV2.swift
@@ -34,14 +34,14 @@ extension Partners {
 
         /// 下单时间范围起始点(不传时会默认查15天内订单，传值时需要传15天内的起始时间)
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$creatTimeRangeStart`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var creatTimeRangeStart: Date?
 
         /// 下单时间范围终止点
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$creatTimeRangeEnd`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var creatTimeRangeEnd: Date?
 
         /// 0:下单时间降序；其他：下单时间升序

--- a/Sources/Teco/Partners/V20180321/actions/DescribeUnbindClientList.swift
+++ b/Sources/Teco/Partners/V20180321/actions/DescribeUnbindClientList.swift
@@ -37,14 +37,14 @@ extension Partners {
 
         /// 解绑申请时间范围起始点
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$applyTimeStart`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var applyTimeStart: Date?
 
         /// 解绑申请时间范围终止点
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$applyTimeEnd`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var applyTimeEnd: Date?
 
         /// 对申请时间的升序降序，值：asc，desc

--- a/Sources/Teco/Partners/V20180321/models.swift
+++ b/Sources/Teco/Partners/V20180321/models.swift
@@ -108,8 +108,8 @@ extension Partners {
 
         /// 支付时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$payTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var payTime: Date
 
         /// 云产品名称
@@ -374,8 +374,8 @@ extension Partners {
 
         /// 业务员创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date
 
         enum CodingKeys: String, CodingKey {
@@ -504,15 +504,15 @@ extension Partners {
         /// 申请时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$applyTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var applyTime: Date?
 
         /// 解绑/撤销时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$actionTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var actionTime: Date?
 
         enum CodingKeys: String, CodingKey {

--- a/Sources/Teco/Postgres/V20170312/actions/DescribeDBBackups.swift
+++ b/Sources/Teco/Postgres/V20170312/actions/DescribeDBBackups.swift
@@ -31,14 +31,14 @@ extension Postgres {
 
         /// 查询开始时间，形如2018-06-10 17:06:38，起始时间不得小于7天以前
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 查询结束时间，形如2018-06-10 17:06:38
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// 备份列表分页返回，每页返回数量，默认为 20，最小为1，最大值为 100。（当该参数不传或者传0时按默认值处理）

--- a/Sources/Teco/Postgres/V20170312/actions/DescribeDBErrlogs.swift
+++ b/Sources/Teco/Postgres/V20170312/actions/DescribeDBErrlogs.swift
@@ -28,14 +28,14 @@ extension Postgres {
 
         /// 查询起始时间，形如2018-01-01 00:00:00。日志保留时间默认为7天，起始时间不能超出保留时间范围。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 查询结束时间，形如2018-01-01 00:00:00。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// 数据库名字。

--- a/Sources/Teco/Postgres/V20170312/actions/DescribeDBSlowlogs.swift
+++ b/Sources/Teco/Postgres/V20170312/actions/DescribeDBSlowlogs.swift
@@ -28,14 +28,14 @@ extension Postgres {
 
         /// 查询起始时间，形如2018-06-10 17:06:38，起始时间不得小于7天以前
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 查询结束时间，形如2018-06-10 17:06:38
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// 数据库名字

--- a/Sources/Teco/Postgres/V20170312/actions/DescribeDBXlogs.swift
+++ b/Sources/Teco/Postgres/V20170312/actions/DescribeDBXlogs.swift
@@ -28,14 +28,14 @@ extension Postgres {
 
         /// 查询开始时间，形如2018-06-10 17:06:38，起始时间不得小于7天以前
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 查询结束时间，形如2018-06-10 17:06:38
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// 分页返回，表示返回第几页的条目。从第0页开始计数。

--- a/Sources/Teco/Postgres/V20170312/models.swift
+++ b/Sources/Teco/Postgres/V20170312/models.swift
@@ -35,14 +35,14 @@ extension Postgres {
 
         /// 帐号创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date
 
         /// 帐号最后一次更新时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updateTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var updateTime: Date
 
         enum CodingKeys: String, CodingKey {
@@ -405,26 +405,26 @@ extension Postgres {
 
         /// 实例创建时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date
 
         /// 实例执行最后一次更新的时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updateTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var updateTime: Date
 
         /// 实例到期时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$expireTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var expireTime: Date
 
         /// 实例隔离时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$isolatedTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var isolatedTime: Date
 
         /// 计费模式：
@@ -1759,14 +1759,14 @@ extension Postgres {
 
         /// 文件生成的开始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 文件生成的结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// 内网下载地址

--- a/Sources/Teco/Privatedns/V20201028/models.swift
+++ b/Sources/Teco/Privatedns/V20201028/models.swift
@@ -117,8 +117,8 @@ extension Privatedns {
     public struct AuditLogInfo: TCOutputModel {
         /// 时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$date`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var date: Date
 
         /// 操作人uin
@@ -138,8 +138,8 @@ extension Privatedns {
     public struct DatePoint: TCOutputModel {
         /// 时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$date`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var date: Date
 
         /// 值
@@ -248,14 +248,14 @@ extension Privatedns {
 
         /// 创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdOn`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createdOn: Date
 
         /// 修改时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updatedOn`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var updatedOn: Date
 
         /// 记录数
@@ -359,14 +359,14 @@ extension Privatedns {
 
         /// 记录创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdOn`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createdOn: Date
 
         /// 记录更新时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updatedOn`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var updatedOn: Date
 
         /// 附加信息

--- a/Sources/Teco/Pts/V20210728/actions/CreateCronJob.swift
+++ b/Sources/Teco/Pts/V20210728/actions/CreateCronJob.swift
@@ -46,8 +46,8 @@ extension Pts {
 
         /// 结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var endTime: Date?
 
         /// Notice ID

--- a/Sources/Teco/Pts/V20210728/actions/DescribeJobs.swift
+++ b/Sources/Teco/Pts/V20210728/actions/DescribeJobs.swift
@@ -46,14 +46,14 @@ extension Pts {
 
         /// 任务开始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var startTime: Date?
 
         /// 任务结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var endTime: Date?
 
         /// 调试任务标记

--- a/Sources/Teco/Pts/V20210728/actions/DescribeNormalLogs.swift
+++ b/Sources/Teco/Pts/V20210728/actions/DescribeNormalLogs.swift
@@ -37,14 +37,14 @@ extension Pts {
 
         /// 日志开始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$from`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var from: Date?
 
         /// 日志结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$to`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var to: Date?
 
         /// 日志级别，可取debug/info/error

--- a/Sources/Teco/Pts/V20210728/actions/DescribeSampleLogs.swift
+++ b/Sources/Teco/Pts/V20210728/actions/DescribeSampleLogs.swift
@@ -37,14 +37,14 @@ extension Pts {
 
         /// 日志开始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$from`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var from: Date?
 
         /// 日志结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$to`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var to: Date?
 
         /// 日志级别debug,info,error

--- a/Sources/Teco/Pts/V20210728/actions/UpdateCronJob.swift
+++ b/Sources/Teco/Pts/V20210728/actions/UpdateCronJob.swift
@@ -52,8 +52,8 @@ extension Pts {
 
         /// 结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var endTime: Date?
 
         /// Notice ID

--- a/Sources/Teco/Pts/V20210728/models.swift
+++ b/Sources/Teco/Pts/V20210728/models.swift
@@ -378,8 +378,8 @@ extension Pts {
         /// 结束时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var endTime: Date?
 
         /// 中止原因
@@ -397,15 +397,15 @@ extension Pts {
         /// 创建时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdAt`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createdAt: Date?
 
         /// 更新时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updatedAt`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var updatedAt: Date?
 
         /// 执行频率类型
@@ -606,8 +606,8 @@ extension Pts {
 
         /// 更新时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updatedAt`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var updatedAt: Date
 
         /// 文件行数
@@ -645,8 +645,8 @@ extension Pts {
         /// 创建时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdAt`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createdAt: Date?
 
         /// 项目 ID
@@ -710,8 +710,8 @@ extension Pts {
         /// 更新时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updatedAt`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var updatedAt: Date?
 
         /// 文件 ID
@@ -885,15 +885,15 @@ extension Pts {
         /// 任务的开始时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var startTime: Date?
 
         /// 任务的结束时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var endTime: Date?
 
         /// 任务的最大VU数
@@ -1003,8 +1003,8 @@ extension Pts {
         /// 任务的创建时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdAt`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createdAt: Date?
 
         /// 项目ID
@@ -1368,14 +1368,14 @@ extension Pts {
 
         /// 创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdAt`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createdAt: Date?
 
         /// 修改时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updatedAt`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var updatedAt: Date?
 
         /// App ID
@@ -1418,8 +1418,8 @@ extension Pts {
         /// 更新时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updatedAt`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var updatedAt: Date?
 
         /// 文件 ID
@@ -1484,14 +1484,14 @@ extension Pts {
 
         /// 创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdAt`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createdAt: Date?
 
         /// 更新时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updatedAt`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var updatedAt: Date?
 
         public init(region: String, regionId: Int64, area: String? = nil, regionName: String? = nil, regionState: Int64? = nil, regionShortName: String? = nil, createdAt: Date? = nil, updatedAt: Date? = nil) {
@@ -1969,8 +1969,8 @@ extension Pts {
         /// 更新时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updatedAt`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var updatedAt: Date?
 
         /// base64编码后的文件内容
@@ -2103,8 +2103,8 @@ extension Pts {
         /// 更新时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updatedAt`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var updatedAt: Date?
 
         /// 文件字节数

--- a/Sources/Teco/Rum/V20210622/models.swift
+++ b/Sources/Teco/Rum/V20210622/models.swift
@@ -265,8 +265,8 @@ extension Rum {
 
         /// 创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date
 
         /// 项目仓库地址

--- a/Sources/Teco/Scf/V20180416/actions/GetAlias.swift
+++ b/Sources/Teco/Scf/V20180416/actions/GetAlias.swift
@@ -63,15 +63,15 @@ extension Scf {
         /// 创建时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$addTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var addTime: Date?
 
         /// 更新时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$modTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var modTime: Date?
 
         /// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。

--- a/Sources/Teco/Scf/V20180416/actions/GetFunction.swift
+++ b/Sources/Teco/Scf/V20180416/actions/GetFunction.swift
@@ -56,8 +56,8 @@ extension Scf {
     public struct GetFunctionResponse: TCResponse {
         /// 函数的最后修改时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$modTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var modTime: Date
 
         /// 函数的代码
@@ -156,8 +156,8 @@ extension Scf {
 
         /// 函数创建回见
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$addTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var addTime: Date
 
         /// 公网访问配置

--- a/Sources/Teco/Scf/V20180416/actions/GetFunctionLogs.swift
+++ b/Sources/Teco/Scf/V20180416/actions/GetFunctionLogs.swift
@@ -54,14 +54,14 @@ extension Scf {
 
         /// 查询的具体日期，例如：2017-05-16 20:00:00，只能与endtime相差一天之内
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date?
 
         /// 查询的具体日期，例如：2017-05-16 20:59:59，只能与startTime相差一天之内
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date?
 
         /// 该字段已下线

--- a/Sources/Teco/Scf/V20180416/models.swift
+++ b/Sources/Teco/Scf/V20180416/models.swift
@@ -57,15 +57,15 @@ extension Scf {
         /// 创建时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$addTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var addTime: Date?
 
         /// 更新时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$modTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var modTime: Date?
 
         public init(functionVersion: String, name: String, routingConfig: RoutingConfig, description: String? = nil, addTime: Date? = nil, modTime: Date? = nil) {
@@ -560,15 +560,15 @@ extension Scf {
         /// 创建时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$addTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var addTime: Date?
 
         /// 更新时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$modTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var modTime: Date?
 
         /// 版本状态
@@ -857,14 +857,14 @@ extension Scf {
     public struct Namespace: TCOutputModel {
         /// 命名空间创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$modTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var modTime: Date
 
         /// 命名空间修改时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$addTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var addTime: Date
 
         /// 命名空间描述
@@ -1269,8 +1269,8 @@ extension Scf {
     public struct Trigger: TCOutputModel {
         /// 触发器最后修改时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$modTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var modTime: Date
 
         /// 触发器类型
@@ -1284,8 +1284,8 @@ extension Scf {
 
         /// 触发器创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$addTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var addTime: Date
 
         /// 使能开关
@@ -1446,14 +1446,14 @@ extension Scf {
 
         /// 触发器创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$addTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var addTime: Date
 
         /// 触发器最后修改时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$modTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var modTime: Date
 
         /// 触发器最小资源ID

--- a/Sources/Teco/Ses/V20201002/actions/GetSendEmailStatus.swift
+++ b/Sources/Teco/Ses/V20201002/actions/GetSendEmailStatus.swift
@@ -25,8 +25,8 @@ extension Ses {
     public struct GetSendEmailStatusRequest: TCPaginatedRequest {
         /// 发送的日期，必填。仅支持查询某个日期，不支持范围查询。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$requestDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var requestDate: Date
 
         /// 偏移量。默认为0

--- a/Sources/Teco/Ses/V20201002/actions/GetStatisticsReport.swift
+++ b/Sources/Teco/Ses/V20201002/actions/GetStatisticsReport.swift
@@ -25,14 +25,14 @@ extension Ses {
     public struct GetStatisticsReportRequest: TCRequest {
         /// 开始日期
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var startDate: Date
 
         /// 结束日期
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var endDate: Date
 
         /// 发信域名

--- a/Sources/Teco/Ses/V20201002/actions/ListBlackEmailAddress.swift
+++ b/Sources/Teco/Ses/V20201002/actions/ListBlackEmailAddress.swift
@@ -25,14 +25,14 @@ extension Ses {
     public struct ListBlackEmailAddressRequest: TCPaginatedRequest {
         /// 开始日期，格式为YYYY-MM-DD
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var startDate: Date
 
         /// 结束日期，格式为YYYY-MM-DD
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var endDate: Date
 
         /// 规范，配合Offset使用

--- a/Sources/Teco/Ses/V20201002/models.swift
+++ b/Sources/Teco/Ses/V20201002/models.swift
@@ -42,8 +42,8 @@ extension Ses {
     public struct BlackEmailAddress: TCOutputModel {
         /// 邮箱被拉黑时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$bounceTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var bounceTime: Date
 
         /// 被拉黑的邮箱地址
@@ -487,8 +487,8 @@ extension Ses {
         /// 日期
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$sendDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var sendDate: Date?
 
         /// 邮件请求数量

--- a/Sources/Teco/Smh/V20210712/models.swift
+++ b/Sources/Teco/Smh/V20210712/models.swift
@@ -30,15 +30,15 @@ extension Smh {
 
         /// 生效时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$effectiveTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var effectiveTime: Date
 
         /// 过期时间。如果为按量计费或永久有效实例，该属性为 null。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$expireTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var expireTime: Date?
 
         /// 用户数量。如果为按量计费或不限制用户数量实例，该属性为 null。
@@ -96,8 +96,8 @@ extension Smh {
 
         /// 媒体库创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$creationTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var creationTime: Date
 
         /// 媒体库配置项
@@ -270,15 +270,15 @@ extension Smh {
 
         /// 生效时间，即流量资源包的订购时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$effectiveTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var effectiveTime: Date
 
         /// 过期时间，即所抵扣的实例的过期时间。如果流量资源包所抵扣的实例为按量计费或永久有效实例，该属性为 null。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$expireTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var expireTime: Date?
 
         enum CodingKeys: String, CodingKey {

--- a/Sources/Teco/Sqlserver/V20180328/actions/DescribeBackupByFlowId.swift
+++ b/Sources/Teco/Sqlserver/V20180328/actions/DescribeBackupByFlowId.swift
@@ -53,14 +53,14 @@ extension Sqlserver {
 
         /// 备份开始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 备份结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// 文件大小，单位 KB，对于单库备份文件只返回第一条记录的文件大小；单库备份文件需要通过DescribeBackupFiles接口获取全部记录的文件大小

--- a/Sources/Teco/Sqlserver/V20180328/actions/DescribeBackups.swift
+++ b/Sources/Teco/Sqlserver/V20180328/actions/DescribeBackups.swift
@@ -25,14 +25,14 @@ extension Sqlserver {
     public struct DescribeBackupsRequest: TCPaginatedRequest {
         /// 开始时间(yyyy-MM-dd HH:mm:ss)
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 结束时间(yyyy-MM-dd HH:mm:ss)
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// 实例ID，形如mssql-njj2mtpl

--- a/Sources/Teco/Sqlserver/V20180328/actions/DescribeMigrationDetail.swift
+++ b/Sources/Teco/Sqlserver/V20180328/actions/DescribeMigrationDetail.swift
@@ -54,20 +54,20 @@ extension Sqlserver {
 
         /// 迁移任务的创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date
 
         /// 迁移任务的开始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 迁移任务的结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// 迁移任务的状态（1:初始化,4:迁移中,5.迁移失败,6.迁移成功）

--- a/Sources/Teco/Sqlserver/V20180328/actions/DescribeSlowlogs.swift
+++ b/Sources/Teco/Sqlserver/V20180328/actions/DescribeSlowlogs.swift
@@ -28,14 +28,14 @@ extension Sqlserver {
 
         /// 开始时间(yyyy-MM-dd HH:mm:ss)
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 结束时间(yyyy-MM-dd HH:mm:ss)
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// 分页返回，每页返回的数目，取值为1-100，默认值为20

--- a/Sources/Teco/Sqlserver/V20180328/actions/RollbackInstance.swift
+++ b/Sources/Teco/Sqlserver/V20180328/actions/RollbackInstance.swift
@@ -31,8 +31,8 @@ extension Sqlserver {
 
         /// 回档目标时间点
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$time`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var time: Date
 
         /// 需要回档的数据库

--- a/Sources/Teco/Sqlserver/V20180328/models.swift
+++ b/Sources/Teco/Sqlserver/V20180328/models.swift
@@ -73,8 +73,8 @@ extension Sqlserver {
 
         /// 账户创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date
 
         /// 账户状态，1-创建中，2-正常，3-修改中，4-密码重置中，-1-删除中
@@ -82,14 +82,14 @@ extension Sqlserver {
 
         /// 账户更新时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updateTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var updateTime: Date
 
         /// 密码更新时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$passTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var passTime: Date
 
         /// 账户内部状态，正常为enable
@@ -222,14 +222,14 @@ extension Sqlserver {
 
         /// 备份开始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 备份结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// 内网下载地址，对于单库备份文件不返回此值；单库备份文件通过DescribeBackupFiles接口获取下载地址
@@ -480,8 +480,8 @@ extension Sqlserver {
 
         /// 数据库创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date
 
         /// 数据库状态。1--创建中， 2--运行中， 3--修改中，-1--删除中
@@ -559,32 +559,32 @@ extension Sqlserver {
 
         /// 实例创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date
 
         /// 实例更新时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updateTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var updateTime: Date
 
         /// 实例计费开始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 实例计费结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// 实例隔离时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$isolateTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var isolateTime: Date
 
         /// 实例内存大小，单位G
@@ -992,14 +992,14 @@ extension Sqlserver {
 
         /// 可回档开始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 可回档结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         enum CodingKeys: String, CodingKey {
@@ -1355,20 +1355,20 @@ extension Sqlserver {
 
         /// 迁移任务的创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date
 
         /// 迁移任务的开始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 迁移任务的结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// 迁移任务的状态（1:初始化,4:迁移中,5.迁移失败,6.迁移成功,7已中止,8已删除,9中止中,10完成中,11中止失败,12完成失败）
@@ -2015,14 +2015,14 @@ extension Sqlserver {
 
         /// 文件生成的开始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 文件生成的结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// 文件大小（KB）

--- a/Sources/Teco/Ssa/V20180608/actions/DescribeSafetyEventList.swift
+++ b/Sources/Teco/Ssa/V20180608/actions/DescribeSafetyEventList.swift
@@ -40,14 +40,14 @@ extension Ssa {
 
         /// 开始查询时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date?
 
         /// 结束查询时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date?
 
         /// 是否过滤响应时间

--- a/Sources/Teco/Ssa/V20180608/models.swift
+++ b/Sources/Teco/Ssa/V20180608/models.swift
@@ -800,8 +800,8 @@ extension Ssa {
 
         /// 更新时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updatetime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var updatetime: Date
 
         /// 标签
@@ -965,8 +965,8 @@ extension Ssa {
         /// 最近一次检测时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$lastCheckTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var lastCheckTime: Date?
 
         /// 资产组类型
@@ -1285,8 +1285,8 @@ extension Ssa {
         /// 最近更新时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$time`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var time: Date?
 
         /// 资产标签
@@ -1349,8 +1349,8 @@ extension Ssa {
         /// 最近一次检查时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$lastCheckTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var lastCheckTime: Date?
 
         /// 初始未检测状态0, 已通过为1，未通过为2
@@ -1420,8 +1420,8 @@ extension Ssa {
         /// 最近一次检查时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$lastCheckTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var lastCheckTime: Date?
 
         /// 初始未检测状态0, 已通过为1，未通过为2
@@ -1514,8 +1514,8 @@ extension Ssa {
         /// 事件发生时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$time`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var time: Date?
 
         /// 目的端口
@@ -1867,8 +1867,8 @@ extension Ssa {
     public struct ListDataSaEventPub: TCOutputModel {
         /// 时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$time`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var time: Date
 
         /// 安全事件1级分类

--- a/Sources/Teco/Ssl/V20191205/actions/DescribeCertificateDetail.swift
+++ b/Sources/Teco/Ssl/V20191205/actions/DescribeCertificateDetail.swift
@@ -88,15 +88,15 @@ extension Ssl {
         /// 证书生效时间。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$certBeginTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var certBeginTime: Date?
 
         /// 证书失效时间。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$certEndTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var certEndTime: Date?
 
         /// 证书有效期：单位（月）。
@@ -106,8 +106,8 @@ extension Ssl {
         /// 申请时间。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$insertTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var insertTime: Date?
 
         /// 订单 ID。

--- a/Sources/Teco/Ssl/V20191205/actions/DescribeCertificateOperateLogs.swift
+++ b/Sources/Teco/Ssl/V20191205/actions/DescribeCertificateOperateLogs.swift
@@ -31,14 +31,14 @@ extension Ssl {
 
         /// 开始时间，默认15天前。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date?
 
         /// 结束时间，默认现在时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date?
 
         public init(offset: UInt64? = nil, limit: UInt64? = nil, startTime: Date? = nil, endTime: Date? = nil) {

--- a/Sources/Teco/Ssl/V20191205/models.swift
+++ b/Sources/Teco/Ssl/V20191205/models.swift
@@ -1077,8 +1077,8 @@ extension Ssl {
 
         /// 操作时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdOn`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createdOn: Date
 
         enum CodingKeys: String, CodingKey {

--- a/Sources/Teco/Tat/V20201028/models.swift
+++ b/Sources/Teco/Tat/V20201028/models.swift
@@ -29,8 +29,8 @@ extension Tat {
 
         /// 上次心跳时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$lastHeartbeatTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var lastHeartbeatTime: Date
 
         /// Agent状态，取值范围：
@@ -81,14 +81,14 @@ extension Tat {
 
         /// 命令创建时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createdTime: Date
 
         /// 命令更新时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updatedTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var updatedTime: Date
 
         /// 是否启用自定义参数功能。
@@ -257,26 +257,26 @@ extension Tat {
 
         /// 执行活动开始时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var startTime: Date
 
         /// 执行活动结束时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var endTime: Date
 
         /// 执行活动创建时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createdTime: Date
 
         /// 执行活动更新时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updatedTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var updatedTime: Date
 
         /// 自定义参数取值。
@@ -372,27 +372,27 @@ extension Tat {
         /// 执行任务开始时间。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var startTime: Date?
 
         /// 执行任务结束时间。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var endTime: Date?
 
         /// 创建时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createdTime: Date
 
         /// 更新时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updatedTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var updatedTime: Date
 
         /// 执行任务所执行的命令详情。
@@ -484,14 +484,14 @@ extension Tat {
 
         /// 创建时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createdTime: Date
 
         /// 修改时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updatedTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var updatedTime: Date
 
         enum CodingKeys: String, CodingKey {
@@ -516,8 +516,8 @@ extension Tat {
 
         /// 执行时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$invokeTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var invokeTime: Date
 
         /// 执行原因。
@@ -579,8 +579,8 @@ extension Tat {
         /// 注意：此字段可能返回 null，表示取不到有效值。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$expiredTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var expiredTime: Date?
 
         /// 该注册码限制tat_agent只能从IpAddressRange所描述公网出口进行注册。
@@ -600,8 +600,8 @@ extension Tat {
         /// 注意：此字段可能返回 null，表示取不到有效值。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createdTime: Date?
 
         /// 注册码最近一次更新时间，按照 ISO8601 标准表示，并且使用 UTC 时间。
@@ -609,8 +609,8 @@ extension Tat {
         /// 注意：此字段可能返回 null，表示取不到有效值。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updatedTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var updatedTime: Date?
 
         enum CodingKeys: String, CodingKey {
@@ -668,15 +668,15 @@ extension Tat {
         /// 创建时间。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createdTime: Date?
 
         /// 上次更新时间。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updatedTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var updatedTime: Date?
 
         enum CodingKeys: String, CodingKey {
@@ -707,8 +707,8 @@ extension Tat {
 
         /// 执行器下次执行时间。Policy 为 ONCE 时，需要指定此字段。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$invokeTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var invokeTime: Date?
 
         public init(policy: String, recurrence: String? = nil, invokeTime: Date? = nil) {
@@ -754,15 +754,15 @@ extension Tat {
         /// 命令执行开始时间。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$execStartTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var execStartTime: Date?
 
         /// 命令执行结束时间。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$execEndTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var execEndTime: Date?
 
         /// 命令最终输出被截断的字节数。

--- a/Sources/Teco/Tbm/V20180129/actions/DescribeBrandCommentCount.swift
+++ b/Sources/Teco/Tbm/V20180129/actions/DescribeBrandCommentCount.swift
@@ -28,14 +28,14 @@ extension Tbm {
 
         /// 查询开始日期
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var startDate: Date
 
         /// 查询结束日期
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var endDate: Date
 
         public init(brandId: String, startDate: Date, endDate: Date) {

--- a/Sources/Teco/Tbm/V20180129/actions/DescribeBrandExposure.swift
+++ b/Sources/Teco/Tbm/V20180129/actions/DescribeBrandExposure.swift
@@ -28,14 +28,14 @@ extension Tbm {
 
         /// 查询开始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var startDate: Date
 
         /// 查询结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var endDate: Date
 
         public init(brandId: String, startDate: Date, endDate: Date) {

--- a/Sources/Teco/Tbm/V20180129/actions/DescribeBrandMediaReport.swift
+++ b/Sources/Teco/Tbm/V20180129/actions/DescribeBrandMediaReport.swift
@@ -28,14 +28,14 @@ extension Tbm {
 
         /// 查询开始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var startDate: Date
 
         /// 查询结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var endDate: Date
 
         public init(brandId: String, startDate: Date, endDate: Date) {

--- a/Sources/Teco/Tbm/V20180129/actions/DescribeBrandNegComments.swift
+++ b/Sources/Teco/Tbm/V20180129/actions/DescribeBrandNegComments.swift
@@ -28,14 +28,14 @@ extension Tbm {
 
         /// 查询开始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var startDate: Date
 
         /// 查询结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var endDate: Date
 
         /// 查询条数上限，默认20

--- a/Sources/Teco/Tbm/V20180129/actions/DescribeBrandPosComments.swift
+++ b/Sources/Teco/Tbm/V20180129/actions/DescribeBrandPosComments.swift
@@ -28,14 +28,14 @@ extension Tbm {
 
         /// 查询开始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var startDate: Date
 
         /// 查询结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var endDate: Date
 
         /// 查询条数上限，默认20

--- a/Sources/Teco/Tbm/V20180129/actions/DescribeBrandSocialOpinion.swift
+++ b/Sources/Teco/Tbm/V20180129/actions/DescribeBrandSocialOpinion.swift
@@ -28,14 +28,14 @@ extension Tbm {
 
         /// 检索开始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var startDate: Date
 
         /// 检索结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var endDate: Date
 
         /// 查询偏移，默认从0开始

--- a/Sources/Teco/Tbm/V20180129/actions/DescribeBrandSocialReport.swift
+++ b/Sources/Teco/Tbm/V20180129/actions/DescribeBrandSocialReport.swift
@@ -28,14 +28,14 @@ extension Tbm {
 
         /// 查询开始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var startDate: Date
 
         /// 查询结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var endDate: Date
 
         public init(brandId: String, startDate: Date, endDate: Date) {

--- a/Sources/Teco/Tbm/V20180129/actions/DescribeIndustryNews.swift
+++ b/Sources/Teco/Tbm/V20180129/actions/DescribeIndustryNews.swift
@@ -28,14 +28,14 @@ extension Tbm {
 
         /// 查询开始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var startDate: Date
 
         /// 查询结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var endDate: Date
 
         /// 是否显示列表，若为 true，则返回文章列表

--- a/Sources/Teco/Tbm/V20180129/models.swift
+++ b/Sources/Teco/Tbm/V20180129/models.swift
@@ -56,8 +56,8 @@ extension Tbm {
 
         /// 文章发表日期
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$pubTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var pubTime: Date
 
         /// 文章标识
@@ -92,8 +92,8 @@ extension Tbm {
     public struct Comment: TCOutputModel {
         /// 评论的日期
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$date`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var date: Date
 
         /// 差评的个数
@@ -116,8 +116,8 @@ extension Tbm {
 
         /// 评论的时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$date`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var date: Date
 
         enum CodingKeys: String, CodingKey {
@@ -130,8 +130,8 @@ extension Tbm {
     public struct DateCount: TCOutputModel {
         /// 统计日期
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$date`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var date: Date
 
         /// 统计值
@@ -174,8 +174,8 @@ extension Tbm {
 
         /// 报道发表时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$pubTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var pubTime: Date
 
         /// 报道来源

--- a/Sources/Teco/Tcaplusdb/V20190823/actions/ModifyClusterPassword.swift
+++ b/Sources/Teco/Tcaplusdb/V20190823/actions/ModifyClusterPassword.swift
@@ -31,8 +31,8 @@ extension Tcaplusdb {
 
         /// 集群旧密码预期失效时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$oldPasswordExpireTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var oldPasswordExpireTime: Date
 
         /// 集群新密码，密码必须是a-zA-Z0-9的字符,且必须包含数字和大小写字母

--- a/Sources/Teco/Tcaplusdb/V20190823/actions/RollbackTables.swift
+++ b/Sources/Teco/Tcaplusdb/V20190823/actions/RollbackTables.swift
@@ -31,8 +31,8 @@ extension Tcaplusdb {
 
         /// 待回档时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$rollbackTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var rollbackTime: Date
 
         /// 回档模式，支持：`KEYS`

--- a/Sources/Teco/Tcaplusdb/V20190823/models.swift
+++ b/Sources/Teco/Tcaplusdb/V20190823/models.swift
@@ -285,8 +285,8 @@ extension Tcaplusdb {
 
         /// 创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createdTime: Date
 
         /// 集群密码
@@ -1112,14 +1112,14 @@ extension Tcaplusdb {
 
         /// 快照时间点
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$snapshotTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var snapshotTime: Date
 
         /// 快照过期时间点
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$snapshotDeadTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var snapshotDeadTime: Date
 
         public init(tableGroupId: String, tableName: String, snapshotName: String, snapshotTime: Date, snapshotDeadTime: Date) {
@@ -1152,8 +1152,8 @@ extension Tcaplusdb {
 
         /// 快照过期时间点
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$snapshotDeadTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var snapshotDeadTime: Date?
 
         public init(tableGroupId: String, tableName: String, snapshotName: String, snapshotDeadTime: Date? = nil) {
@@ -1196,22 +1196,22 @@ extension Tcaplusdb {
         /// 快照的时间点
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$snapshotTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var snapshotTime: Date?
 
         /// 快照的过期时间点
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$snapshotDeadTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var snapshotDeadTime: Date?
 
         /// 快照创建时间点
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$snapshotCreateTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var snapshotCreateTime: Date?
 
         /// 快照大小
@@ -1315,8 +1315,8 @@ extension Tcaplusdb {
 
         /// 表格组创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createdTime: Date
 
         /// 表格组包含的表格数量
@@ -1736,14 +1736,14 @@ extension Tcaplusdb {
 
         /// 任务创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 任务最后更新时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updateTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var updateTime: Date
 
         /// 操作者

--- a/Sources/Teco/Tcb/V20180608/models.swift
+++ b/Sources/Teco/Tcb/V20180608/models.swift
@@ -105,14 +105,14 @@ extension Tcb {
 
         /// 创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date
 
         /// 更新时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updateTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var updateTime: Date
 
         enum CodingKeys: String, CodingKey {
@@ -1306,8 +1306,8 @@ extension Tcb {
 
         /// 创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date
 
         enum CodingKeys: String, CodingKey {
@@ -1487,8 +1487,8 @@ extension Tcb {
         /// 更新时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updateTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var updateTime: Date?
 
         enum CodingKeys: String, CodingKey {
@@ -1655,14 +1655,14 @@ extension Tcb {
 
         /// 创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date
 
         /// 最后修改时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updateTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var updateTime: Date
 
         /// 环境状态。包含以下取值：

--- a/Sources/Teco/Tchd/V20230306/actions/DescribeEvents.swift
+++ b/Sources/Teco/Tchd/V20230306/actions/DescribeEvents.swift
@@ -25,8 +25,8 @@ extension Tchd {
     public struct DescribeEventsRequest: TCRequest {
         /// 事件的发生日期
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$eventDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var eventDate: Date
 
         /// 1. 不指定产品列表时将查询所有产品。

--- a/Sources/Teco/Tci/V20190318/actions/DescribePerson.swift
+++ b/Sources/Teco/Tci/V20190318/actions/DescribePerson.swift
@@ -47,8 +47,8 @@ extension Tci {
 
         /// 创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createTime: Date
 
         /// 工作号码
@@ -77,8 +77,8 @@ extension Tci {
 
         /// 修改时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updateTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var updateTime: Date
 
         /// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。

--- a/Sources/Teco/Tci/V20190318/models.swift
+++ b/Sources/Teco/Tci/V20190318/models.swift
@@ -1074,8 +1074,8 @@ extension Tci {
     public struct Library: TCInputModel {
         /// 人员库创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createTime: Date
 
         /// 人员库唯一标识符
@@ -1089,8 +1089,8 @@ extension Tci {
 
         /// 人员库修改时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updateTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var updateTime: Date?
 
         public init(createTime: Date, libraryId: String, libraryName: String, personCount: Int64? = nil, updateTime: Date? = nil) {
@@ -1242,8 +1242,8 @@ extension Tci {
 
         /// 创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createTime: Date?
 
         /// 工作号码
@@ -1263,8 +1263,8 @@ extension Tci {
 
         /// 修改时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updateTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var updateTime: Date?
 
         public init(libraryId: String, personId: String, personName: String, createTime: Date? = nil, jobNumber: String? = nil, mail: String? = nil, male: Int64? = nil, phoneNumber: String? = nil, studentNumber: String? = nil, updateTime: Date? = nil) {

--- a/Sources/Teco/Tcm/V20210413/models.swift
+++ b/Sources/Teco/Tcm/V20210413/models.swift
@@ -193,8 +193,8 @@ extension Tcm {
 
         /// 关联时间，只读
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$linkedTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var linkedTime: Date?
 
         /// 集群配置
@@ -817,15 +817,15 @@ extension Tcm {
 
         /// 创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createdTime: Date
 
         /// 修改时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updatedTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var updatedTime: Date?
 
         /// 集群列表

--- a/Sources/Teco/Tcr/V20190924/actions/CreateCustomAccount.swift
+++ b/Sources/Teco/Tcr/V20190924/actions/CreateCustomAccount.swift
@@ -78,8 +78,8 @@ extension Tcr {
 
         /// 自定义用户创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createTime: Date
 
         /// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。

--- a/Sources/Teco/Tcr/V20190924/actions/CreateServiceAccount.swift
+++ b/Sources/Teco/Tcr/V20190924/actions/CreateServiceAccount.swift
@@ -78,8 +78,8 @@ extension Tcr {
 
         /// 服务级账号创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createTime: Date
 
         /// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。

--- a/Sources/Teco/Tcr/V20190924/models.swift
+++ b/Sources/Teco/Tcr/V20190924/models.swift
@@ -122,15 +122,15 @@ extension Tcr {
         /// 创建时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createTime: Date?
 
         /// 更新时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updateTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var updateTime: Date?
 
         /// 策略
@@ -541,14 +541,14 @@ extension Tcr {
 
         /// 创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdAt`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createdAt: Date
 
         /// 更新时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updatedAt`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var updatedAt: Date
 
         /// id
@@ -585,8 +585,8 @@ extension Tcr {
 
         /// 实例创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdAt`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createdAt: Date
 
         /// 地域名称
@@ -1155,15 +1155,15 @@ extension Tcr {
         /// 创建时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createTime: Date?
 
         /// 更新时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updateTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var updateTime: Date?
 
         /// 策略
@@ -1402,8 +1402,8 @@ extension Tcr {
 
         /// 令牌创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdAt`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createdAt: Date
 
         /// 令牌过期时间戳
@@ -1426,8 +1426,8 @@ extension Tcr {
 
         /// 创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$creationTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var creationTime: Date
 
         /// 访问级别

--- a/Sources/Teco/Tcss/V20201101/actions/DescribeAbnormalProcessEventTendency.swift
+++ b/Sources/Teco/Tcss/V20201101/actions/DescribeAbnormalProcessEventTendency.swift
@@ -25,14 +25,14 @@ extension Tcss {
     public struct DescribeAbnormalProcessEventTendencyRequest: TCRequest {
         /// 开始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var startTime: Date
 
         /// 结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var endTime: Date
 
         public init(startTime: Date, endTime: Date) {

--- a/Sources/Teco/Tcss/V20201101/actions/DescribeAssetImageRegistryDetail.swift
+++ b/Sources/Teco/Tcss/V20201101/actions/DescribeAssetImageRegistryDetail.swift
@@ -170,8 +170,8 @@ extension Tcss {
         /// 镜像创建的时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$imageCreateTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var imageCreateTime: Date?
 
         /// 敏感信息数

--- a/Sources/Teco/Tcss/V20201101/actions/DescribeEscapeEventTendency.swift
+++ b/Sources/Teco/Tcss/V20201101/actions/DescribeEscapeEventTendency.swift
@@ -25,14 +25,14 @@ extension Tcss {
     public struct DescribeEscapeEventTendencyRequest: TCRequest {
         /// 结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var endTime: Date
 
         /// 开始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var startTime: Date
 
         public init(endTime: Date, startTime: Date) {

--- a/Sources/Teco/Tcss/V20201101/actions/DescribeImageAutoAuthorizedTaskList.swift
+++ b/Sources/Teco/Tcss/V20201101/actions/DescribeImageAutoAuthorizedTaskList.swift
@@ -25,14 +25,14 @@ extension Tcss {
     public struct DescribeImageAutoAuthorizedTaskListRequest: TCPaginatedRequest {
         /// 开始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var startTime: Date
 
         /// 结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var endTime: Date
 
         /// 过滤字段

--- a/Sources/Teco/Tcss/V20201101/actions/DescribeImageRiskTendency.swift
+++ b/Sources/Teco/Tcss/V20201101/actions/DescribeImageRiskTendency.swift
@@ -25,14 +25,14 @@ extension Tcss {
     public struct DescribeImageRiskTendencyRequest: TCRequest {
         /// 开始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var startTime: Date
 
         /// 结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var endTime: Date
 
         public init(startTime: Date, endTime: Date) {

--- a/Sources/Teco/Tcss/V20201101/actions/DescribeSecEventsTendency.swift
+++ b/Sources/Teco/Tcss/V20201101/actions/DescribeSecEventsTendency.swift
@@ -25,14 +25,14 @@ extension Tcss {
     public struct DescribeSecEventsTendencyRequest: TCRequest {
         /// 开始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var startTime: Date
 
         /// 结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var endTime: Date
 
         public init(startTime: Date, endTime: Date) {

--- a/Sources/Teco/Tcss/V20201101/actions/DescribeVulDefenceEventTendency.swift
+++ b/Sources/Teco/Tcss/V20201101/actions/DescribeVulDefenceEventTendency.swift
@@ -25,14 +25,14 @@ extension Tcss {
     public struct DescribeVulDefenceEventTendencyRequest: TCRequest {
         /// 开始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var startTime: Date
 
         /// 结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var endTime: Date
 
         public init(startTime: Date, endTime: Date) {

--- a/Sources/Teco/Tcss/V20201101/actions/DescribeVulTendency.swift
+++ b/Sources/Teco/Tcss/V20201101/actions/DescribeVulTendency.swift
@@ -25,14 +25,14 @@ extension Tcss {
     public struct DescribeVulTendencyRequest: TCRequest {
         /// 开始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var startTime: Date
 
         /// 结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var endTime: Date
 
         /// 枚举类型：

--- a/Sources/Teco/Tcss/V20201101/models.swift
+++ b/Sources/Teco/Tcss/V20201101/models.swift
@@ -120,8 +120,8 @@ extension Tcss {
 
         /// 生成时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$foundTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var foundTime: Date
 
         /// 容器名
@@ -177,8 +177,8 @@ extension Tcss {
 
         /// 最近生成时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$latestFoundTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var latestFoundTime: Date
 
         /// 规则组Id
@@ -303,8 +303,8 @@ extension Tcss {
     public struct AbnormalProcessEventTendencyInfo: TCOutputModel {
         /// 日期
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$date`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var date: Date
 
         /// 待处理代理软件事件数
@@ -511,8 +511,8 @@ extension Tcss {
 
         /// 生成时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$foundTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var foundTime: Date
 
         /// 容器名
@@ -1592,8 +1592,8 @@ extension Tcss {
         /// 上次检测的时间。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$lastCheckTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var lastCheckTime: Date?
 
         /// 检测结果：
@@ -1611,8 +1611,8 @@ extension Tcss {
         /// ASSET_STOPPED: 停止运行，
         /// ASSET_ABNORMAL: 异常
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$assetCreateTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var assetCreateTime: Date
 
         enum CodingKeys: String, CodingKey {
@@ -1675,8 +1675,8 @@ extension Tcss {
         /// 上次检测的时间。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$lastCheckTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var lastCheckTime: Date?
 
         /// 检测结果：
@@ -1857,8 +1857,8 @@ extension Tcss {
         /// 上次检测的时间。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$lastCheckTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var lastCheckTime: Date?
 
         /// 定时检测规则。
@@ -2055,8 +2055,8 @@ extension Tcss {
         /// 最近一次触发的时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$lastTriggerTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var lastTriggerTime: Date?
 
         /// 总的检查项数目
@@ -2148,8 +2148,8 @@ extension Tcss {
         /// 最近检测的时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$lastCheckTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var lastCheckTime: Date?
 
         /// 检测状态
@@ -2237,8 +2237,8 @@ extension Tcss {
 
         /// 检测的时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$checkTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var checkTime: Date
 
         enum CodingKeys: String, CodingKey {
@@ -2274,14 +2274,14 @@ extension Tcss {
 
         /// 最后更新的时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$lastUpdateTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var lastUpdateTime: Date
 
         /// 加入到白名单的时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$insertTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var insertTime: Date
 
         enum CodingKeys: String, CodingKey {
@@ -2709,8 +2709,8 @@ extension Tcss {
 
         /// 生成时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$foundTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var foundTime: Date
 
         /// 事件名字，
@@ -2739,8 +2739,8 @@ extension Tcss {
 
         /// 最近生成时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$latestFoundTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var latestFoundTime: Date
 
         /// 节点IP
@@ -2856,8 +2856,8 @@ extension Tcss {
 
         /// 日期
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$date`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var date: Date
 
         enum CodingKeys: String, CodingKey {
@@ -3023,14 +3023,14 @@ extension Tcss {
 
         /// 文件创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$fileCreateTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var fileCreateTime: Date
 
         /// 最近被篡改文件创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$latestTamperedFileMTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var latestTamperedFileMTime: Date
 
         /// 新文件内容
@@ -3149,8 +3149,8 @@ extension Tcss {
 
         /// 任务日期
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$authorizedDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var authorizedDate: Date
 
         /// 镜像来源，LOCAL:本地镜像，REGISTRY:仓库镜像
@@ -3460,8 +3460,8 @@ extension Tcss {
         /// 镜像创建的时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$imageCreateTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var imageCreateTime: Date?
 
         /// 是否为镜像的最新版本
@@ -5324,14 +5324,14 @@ extension Tcss {
 
         /// 创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date
 
         /// 更新时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updateTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var updateTime: Date
 
         /// 目标端口
@@ -5737,14 +5737,14 @@ extension Tcss {
 
         /// 创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date
 
         /// 更新时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updateTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var updateTime: Date
 
         /// 是否是全局白名单，true全局
@@ -5836,8 +5836,8 @@ extension Tcss {
 
         /// 事件发现时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$foundTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var foundTime: Date?
 
         /// 容器id
@@ -6037,8 +6037,8 @@ extension Tcss {
     public struct RunTimeTendencyInfo: TCOutputModel {
         /// 当天时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$curTime`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var curTime: Date
 
         /// 当前数量
@@ -6522,8 +6522,8 @@ extension Tcss {
 
         /// 最近编辑时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$modifyTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var modifyTime: Date
 
         /// 自动隔离开关(true:开 false:关)
@@ -6808,8 +6808,8 @@ extension Tcss {
     public struct VirusTendencyInfo: TCOutputModel {
         /// 日期
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$date`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var date: Date
 
         /// 待处理事件总数
@@ -7372,8 +7372,8 @@ extension Tcss {
     public struct VulDefenceEventTendency: TCOutputModel {
         /// 日期
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$date`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var date: Date
 
         /// 事件数量

--- a/Sources/Teco/Tdmq/V20200217/models.swift
+++ b/Sources/Teco/Tdmq/V20200217/models.swift
@@ -749,14 +749,14 @@ extension Tdmq {
 
         /// 创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date
 
         /// 最近修改时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updateTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var updateTime: Date
 
         /// 命名空间ID
@@ -807,14 +807,14 @@ extension Tdmq {
 
         /// 创建时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date
 
         /// 更新时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updateTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var updateTime: Date
 
         enum CodingKeys: String, CodingKey {
@@ -2411,14 +2411,14 @@ extension Tdmq {
 
         /// 创建时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date
 
         /// 更新时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updateTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var updateTime: Date
 
         enum CodingKeys: String, CodingKey {
@@ -2512,15 +2512,15 @@ extension Tdmq {
         /// 创建时间。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date?
 
         /// 最近修改时间。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updateTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var updateTime: Date?
 
         /// 订阅类型，Exclusive，Shared，Failover， Key_Shared，空或NULL表示未知，
@@ -2681,15 +2681,15 @@ extension Tdmq {
         /// 创建时间。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date?
 
         /// 最近修改时间。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updateTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var updateTime: Date?
 
         /// 生产者上限。

--- a/Sources/Teco/Tem/V20210701/models.swift
+++ b/Sources/Teco/Tem/V20210701/models.swift
@@ -2000,15 +2000,15 @@ extension Tem {
         /// 创建时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createDate`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createDate: Date?
 
         /// 修改时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$modifyDate`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var modifyDate: Date?
 
         /// 修改人

--- a/Sources/Teco/Teo/V20220106/actions/DescribePrefetchTasks.swift
+++ b/Sources/Teco/Teo/V20220106/actions/DescribePrefetchTasks.swift
@@ -28,14 +28,14 @@ extension Teo {
 
         /// 查询起始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var startTime: Date?
 
         /// 查询结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var endTime: Date?
 
         /// 查询起始偏移量

--- a/Sources/Teco/Teo/V20220106/actions/DescribePurgeTasks.swift
+++ b/Sources/Teco/Teo/V20220106/actions/DescribePurgeTasks.swift
@@ -31,14 +31,14 @@ extension Teo {
 
         /// 查询起始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var startTime: Date?
 
         /// 查询结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var endTime: Date?
 
         /// 查询起始偏移量

--- a/Sources/Teco/Teo/V20220106/models.swift
+++ b/Sources/Teco/Teo/V20220106/models.swift
@@ -64,20 +64,20 @@ extension Teo {
 
         /// 创建时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createTime: Date
 
         /// 生效时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$enableTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var enableTime: Date
 
         /// 失效时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$expireTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var expireTime: Date
 
         /// 套餐状态，取值有：
@@ -168,14 +168,14 @@ extension Teo {
 
         /// 任务创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createTime: Date
 
         /// 任务完成时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updateTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var updateTime: Date
 
         enum CodingKeys: String, CodingKey {
@@ -235,14 +235,14 @@ extension Teo {
 
         /// 站点创建时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdOn`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createdOn: Date
 
         /// 站点修改时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$modifiedOn`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var modifiedOn: Date
 
         /// 站点接入地域，取值为：

--- a/Sources/Teco/Teo/V20220901/actions/DescribeDDoSAttackData.swift
+++ b/Sources/Teco/Teo/V20220901/actions/DescribeDDoSAttackData.swift
@@ -25,14 +25,14 @@ extension Teo {
     public struct DescribeDDoSAttackDataRequest: TCRequest {
         /// 开始时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var startTime: Date
 
         /// 结束时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var endTime: Date
 
         /// 统计指标列表，取值有：

--- a/Sources/Teco/Teo/V20220901/actions/DescribeDDoSAttackEvent.swift
+++ b/Sources/Teco/Teo/V20220901/actions/DescribeDDoSAttackEvent.swift
@@ -25,14 +25,14 @@ extension Teo {
     public struct DescribeDDoSAttackEventRequest: TCPaginatedRequest {
         /// 开始时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var startTime: Date
 
         /// 结束时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var endTime: Date
 
         /// ddos策略组集合，不填默认选择全部策略。

--- a/Sources/Teco/Teo/V20220901/actions/DescribeDDoSAttackTopData.swift
+++ b/Sources/Teco/Teo/V20220901/actions/DescribeDDoSAttackTopData.swift
@@ -25,14 +25,14 @@ extension Teo {
     public struct DescribeDDoSAttackTopDataRequest: TCRequest {
         /// 开始时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var startTime: Date
 
         /// 结束时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var endTime: Date
 
         /// 查询的统计指标，取值有：

--- a/Sources/Teco/Teo/V20220901/actions/DescribeOverviewL7Data.swift
+++ b/Sources/Teco/Teo/V20220901/actions/DescribeOverviewL7Data.swift
@@ -25,14 +25,14 @@ extension Teo {
     public struct DescribeOverviewL7DataRequest: TCRequest {
         /// 开始时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var startTime: Date
 
         /// 结束时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var endTime: Date
 
         /// 查询的指标，取值有：

--- a/Sources/Teco/Teo/V20220901/actions/DescribePrefetchTasks.swift
+++ b/Sources/Teco/Teo/V20220901/actions/DescribePrefetchTasks.swift
@@ -25,14 +25,14 @@ extension Teo {
     public struct DescribePrefetchTasksRequest: TCPaginatedRequest {
         /// 查询起始时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var startTime: Date?
 
         /// 查询结束时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var endTime: Date?
 
         /// 分页查询偏移量，默认为 0。

--- a/Sources/Teco/Teo/V20220901/actions/DescribePurgeTasks.swift
+++ b/Sources/Teco/Teo/V20220901/actions/DescribePurgeTasks.swift
@@ -28,14 +28,14 @@ extension Teo {
 
         /// 查询起始时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var startTime: Date?
 
         /// 查询结束时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var endTime: Date?
 
         /// 分页查询偏移量，默认为0。

--- a/Sources/Teco/Teo/V20220901/actions/DescribeTimingL4Data.swift
+++ b/Sources/Teco/Teo/V20220901/actions/DescribeTimingL4Data.swift
@@ -25,14 +25,14 @@ extension Teo {
     public struct DescribeTimingL4DataRequest: TCRequest {
         /// 开始时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var startTime: Date
 
         /// 结束时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var endTime: Date
 
         /// 查询指标，取值有：

--- a/Sources/Teco/Teo/V20220901/actions/DescribeTimingL7AnalysisData.swift
+++ b/Sources/Teco/Teo/V20220901/actions/DescribeTimingL7AnalysisData.swift
@@ -25,14 +25,14 @@ extension Teo {
     public struct DescribeTimingL7AnalysisDataRequest: TCRequest {
         /// 开始时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var startTime: Date
 
         /// 结束时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var endTime: Date
 
         /// 指标列表，取值有:

--- a/Sources/Teco/Teo/V20220901/actions/DescribeTimingL7CacheData.swift
+++ b/Sources/Teco/Teo/V20220901/actions/DescribeTimingL7CacheData.swift
@@ -25,14 +25,14 @@ extension Teo {
     public struct DescribeTimingL7CacheDataRequest: TCRequest {
         /// 开始时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var startTime: Date
 
         /// 结束时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var endTime: Date
 
         /// 查询的指标，取值有：

--- a/Sources/Teco/Teo/V20220901/actions/DescribeTopL7AnalysisData.swift
+++ b/Sources/Teco/Teo/V20220901/actions/DescribeTopL7AnalysisData.swift
@@ -25,14 +25,14 @@ extension Teo {
     public struct DescribeTopL7AnalysisDataRequest: TCRequest {
         /// 开始时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var startTime: Date
 
         /// 结束时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var endTime: Date
 
         /// 查询的指标，取值有：

--- a/Sources/Teco/Teo/V20220901/actions/DescribeTopL7CacheData.swift
+++ b/Sources/Teco/Teo/V20220901/actions/DescribeTopL7CacheData.swift
@@ -25,14 +25,14 @@ extension Teo {
     public struct DescribeTopL7CacheDataRequest: TCRequest {
         /// 开始时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var startTime: Date
 
         /// 结束时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var endTime: Date
 
         /// 查询的指标，取值有：

--- a/Sources/Teco/Teo/V20220901/actions/DownloadL4Logs.swift
+++ b/Sources/Teco/Teo/V20220901/actions/DownloadL4Logs.swift
@@ -25,14 +25,14 @@ extension Teo {
     public struct DownloadL4LogsRequest: TCPaginatedRequest {
         /// 开始时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var startTime: Date
 
         /// 结束时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var endTime: Date
 
         /// 站点集合，此参数必填，不填默认查询为空。

--- a/Sources/Teco/Teo/V20220901/actions/DownloadL7Logs.swift
+++ b/Sources/Teco/Teo/V20220901/actions/DownloadL7Logs.swift
@@ -25,14 +25,14 @@ extension Teo {
     public struct DownloadL7LogsRequest: TCPaginatedRequest {
         /// 开始时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var startTime: Date
 
         /// 结束时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var endTime: Date
 
         /// 站点集合，此参数必填，不填默认查询为空。

--- a/Sources/Teco/Teo/V20220901/models.swift
+++ b/Sources/Teco/Teo/V20220901/models.swift
@@ -83,14 +83,14 @@ extension Teo {
 
         /// 创建时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdOn`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createdOn: Date
 
         /// 修改时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$modifiedOn`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var modifiedOn: Date
 
         /// 当域名需要进行归属权验证才能继续提供服务时，该对象会携带对应验证方式所需要的信息。
@@ -619,14 +619,14 @@ extension Teo {
 
         /// 别称域名创建时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdOn`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createdOn: Date
 
         /// 别称域名修改时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$modifiedOn`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var modifiedOn: Date
 
         enum CodingKeys: String, CodingKey {
@@ -712,8 +712,8 @@ extension Teo {
 
         /// 更新时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updateTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var updateTime: Date
 
         /// 规则列表。
@@ -1263,14 +1263,14 @@ extension Teo {
 
         /// 证书过期时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$expireTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var expireTime: Date?
 
         /// 证书部署时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$deployTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var deployTime: Date?
 
         /// 签名算法。
@@ -1519,15 +1519,15 @@ extension Teo {
         /// 证书过期时间。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$expireTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var expireTime: Date?
 
         /// 证书生效时间。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$effectiveTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var effectiveTime: Date?
 
         /// 证书公用名。
@@ -1839,8 +1839,8 @@ extension Teo {
         /// 更新时间，如果为null，默认由底层按当前时间生成。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updateTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var updateTime: Date?
 
         /// 匹配条件。
@@ -2457,8 +2457,8 @@ extension Teo {
 
         /// 更新时间。仅出参使用。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updateTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var updateTime: Date?
 
         /// 规则启用状态，当返回为null时，为启用。取值有：
@@ -2535,14 +2535,14 @@ extension Teo {
 
         /// 日志打包开始时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$logStartTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var logStartTime: Date
 
         /// 日志打包结束时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$logEndTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var logEndTime: Date
 
         /// 日志大小，单位为 Byte。
@@ -2581,14 +2581,14 @@ extension Teo {
 
         /// 日志打包开始时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$logStartTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var logStartTime: Date
 
         /// 日志打包结束时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$logEndTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var logEndTime: Date
 
         /// 日志原始大小，单位 Byte。
@@ -2804,8 +2804,8 @@ extension Teo {
 
         /// 源站组更新时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updateTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var updateTime: Date?
 
         /// 当OriginType=self时，表示回源Host。
@@ -3481,20 +3481,20 @@ extension Teo {
 
         /// 创建时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createTime: Date
 
         /// 生效时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$enableTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var enableTime: Date
 
         /// 失效时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$expireTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var expireTime: Date
 
         /// 套餐状态，取值有：
@@ -4091,15 +4091,15 @@ extension Teo {
         /// 证书过期时间。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$expireTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var expireTime: Date?
 
         /// 证书部署时间。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$deployTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var deployTime: Date?
 
         /// 签名算法。
@@ -4288,8 +4288,8 @@ extension Teo {
 
         /// Debug 功能到期时间。超出设置的时间，则功能失效。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$expireTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var expireTime: Date
 
         public init(switch: String, allowClientIPList: [String], expireTime: Date) {
@@ -4453,14 +4453,14 @@ extension Teo {
 
         /// 任务创建时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createTime: Date
 
         /// 任务完成时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updateTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var updateTime: Date
 
         enum CodingKeys: String, CodingKey {
@@ -4815,14 +4815,14 @@ extension Teo {
 
         /// 站点创建时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdOn`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createdOn: Date
 
         /// 站点修改时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$modifiedOn`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var modifiedOn: Date
 
         /// 站点接入地域，取值有：

--- a/Sources/Teco/Thpc/V20211109/models.swift
+++ b/Sources/Teco/Thpc/V20211109/models.swift
@@ -73,8 +73,8 @@ extension Thpc {
 
         /// 集群创建时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createTime: Date
 
         /// 集群调度器。

--- a/Sources/Teco/Thpc/V20220401/models.swift
+++ b/Sources/Teco/Thpc/V20220401/models.swift
@@ -122,15 +122,15 @@ extension Thpc {
         /// 集群活动开始时间。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var startTime: Date?
 
         /// 集群活动结束时间。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var endTime: Date?
 
         enum CodingKeys: String, CodingKey {
@@ -170,8 +170,8 @@ extension Thpc {
 
         /// 集群创建时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createTime: Date
 
         /// 集群调度器。

--- a/Sources/Teco/Thpc/V20230321/models.swift
+++ b/Sources/Teco/Thpc/V20230321/models.swift
@@ -135,15 +135,15 @@ extension Thpc {
         /// 集群活动开始时间。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var startTime: Date?
 
         /// 集群活动结束时间。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var endTime: Date?
 
         enum CodingKeys: String, CodingKey {
@@ -183,8 +183,8 @@ extension Thpc {
 
         /// 集群创建时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createTime: Date
 
         /// 集群调度器。

--- a/Sources/Teco/Tione/V20191022/actions/DescribeCodeRepository.swift
+++ b/Sources/Teco/Tione/V20191022/actions/DescribeCodeRepository.swift
@@ -39,14 +39,14 @@ extension Tione {
     public struct DescribeCodeRepositoryResponse: TCResponse {
         /// 创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$creationTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var creationTime: Date
 
         /// 更新时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$lastModifiedTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var lastModifiedTime: Date
 
         /// 存储库名称

--- a/Sources/Teco/Tione/V20191022/actions/DescribeNotebookInstance.swift
+++ b/Sources/Teco/Tione/V20191022/actions/DescribeNotebookInstance.swift
@@ -72,15 +72,15 @@ extension Tione {
         /// Notebook实例创建时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$creationTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var creationTime: Date?
 
         /// Notebook实例最近修改时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$lastModifiedTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var lastModifiedTime: Date?
 
         /// Notebook实例日志链接
@@ -126,8 +126,8 @@ extension Tione {
         /// 实例运行截止时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$deadline`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var deadline: Date?
 
         /// 自动停止配置

--- a/Sources/Teco/Tione/V20191022/actions/DescribeNotebookLifecycleScript.swift
+++ b/Sources/Teco/Tione/V20191022/actions/DescribeNotebookLifecycleScript.swift
@@ -50,14 +50,14 @@ extension Tione {
 
         /// 创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$creationTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var creationTime: Date
 
         /// 最后修改时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$lastModifiedTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var lastModifiedTime: Date
 
         /// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。

--- a/Sources/Teco/Tione/V20191022/actions/DescribeTrainingJob.swift
+++ b/Sources/Teco/Tione/V20191022/actions/DescribeTrainingJob.swift
@@ -70,22 +70,22 @@ extension Tione {
 
         /// 最近修改时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$lastModifiedTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var lastModifiedTime: Date
 
         /// 任务开始时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$trainingStartTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var trainingStartTime: Date?
 
         /// 任务完成时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$trainingEndTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var trainingEndTime: Date?
 
         /// 模型输出配置

--- a/Sources/Teco/Tione/V20191022/actions/DescribeTrainingJobs.swift
+++ b/Sources/Teco/Tione/V20191022/actions/DescribeTrainingJobs.swift
@@ -31,14 +31,14 @@ extension Tione {
 
         /// 创建时间晚于
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$creationTimeAfter`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var creationTimeAfter: Date?
 
         /// 创建时间早于
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$creationTimeBefore`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var creationTimeBefore: Date?
 
         /// 根据名称过滤

--- a/Sources/Teco/Tione/V20191022/models.swift
+++ b/Sources/Teco/Tione/V20191022/models.swift
@@ -96,14 +96,14 @@ extension Tione {
     public struct CodeRepoSummary: TCOutputModel {
         /// 创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$creationTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var creationTime: Date
 
         /// 更新时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$lastModifiedTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var lastModifiedTime: Date
 
         /// 存储库名称
@@ -339,8 +339,8 @@ extension Tione {
         /// 创建时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$creationTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var creationTime: Date?
 
         /// 最近修改时间
@@ -371,15 +371,15 @@ extension Tione {
         /// 启动时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startupTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startupTime: Date?
 
         /// 运行截止时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$deadline`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var deadline: Date?
 
         /// 自动停止配置
@@ -426,14 +426,14 @@ extension Tione {
 
         /// 创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$creationTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var creationTime: Date
 
         /// 修改时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$lastModifiedTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var lastModifiedTime: Date
 
         enum CodingKeys: String, CodingKey {
@@ -502,15 +502,15 @@ extension Tione {
         /// 状态开始时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date?
 
         /// 状态结束时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date?
 
         /// 状态名
@@ -555,15 +555,15 @@ extension Tione {
         /// 任务创建时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$creationTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var creationTime: Date?
 
         /// 最近修改时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$lastModifiedTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var lastModifiedTime: Date?
 
         /// 训练任务名
@@ -582,8 +582,8 @@ extension Tione {
         /// 完成时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$trainingEndTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var trainingEndTime: Date?
 
         /// 算了实例Id

--- a/Sources/Teco/Tione/V20211111/models.swift
+++ b/Sources/Teco/Tione/V20211111/models.swift
@@ -584,15 +584,15 @@ extension Tione {
         /// 周期开始时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var startTime: Date?
 
         /// 周期结束时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var endTime: Date?
 
         public init(cronConfig: String, startTime: Date? = nil, endTime: Date? = nil) {

--- a/Sources/Teco/Tiw/V20190919/actions/DescribeApplicationUsage.swift
+++ b/Sources/Teco/Tiw/V20190919/actions/DescribeApplicationUsage.swift
@@ -25,14 +25,14 @@ extension Tiw {
     public struct DescribeApplicationUsageRequest: TCRequest {
         /// 用量开始时间（包括该时间点）
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$beginTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var beginTime: Date
 
         /// 用量结束时间（不包括该时间点）
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// 白板子产品名

--- a/Sources/Teco/Tiw/V20190919/actions/DescribePostpaidUsage.swift
+++ b/Sources/Teco/Tiw/V20190919/actions/DescribePostpaidUsage.swift
@@ -25,14 +25,14 @@ extension Tiw {
     public struct DescribePostpaidUsageRequest: TCRequest {
         /// 开始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$beginTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var beginTime: Date
 
         /// 结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         public init(beginTime: Date, endTime: Date) {

--- a/Sources/Teco/Tiw/V20190919/actions/DescribeTIWDailyUsage.swift
+++ b/Sources/Teco/Tiw/V20190919/actions/DescribeTIWDailyUsage.swift
@@ -37,14 +37,14 @@ extension Tiw {
 
         /// 开始时间，格式YYYY-MM-DD，查询结果里包括该天数据
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var startTime: Date
 
         /// 结束时间，格式YYYY-MM-DD，查询结果里包括该天数据，单次查询统计区间最多不能超过31天。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var endTime: Date
 
         public init(sdkAppId: Int64, subProduct: String, startTime: Date, endTime: Date) {

--- a/Sources/Teco/Tiw/V20190919/actions/DescribeTIWRoomDailyUsage.swift
+++ b/Sources/Teco/Tiw/V20190919/actions/DescribeTIWRoomDailyUsage.swift
@@ -33,14 +33,14 @@ extension Tiw {
 
         /// 开始时间，格式YYYY-MM-DD，查询结果里包括该天数据
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var startTime: Date
 
         /// 结束时间，格式YYYY-MM-DD，查询结果里包括该天数据，单次查询统计区间最多不能超过31天。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var endTime: Date
 
         /// 需要查询的房间ID列表，不填默认查询全部房间

--- a/Sources/Teco/Tiw/V20190919/actions/DescribeUsageSummary.swift
+++ b/Sources/Teco/Tiw/V20190919/actions/DescribeUsageSummary.swift
@@ -25,14 +25,14 @@ extension Tiw {
     public struct DescribeUsageSummaryRequest: TCRequest {
         /// 统计时间段的开始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$beginTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var beginTime: Date
 
         /// 统计时间段的结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// 需要获取用量的子产品列表

--- a/Sources/Teco/Tiw/V20190919/models.swift
+++ b/Sources/Teco/Tiw/V20190919/models.swift
@@ -29,8 +29,8 @@ extension Tiw {
 
         /// 创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date
 
         /// 标签列表
@@ -430,8 +430,8 @@ extension Tiw {
 
         /// 任务创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createTime: Date
 
         /// 用户应用SdkAppId
@@ -816,8 +816,8 @@ extension Tiw {
     public struct TranscodeTaskSearchResult: TCOutputModel {
         /// 任务创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createTime: Date
 
         /// 任务唯一ID
@@ -1119,8 +1119,8 @@ extension Tiw {
 
         /// 任务创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createTime: Date
 
         /// 用户应用SdkAppId

--- a/Sources/Teco/Tke/V20180525/models.swift
+++ b/Sources/Teco/Tke/V20180525/models.swift
@@ -732,15 +732,15 @@ extension Tke {
         /// 最后一次探测到该状态的时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$lastProbeTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var lastProbeTime: Date?
 
         /// 最后一次转换到该过程的时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$lastTransitionTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var lastTransitionTime: Date?
 
         /// 转换到该过程的简明原因
@@ -3442,8 +3442,8 @@ extension Tke {
         /// 创建时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createdTime: Date?
 
         /// 应用ID

--- a/Sources/Teco/Trro/V20220325/actions/DescribeDeviceInfo.swift
+++ b/Sources/Teco/Trro/V20220325/actions/DescribeDeviceInfo.swift
@@ -53,14 +53,14 @@ extension Trro {
 
         /// 设备状态最后更新时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$lastReportTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var lastReportTime: Date
 
         /// 设备信息最后修改时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$modifyTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var modifyTime: Date
 
         /// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。

--- a/Sources/Teco/Trro/V20220325/actions/DescribeProjectInfo.swift
+++ b/Sources/Teco/Trro/V20220325/actions/DescribeProjectInfo.swift
@@ -48,8 +48,8 @@ extension Trro {
 
         /// 项目信息修改时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$modifyTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var modifyTime: Date
 
         /// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。

--- a/Sources/Teco/Trro/V20220325/models.swift
+++ b/Sources/Teco/Trro/V20220325/models.swift
@@ -76,14 +76,14 @@ extension Trro {
 
         /// 设备信息最近修改时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$modifyTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var modifyTime: Date
 
         /// 设备状态最近更新时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$lastReportTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var lastReportTime: Date
 
         /// 设备所属项目Id
@@ -146,8 +146,8 @@ extension Trro {
 
         /// 最近添加时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$modifyTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var modifyTime: Date
 
         enum CodingKeys: String, CodingKey {
@@ -173,8 +173,8 @@ extension Trro {
 
         /// 项目信息修改时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$modifyTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var modifyTime: Date
 
         enum CodingKeys: String, CodingKey {

--- a/Sources/Teco/Trtc/V20190722/actions/DescribeRecordStatistic.swift
+++ b/Sources/Teco/Trtc/V20190722/actions/DescribeRecordStatistic.swift
@@ -25,15 +25,15 @@ extension Trtc {
     public struct DescribeRecordStatisticRequest: TCRequest {
         /// 查询开始日期，格式为YYYY-MM-DD。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var startTime: Date
 
         /// 查询结束日期，格式为YYYY-MM-DD。
         /// 单次查询统计区间最多不能超过31天。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var endTime: Date
 
         /// 应用ID，可不传。传应用ID时返回的是该应用的用量，不传时返回多个应用的合计值。

--- a/Sources/Teco/Trtc/V20190722/actions/DescribeTRTCMarketQualityData.swift
+++ b/Sources/Teco/Trtc/V20190722/actions/DescribeTRTCMarketQualityData.swift
@@ -28,14 +28,14 @@ extension Trtc {
 
         /// 查询开始时间，格式为YYYY-MM-DD。（查询时间范围根据监控仪表盘功能版本而定，【基础版】可查近30天，【进阶版】可查近60天）
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var startTime: Date
 
         /// 查询结束时间，格式为YYYY-MM-DD。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var endTime: Date
 
         /// 返回数据的粒度，支持设为以下值：

--- a/Sources/Teco/Trtc/V20190722/actions/DescribeTRTCMarketQualityMetricData.swift
+++ b/Sources/Teco/Trtc/V20190722/actions/DescribeTRTCMarketQualityMetricData.swift
@@ -28,14 +28,14 @@ extension Trtc {
 
         /// 查询开始时间，格式为YYYY-MM-DD。（查询时间范围根据监控仪表盘功能版本而定，【基础版】可查近30天，【进阶版】可查近60天）
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var startTime: Date
 
         /// 查询结束时间，格式为YYYY-MM-DD。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var endTime: Date
 
         /// 返回数据的粒度，支持设为以下值：

--- a/Sources/Teco/Trtc/V20190722/actions/DescribeTRTCMarketScaleData.swift
+++ b/Sources/Teco/Trtc/V20190722/actions/DescribeTRTCMarketScaleData.swift
@@ -28,14 +28,14 @@ extension Trtc {
 
         /// 查询开始时间，格式为YYYY-MM-DD。（查询时间范围根据监控仪表盘功能版本而定，【基础版】可查近30天，【进阶版】可查近60天）
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var startTime: Date
 
         /// 查询结束时间，格式为YYYY-MM-DD。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var endTime: Date
 
         /// 返回数据的粒度，支持设为以下值：

--- a/Sources/Teco/Trtc/V20190722/actions/DescribeTRTCMarketScaleMetricData.swift
+++ b/Sources/Teco/Trtc/V20190722/actions/DescribeTRTCMarketScaleMetricData.swift
@@ -28,14 +28,14 @@ extension Trtc {
 
         /// 查询开始时间，格式为YYYY-MM-DD。（查询时间范围根据监控仪表盘功能版本而定，【基础版】可查近30天，【进阶版】可查近60天）
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var startTime: Date
 
         /// 查询结束时间，格式为YYYY-MM-DD。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var endTime: Date
 
         /// 返回数据的粒度，支持设为以下值：

--- a/Sources/Teco/Trtc/V20190722/actions/DescribeTrtcMcuTranscodeTime.swift
+++ b/Sources/Teco/Trtc/V20190722/actions/DescribeTrtcMcuTranscodeTime.swift
@@ -25,15 +25,15 @@ extension Trtc {
     public struct DescribeTrtcMcuTranscodeTimeRequest: TCRequest {
         /// 查询开始时间，格式为YYYY-MM-DD。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var startTime: Date
 
         /// 查询结束时间，格式为YYYY-MM-DD。
         /// 单次查询统计区间最多不能超过31天。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var endTime: Date
 
         /// 应用ID，可不传。传应用ID时返回的是该应用的用量，不传时返回多个应用的合计值。

--- a/Sources/Teco/Tsf/V20180326/actions/DescribeApiUseDetail.swift
+++ b/Sources/Teco/Tsf/V20180326/actions/DescribeApiUseDetail.swift
@@ -31,14 +31,14 @@ extension Tsf {
 
         /// 查询的日期,格式：yyyy-MM-dd HH:mm:ss
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 查询的日期,格式：yyyy-MM-dd HH:mm:ss
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         public init(gatewayDeployGroupId: String, apiId: String, startTime: Date, endTime: Date) {

--- a/Sources/Teco/Tsf/V20180326/actions/DescribeGroupUseDetail.swift
+++ b/Sources/Teco/Tsf/V20180326/actions/DescribeGroupUseDetail.swift
@@ -31,14 +31,14 @@ extension Tsf {
 
         /// 查询的日期,格式：yyyy-MM-dd HH:mm:ss
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 查询的日期,格式：yyyy-MM-dd HH:mm:ss
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// 指定top的条数,默认为10

--- a/Sources/Teco/Tsf/V20180326/actions/DescribeInovcationIndicators.swift
+++ b/Sources/Teco/Tsf/V20180326/actions/DescribeInovcationIndicators.swift
@@ -28,14 +28,14 @@ extension Tsf {
 
         /// 开始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// 命名空间ID

--- a/Sources/Teco/Tsf/V20180326/actions/DescribeInvocationMetricDataCurve.swift
+++ b/Sources/Teco/Tsf/V20180326/actions/DescribeInvocationMetricDataCurve.swift
@@ -25,14 +25,14 @@ extension Tsf {
     public struct DescribeInvocationMetricDataCurveRequest: TCRequest {
         /// 查询开始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date?
 
         /// 查询结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date?
 
         /// 查询时间粒度，单位秒可选值：60、3600、86400

--- a/Sources/Teco/Tsf/V20180326/actions/DescribeInvocationMetricScatterPlot.swift
+++ b/Sources/Teco/Tsf/V20180326/actions/DescribeInvocationMetricScatterPlot.swift
@@ -25,14 +25,14 @@ extension Tsf {
     public struct DescribeInvocationMetricScatterPlotRequest: TCRequest {
         /// 查询开始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date?
 
         /// 查询结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date?
 
         /// 查询时间粒度，单位秒。可选值：60、3600、86400。

--- a/Sources/Teco/Tsf/V20180326/actions/DescribeOverviewInvocation.swift
+++ b/Sources/Teco/Tsf/V20180326/actions/DescribeOverviewInvocation.swift
@@ -34,14 +34,14 @@ extension Tsf {
 
         /// 查询开始时间，默认为当天的 00:00:00
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date?
 
         /// 查询结束时间，默认为当前时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date?
 
         public init(namespaceId: String? = nil, type: String? = nil, period: Int64? = nil, startTime: Date? = nil, endTime: Date? = nil) {

--- a/Sources/Teco/Tsf/V20180326/actions/DescribeStatistics.swift
+++ b/Sources/Teco/Tsf/V20180326/actions/DescribeStatistics.swift
@@ -46,14 +46,14 @@ extension Tsf {
 
         /// 开始时间：年月日 时分秒2020-05-12 14:43:12
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date?
 
         /// 开始时间：年月日 时分秒2020-05-12 14:43:12
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date?
 
         /// 服务名称

--- a/Sources/Teco/Tsf/V20180326/actions/DescribeUnitApiUseDetail.swift
+++ b/Sources/Teco/Tsf/V20180326/actions/DescribeUnitApiUseDetail.swift
@@ -31,14 +31,14 @@ extension Tsf {
 
         /// 查询的日期,格式：yyyy-MM-dd HH:mm:ss
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 查询的日期,格式：yyyy-MM-dd HH:mm:ss
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// 网关实例ID

--- a/Sources/Teco/Tsf/V20180326/actions/SearchBusinessLog.swift
+++ b/Sources/Teco/Tsf/V20180326/actions/SearchBusinessLog.swift
@@ -31,14 +31,14 @@ extension Tsf {
 
         /// 开始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date?
 
         /// 结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date?
 
         /// 请求偏移量，取值范围大于等于0，默认值为0

--- a/Sources/Teco/Tsf/V20180326/actions/SearchStdoutLog.swift
+++ b/Sources/Teco/Tsf/V20180326/actions/SearchStdoutLog.swift
@@ -34,8 +34,8 @@ extension Tsf {
 
         /// 查询起始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date?
 
         /// 部署组ID
@@ -43,8 +43,8 @@ extension Tsf {
 
         /// 查询结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date?
 
         /// 请求偏移量，取值范围大于等于0，默认值为

--- a/Sources/Teco/Vm/V20201229/actions/DescribeTasks.swift
+++ b/Sources/Teco/Vm/V20201229/actions/DescribeTasks.swift
@@ -36,16 +36,16 @@ extension Vm {
         ///
         /// 备注：该参数与Filter共同起到任务筛选作用，二者作用无先后顺序。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var startTime: Date?
 
         /// 该参数表示任务列表的结束时间，格式为ISO8601标准的时间戳。**默认值为空**，若传入该参数，则在这StartTime到这一时间之间的任务将会被筛选出来。
         ///
         /// 备注：该参数与Filter共同起到任务筛选作用，二者作用无先后顺序。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var endTime: Date?
 
         public init(limit: Int64? = nil, filter: TaskFilter? = nil, pageToken: String? = nil, startTime: Date? = nil, endTime: Date? = nil) {

--- a/Sources/Teco/Vm/V20210922/actions/DescribeTasks.swift
+++ b/Sources/Teco/Vm/V20210922/actions/DescribeTasks.swift
@@ -36,16 +36,16 @@ extension Vm {
         ///
         /// 备注：该参数与Filter共同起到任务筛选作用，二者作用无先后顺序。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var startTime: Date?
 
         /// 该参数表示任务列表的结束时间，格式为ISO8601标准的时间戳。**默认值为空**，若传入该参数，则在这StartTime到这一时间之间的任务将会被筛选出来。
         ///
         /// 备注：该参数与Filter共同起到任务筛选作用，二者作用无先后顺序。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var endTime: Date?
 
         public init(limit: Int64? = nil, filter: TaskFilter? = nil, pageToken: String? = nil, startTime: Date? = nil, endTime: Date? = nil) {

--- a/Sources/Teco/Vod/V20180717/actions/ApplyUpload.swift
+++ b/Sources/Teco/Vod/V20180717/actions/ApplyUpload.swift
@@ -40,8 +40,8 @@ extension Vod {
 
         /// 媒体文件过期时间，格式按照 ISO 8601 标准表示，详见 [ISO 日期格式说明](/document/product/266/11732#iso-.E6.97.A5.E6.9C.9F.E6.A0.BC.E5.BC.8F)。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$expireTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var expireTime: Date?
 
         /// 指定上传园区，仅适用于对上传地域有特殊需求的用户。

--- a/Sources/Teco/Vod/V20180717/actions/PullUpload.swift
+++ b/Sources/Teco/Vod/V20180717/actions/PullUpload.swift
@@ -45,8 +45,8 @@ extension Vod {
 
         /// 媒体文件过期时间，格式按照 ISO 8601 标准表示，详见 [ISO 日期格式说明](https://cloud.tencent.com/document/product/266/11732#I)。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$expireTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var expireTime: Date?
 
         /// 指定上传园区，仅适用于对上传地域有特殊需求的用户：

--- a/Sources/Teco/Vpc/V20170312/actions/DescribeGatewayFlowMonitorDetail.swift
+++ b/Sources/Teco/Vpc/V20170312/actions/DescribeGatewayFlowMonitorDetail.swift
@@ -25,8 +25,8 @@ extension Vpc {
     public struct DescribeGatewayFlowMonitorDetailRequest: TCPaginatedRequest {
         /// 时间点。表示要查询这分钟内的明细。如：`2019-02-28 18:15:20`，将查询 `18:15` 这一分钟内的明细。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$timePoint`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var timePoint: Date
 
         /// VPN网关实例ID，形如：`vpn-ltjahce6`。

--- a/Sources/Teco/Vpc/V20170312/actions/DescribeIpGeolocationDatabaseUrl.swift
+++ b/Sources/Teco/Vpc/V20170312/actions/DescribeIpGeolocationDatabaseUrl.swift
@@ -42,8 +42,8 @@ extension Vpc {
 
         /// 链接到期时间。按照`ISO8601`标准表示，并且使用`UTC`时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$expiredAt`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var expiredAt: Date
 
         /// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。

--- a/Sources/Teco/Vpc/V20170312/actions/DescribeSpecificTrafficPackageUsedDetails.swift
+++ b/Sources/Teco/Vpc/V20170312/actions/DescribeSpecificTrafficPackageUsedDetails.swift
@@ -39,14 +39,14 @@ extension Vpc {
 
         /// 开始时间。不传默认为当前时间往前推30天
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date?
 
         /// 结束时间。不传默认为当前时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date?
 
         /// 分页参数

--- a/Sources/Teco/Vpc/V20170312/actions/ModifyAddressesBandwidth.swift
+++ b/Sources/Teco/Vpc/V20170312/actions/ModifyAddressesBandwidth.swift
@@ -31,14 +31,14 @@ extension Vpc {
 
         /// 包月带宽起始时间(已废弃，输入无效)
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date?
 
         /// 包月带宽结束时间(已废弃，输入无效)
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date?
 
         public init(addressIds: [String], internetMaxBandwidthOut: Int64, startTime: Date? = nil, endTime: Date? = nil) {

--- a/Sources/Teco/Vpc/V20170312/models.swift
+++ b/Sources/Teco/Vpc/V20170312/models.swift
@@ -83,8 +83,8 @@ extension Vpc {
 
         /// 创建时间。按照`ISO8601`标准表示，并且使用`UTC`时间。格式为：`YYYY-MM-DDThh:mm:ssZ`。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createdTime: Date
 
         /// 绑定的弹性网卡ID
@@ -150,8 +150,8 @@ extension Vpc {
         /// 到期时间。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$deadlineDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var deadlineDate: Date?
 
         /// EIP绑定的实例类型。
@@ -403,8 +403,8 @@ extension Vpc {
 
         /// 带宽包创建时间。按照`ISO8601`标准表示，并且使用`UTC`时间。格式为：`YYYY-MM-DDThh:mm:ssZ`。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createdTime: Date
 
         /// 带宽包状态，包括'CREATING','CREATED','DELETING','DELETED'
@@ -488,8 +488,8 @@ extension Vpc {
 
         /// 创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date?
 
         /// 实例状态， 'ISOLATED': 隔离中（欠费停服），'AVAILABLE'：运行中。
@@ -587,8 +587,8 @@ extension Vpc {
 
         /// 关联时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$attachedTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var attachedTime: Date
 
         /// 云联网所属UIN（根账号）。
@@ -882,8 +882,8 @@ extension Vpc {
 
         /// 更新时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updateTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var updateTime: Date
 
         /// 路由是否启用
@@ -1041,14 +1041,14 @@ extension Vpc {
 
         /// 服务开始时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$serviceStartDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var serviceStartDate: Date
 
         /// 服务截止时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$serviceEndDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var serviceEndDate: Date
 
         /// 状态。待审批：`PENDING`，已通过：`APPROVED`，已拒绝：`DENY`。
@@ -1056,8 +1056,8 @@ extension Vpc {
 
         /// 审批单创建时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createdTime: Date
 
         enum CodingKeys: String, CodingKey {
@@ -1297,8 +1297,8 @@ extension Vpc {
 
         /// 创建时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createdTime: Date
 
         enum CodingKeys: String, CodingKey {
@@ -1345,8 +1345,8 @@ extension Vpc {
 
         /// 创建时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date
 
         /// 专线网关IP。
@@ -1799,8 +1799,8 @@ extension Vpc {
 
         /// 创建时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createdTime: Date
 
         /// 使用havip的业务标识。
@@ -1985,8 +1985,8 @@ extension Vpc {
 
         /// 转换规则创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createdTime: Date
 
         enum CodingKeys: String, CodingKey {
@@ -2050,8 +2050,8 @@ extension Vpc {
 
         /// IPV6转换实例创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createdTime: Date
 
         /// 绑定的IPV6转换规则数量
@@ -2345,14 +2345,14 @@ extension Vpc {
 
         /// 路由的创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date
 
         /// 路由的更新时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updateTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var updateTime: Date
 
         enum CodingKeys: String, CodingKey {
@@ -2594,8 +2594,8 @@ extension Vpc {
         /// 创建时间。
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date?
 
         enum CodingKeys: String, CodingKey {
@@ -3507,8 +3507,8 @@ extension Vpc {
 
         /// 路由策略创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createdTime: Date?
 
         public init(destinationCidrBlock: String, gatewayType: String, gatewayId: String, routeId: UInt64? = nil, routeDescription: String? = nil, enabled: Bool? = nil, routeType: String? = nil, routeTableId: String? = nil, destinationIpv6CidrBlock: String? = nil, routeItemId: String? = nil, publishedToVbc: Bool? = nil, createdTime: Date? = nil) {
@@ -4481,14 +4481,14 @@ extension Vpc {
 
         /// 流量包创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createdTime: Date
 
         /// 流量包截止时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$deadline`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var deadline: Date
 
         /// 已使用的流量，单位GB
@@ -4535,8 +4535,8 @@ extension Vpc {
 
         /// 抵扣时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$time`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var time: Date
 
         /// 资源类型。可能的值: CVM, LB, NAT, HAVIP, EIP
@@ -4550,8 +4550,8 @@ extension Vpc {
 
         /// 流量包到期时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$deadline`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var deadline: Date
 
         enum CodingKeys: String, CodingKey {
@@ -4702,8 +4702,8 @@ extension Vpc {
 
         /// `IP`申请时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createdTime: Date
 
         enum CodingKeys: String, CodingKey {
@@ -4761,8 +4761,8 @@ extension Vpc {
 
         /// 创建时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createdTime: Date
 
         /// 通道的生产状态，PENDING：生产中，AVAILABLE：运行中，DELETING：删除中。
@@ -4870,14 +4870,14 @@ extension Vpc {
 
         /// 创建时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createdTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createdTime: Date
 
         /// 预付费网关过期时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$expiredTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var expiredTime: Date
 
         /// 公网IP是否被封堵。
@@ -4974,14 +4974,14 @@ extension Vpc {
 
         /// 创建时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date?
 
         /// 更新时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updateTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var updateTime: Date?
 
         public init(destinationCidrBlock: String, instanceType: String, instanceId: String, priority: Int64, status: String, routeId: String? = nil, type: String? = nil, createTime: Date? = nil, updateTime: Date? = nil) {

--- a/Sources/Teco/Waf/V20180125/actions/DescribeAttackOverview.swift
+++ b/Sources/Teco/Waf/V20180125/actions/DescribeAttackOverview.swift
@@ -25,14 +25,14 @@ extension Waf {
     public struct DescribeAttackOverviewRequest: TCRequest {
         /// 查询开始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$fromTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var fromTime: Date
 
         /// 查询结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$toTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var toTime: Date
 
         /// 客户的Appid

--- a/Sources/Teco/Waf/V20180125/actions/DescribePeakPoints.swift
+++ b/Sources/Teco/Waf/V20180125/actions/DescribePeakPoints.swift
@@ -25,14 +25,14 @@ extension Waf {
     public struct DescribePeakPointsRequest: TCRequest {
         /// 查询起始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$fromTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var fromTime: Date
 
         /// 查询终止时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$toTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var toTime: Date
 
         /// 查询的域名，如果查询所有域名数据，该参数不填写

--- a/Sources/Teco/Waf/V20180125/actions/DescribePeakValue.swift
+++ b/Sources/Teco/Waf/V20180125/actions/DescribePeakValue.swift
@@ -25,14 +25,14 @@ extension Waf {
     public struct DescribePeakValueRequest: TCRequest {
         /// 查询起始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$fromTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var fromTime: Date
 
         /// 查询结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$toTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var toTime: Date
 
         /// 需要查询的域名，当前用户所有域名可以不传

--- a/Sources/Teco/Waf/V20180125/actions/GetAttackHistogram.swift
+++ b/Sources/Teco/Waf/V20180125/actions/GetAttackHistogram.swift
@@ -28,14 +28,14 @@ extension Waf {
 
         /// 查询起始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 查询结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// Lucene语法

--- a/Sources/Teco/Waf/V20180125/actions/GetAttackTotalCount.swift
+++ b/Sources/Teco/Waf/V20180125/actions/GetAttackTotalCount.swift
@@ -25,14 +25,14 @@ extension Waf {
     public struct GetAttackTotalCountRequest: TCRequest {
         /// 起始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var startTime: Date
 
         /// 结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var endTime: Date
 
         /// 查询的域名，全部域名不指定

--- a/Sources/Teco/Waf/V20180125/actions/PostAttackDownloadTask.swift
+++ b/Sources/Teco/Waf/V20180125/actions/PostAttackDownloadTask.swift
@@ -28,14 +28,14 @@ extension Waf {
 
         /// 查询起始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var startTime: Date
 
         /// 查询结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var endTime: Date
 
         /// Lucene语法

--- a/Sources/Teco/Waf/V20180125/actions/SearchAttackLog.swift
+++ b/Sources/Teco/Waf/V20180125/actions/SearchAttackLog.swift
@@ -28,14 +28,14 @@ extension Waf {
 
         /// 查询起始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 查询结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         /// 接口升级，这个字段传空字符串,翻页使用Page字段

--- a/Sources/Teco/Waf/V20180125/models.swift
+++ b/Sources/Teco/Waf/V20180125/models.swift
@@ -241,8 +241,8 @@ extension Waf {
 
         /// CLS返回内容
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$timeStamp`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var timeStamp: Date
 
         enum CodingKeys: String, CodingKey {
@@ -272,8 +272,8 @@ extension Waf {
 
         /// 最后更新时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$lastUpdateTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var lastUpdateTime: Date?
 
         public init(attackTags: [String], attackThreshold: Int64, defenseStatus: Int64, timeThreshold: Int64, denyTimeThreshold: Int64, lastUpdateTime: Date? = nil) {
@@ -1324,20 +1324,20 @@ extension Waf {
 
         /// 创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date
 
         /// 最后更新修改时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$modifyTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var modifyTime: Date
 
         /// 过期时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$expireTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var expireTime: Date
 
         /// 下载任务需下载的日志总条数
@@ -3149,8 +3149,8 @@ extension Waf {
 
         /// 最后更新时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$lastUpdateTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var lastUpdateTime: Date?
 
         public init(tags: [String]? = nil, defenseStatus: Int64? = nil, lastUpdateTime: Date? = nil) {

--- a/Sources/Teco/Wedata/V20210820/actions/DescribeTaskReport.swift
+++ b/Sources/Teco/Wedata/V20210820/actions/DescribeTaskReport.swift
@@ -28,14 +28,14 @@ extension Wedata {
 
         /// 统计周期的开始日期，格式为 yyyy-MM-dd
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$beginDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var beginDate: Date
 
         /// 统计周期的结束日期，格式为 yyyy-MM-dd
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var endDate: Date
 
         /// WeData项目id

--- a/Sources/Teco/Wedata/V20210820/actions/DescribeTaskReportDetailList.swift
+++ b/Sources/Teco/Wedata/V20210820/actions/DescribeTaskReportDetailList.swift
@@ -31,14 +31,14 @@ extension Wedata {
 
         /// 统计周期的开始日期，格式为 yyyy-MM-dd
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$beginDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var beginDate: Date
 
         /// 统计周期的结束日期，格式为 yyyy-MM-dd
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var endDate: Date
 
         /// 任务状态，多个状态用逗号连接

--- a/Sources/Teco/Wedata/V20210820/models.swift
+++ b/Sources/Teco/Wedata/V20210820/models.swift
@@ -30,15 +30,15 @@ extension Wedata {
         /// 任务启动时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var startTime: Date?
 
         /// 任务结束时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var endTime: Date?
 
         /// 当前任务状态
@@ -70,8 +70,8 @@ extension Wedata {
         /// 任务提交时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createTime: Date?
 
         /// 任务状态
@@ -455,8 +455,8 @@ extension Wedata {
 
         /// 基线创建时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createTime: Date?
 
         /// 保障任务
@@ -478,8 +478,8 @@ extension Wedata {
 
         /// 承诺时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$promiseTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var promiseTime: Date?
 
         /// 责任人uin
@@ -555,15 +555,15 @@ extension Wedata {
         /// 基线实例生成时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createTime: Date?
 
         /// 基线实例预计完成时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$estimatedEndTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var estimatedEndTime: Date?
 
         /// 基线实例状态，P:暂停/ SF:安全/ WN:预警/ BL:破线 / TF:任务失败
@@ -585,8 +585,8 @@ extension Wedata {
         /// 承诺时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$promiseTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var promiseTime: Date?
 
         /// 告警级别 N: 普通 / I重要 / E: 紧急
@@ -616,8 +616,8 @@ extension Wedata {
         /// 任务实例DAG整体启动时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$criticalStartTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var criticalStartTime: Date?
 
         /// 基线实例上的关键任务实例
@@ -627,8 +627,8 @@ extension Wedata {
         /// 更新时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updateTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var updateTime: Date?
 
         /// 基线实例与保障任务实例映射
@@ -873,8 +873,8 @@ extension Wedata {
         /// 任务实例的数据时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$curRunDate`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var curRunDate: Date?
 
         /// 任务名称
@@ -900,36 +900,36 @@ extension Wedata {
         /// 预计最晚开始时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$latestStartTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var latestStartTime: Date?
 
         /// 实际开始时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$actualStartTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var actualStartTime: Date?
 
         /// 预计完成时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$estimatedEndTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var estimatedEndTime: Date?
 
         /// 最晚完成时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$latestEndTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var latestEndTime: Date?
 
         /// 实际完成时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$actualEndTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var actualEndTime: Date?
 
         /// 实例运行状态
@@ -3012,8 +3012,8 @@ extension Wedata {
 
         /// 产生事件时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$eventTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var eventTime: Date
 
         /// 事件名称
@@ -3046,15 +3046,15 @@ extension Wedata {
         /// 创建时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createTime: Date?
 
         /// 更新时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$updateTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var updateTime: Date?
 
         /// 租户id

--- a/Sources/Teco/Wss/V20180426/models.swift
+++ b/Sources/Teco/Wss/V20180426/models.swift
@@ -72,15 +72,15 @@ extension Wss {
         /// 证书生效时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$certBeginTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var certBeginTime: Date?
 
         /// 证书过期时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$certEndTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var certEndTime: Date?
 
         /// 证书过期时间
@@ -90,8 +90,8 @@ extension Wss {
         /// 创建时间
         /// 注意：此字段可能返回 null，表示取不到有效值。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$insertTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var insertTime: Date?
 
         /// 项目信息，ProjectId：项目ID，OwnerUin：项目所属的 uin（默认项目为0），Name：项目名称，CreatorUin：创建项目的 uin，CreateTime：项目创建时间，Info：项目说明

--- a/Sources/Teco/Yinsuda/V20220527/actions/DescribeLiveVipTradeInfos.swift
+++ b/Sources/Teco/Yinsuda/V20220527/actions/DescribeLiveVipTradeInfos.swift
@@ -28,14 +28,14 @@ extension Yinsuda {
 
         /// 直播会员充值下单起始时间，格式为 ISO。默认为当前时间前一天。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var startTime: Date?
 
         /// 直播会员充值下单截止时间，格式为 ISO。默认为当前时间。 EndTime不能小于StartTime
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var endTime: Date?
 
         /// 交易流水号集合，匹配集合指定所有流水号 。

--- a/Sources/Teco/Yinsuda/V20220527/models.swift
+++ b/Sources/Teco/Yinsuda/V20220527/models.swift
@@ -381,8 +381,8 @@ extension Yinsuda {
 
         /// 创建时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var createTime: Date?
 
         enum CodingKeys: String, CodingKey {
@@ -403,8 +403,8 @@ extension Yinsuda {
 
         /// 直播会员结束时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$liveVipEndTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var liveVipEndTime: Date?
 
         /// 会员生效状态

--- a/Sources/Teco/Youmall/V20180228/actions/DescribeClusterPersonArrivedMall.swift
+++ b/Sources/Teco/Youmall/V20180228/actions/DescribeClusterPersonArrivedMall.swift
@@ -31,14 +31,14 @@ extension Youmall {
 
         /// 查询开始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 查询结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         public init(mallId: String, personId: String, startTime: Date, endTime: Date) {

--- a/Sources/Teco/Youmall/V20180228/actions/DescribeClusterPersonTrace.swift
+++ b/Sources/Teco/Youmall/V20180228/actions/DescribeClusterPersonTrace.swift
@@ -31,14 +31,14 @@ extension Youmall {
 
         /// 查询开始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 查询结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         public init(mallId: String, personId: String, startTime: Date, endTime: Date) {

--- a/Sources/Teco/Youmall/V20180228/actions/DescribePersonInfoByFacePicture.swift
+++ b/Sources/Teco/Youmall/V20180228/actions/DescribePersonInfoByFacePicture.swift
@@ -64,8 +64,8 @@ extension Youmall {
 
         /// 顾客首次进店时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$firstVisitTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var firstVisitTime: Date
 
         /// 顾客历史到访次数

--- a/Sources/Teco/Youmall/V20180228/actions/DescribePersonTrace.swift
+++ b/Sources/Teco/Youmall/V20180228/actions/DescribePersonTrace.swift
@@ -31,14 +31,14 @@ extension Youmall {
 
         /// 查询开始时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startTime: Date
 
         /// 查询结束时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endTime: Date
 
         public init(mallId: String, personId: String, startTime: Date, endTime: Date) {

--- a/Sources/Teco/Youmall/V20180228/actions/DescribePersonVisitInfo.swift
+++ b/Sources/Teco/Youmall/V20180228/actions/DescribePersonVisitInfo.swift
@@ -37,14 +37,14 @@ extension Youmall {
 
         /// 开始日期，格式yyyy-MM-dd，已废弃，请使用StartDateTime
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var startDate: Date?
 
         /// 结束日期，格式yyyy-MM-dd，已废弃，请使用EndDateTime
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var endDate: Date?
 
         /// 图片url过期时间：在当前时间+PictureExpires秒后，图片url无法继续正常访问；单位s；默认值1*24*60*60（1天）
@@ -52,14 +52,14 @@ extension Youmall {
 
         /// 开始时间，格式yyyy-MM-dd HH:mm:ss
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startDateTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var startDateTime: Date?
 
         /// 结束时间，格式yyyy-MM-dd HH:mm:ss
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endDateTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var endDateTime: Date?
 
         public init(companyId: String, shopId: UInt64, offset: UInt64, limit: UInt64, startDate: Date? = nil, endDate: Date? = nil, pictureExpires: UInt64? = nil, startDateTime: Date? = nil, endDateTime: Date? = nil) {

--- a/Sources/Teco/Youmall/V20180228/actions/DescribeShopHourTrafficInfo.swift
+++ b/Sources/Teco/Youmall/V20180228/actions/DescribeShopHourTrafficInfo.swift
@@ -31,14 +31,14 @@ extension Youmall {
 
         /// 开始日期，格式：yyyy-MM-dd
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var startDate: Date
 
         /// 结束日期，格式：yyyy-MM-dd
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var endDate: Date
 
         /// 偏移量：分页控制参数，第一页传0，第n页Offset=(n-1)*Limit

--- a/Sources/Teco/Youmall/V20180228/actions/DescribeShopTrafficInfo.swift
+++ b/Sources/Teco/Youmall/V20180228/actions/DescribeShopTrafficInfo.swift
@@ -31,14 +31,14 @@ extension Youmall {
 
         /// 开始日期，格式yyyy-MM-dd
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var startDate: Date
 
         /// 介绍日期，格式yyyy-MM-dd
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var endDate: Date
 
         /// 偏移量：分页控制参数，第一页传0，第n页Offset=(n-1)*Limit

--- a/Sources/Teco/Youmall/V20180228/actions/DescribeZoneTrafficInfo.swift
+++ b/Sources/Teco/Youmall/V20180228/actions/DescribeZoneTrafficInfo.swift
@@ -31,14 +31,14 @@ extension Youmall {
 
         /// 开始日期，格式yyyy-MM-dd
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$startDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var startDate: Date
 
         /// 结束日期，格式yyyy-MM-dd
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var endDate: Date
 
         /// 偏移量：分页控制参数，第一页传0，第n页Offset=(n-1)*Limit

--- a/Sources/Teco/Youmall/V20180228/models.swift
+++ b/Sources/Teco/Youmall/V20180228/models.swift
@@ -23,14 +23,14 @@ extension Youmall {
     public struct ArrivedMallInfo: TCOutputModel {
         /// 到场时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$arrivedTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var arrivedTime: Date
 
         /// 出场时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$leaveTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var leaveTime: Date
 
         /// 停留时间，秒
@@ -89,8 +89,8 @@ extension Youmall {
     public struct DailyTracePoint: TCOutputModel {
         /// 轨迹日期
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$traceDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var traceDate: Date
 
         /// 轨迹点序列
@@ -296,8 +296,8 @@ extension Youmall {
 
         /// 抓拍时间点
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$capTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var capTime: Date
 
         /// 抓拍图片
@@ -385,8 +385,8 @@ extension Youmall {
 
         /// 首次到场时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$firstArrivedTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var firstArrivedTime: Date
 
         /// 来访次数
@@ -449,8 +449,8 @@ extension Youmall {
 
         /// 轨迹事件发生时间点
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$traceEventTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var traceEventTime: Date
 
         /// 抓拍图片
@@ -560,8 +560,8 @@ extension Youmall {
     public struct ShopDayTrafficInfo: TCOutputModel {
         /// 日期
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$date`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var date: Date
 
         /// 客流量
@@ -581,8 +581,8 @@ extension Youmall {
     public struct ShopHourTrafficInfo: TCOutputModel {
         /// 日期，格式yyyy-MM-dd
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$date`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var date: Date
 
         /// 分时客流详细信息
@@ -714,8 +714,8 @@ extension Youmall {
     public struct ZoneTrafficInfo: TCOutputModel {
         /// 日期
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$date`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var date: Date
 
         /// 门店区域客流详细信息

--- a/Sources/Teco/Yunjing/V20180228/actions/DescribeSecurityTrends.swift
+++ b/Sources/Teco/Yunjing/V20180228/actions/DescribeSecurityTrends.swift
@@ -25,14 +25,14 @@ extension Yunjing {
     public struct DescribeSecurityTrendsRequest: TCRequest {
         /// 开始时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$beginDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var beginDate: Date
 
         /// 结束时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var endDate: Date
 
         public init(beginDate: Date, endDate: Date) {

--- a/Sources/Teco/Yunjing/V20180228/actions/DescribeWeeklyReportBruteAttacks.swift
+++ b/Sources/Teco/Yunjing/V20180228/actions/DescribeWeeklyReportBruteAttacks.swift
@@ -25,8 +25,8 @@ extension Yunjing {
     public struct DescribeWeeklyReportBruteAttacksRequest: TCPaginatedRequest {
         /// 专业周报开始时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$beginDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var beginDate: Date
 
         /// 返回数量，默认为10，最大值为100。

--- a/Sources/Teco/Yunjing/V20180228/actions/DescribeWeeklyReportInfo.swift
+++ b/Sources/Teco/Yunjing/V20180228/actions/DescribeWeeklyReportInfo.swift
@@ -25,8 +25,8 @@ extension Yunjing {
     public struct DescribeWeeklyReportInfoRequest: TCRequest {
         /// 专业周报开始时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$beginDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var beginDate: Date
 
         public init(beginDate: Date) {
@@ -57,14 +57,14 @@ extension Yunjing {
 
         /// 周报开始时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$beginDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var beginDate: Date
 
         /// 周报结束时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var endDate: Date
 
         /// 安全等级。

--- a/Sources/Teco/Yunjing/V20180228/actions/DescribeWeeklyReportMalwares.swift
+++ b/Sources/Teco/Yunjing/V20180228/actions/DescribeWeeklyReportMalwares.swift
@@ -25,8 +25,8 @@ extension Yunjing {
     public struct DescribeWeeklyReportMalwaresRequest: TCPaginatedRequest {
         /// 专业周报开始时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$beginDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var beginDate: Date
 
         /// 返回数量，默认为10，最大值为100。

--- a/Sources/Teco/Yunjing/V20180228/actions/DescribeWeeklyReportNonlocalLoginPlaces.swift
+++ b/Sources/Teco/Yunjing/V20180228/actions/DescribeWeeklyReportNonlocalLoginPlaces.swift
@@ -25,8 +25,8 @@ extension Yunjing {
     public struct DescribeWeeklyReportNonlocalLoginPlacesRequest: TCPaginatedRequest {
         /// 专业周报开始时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$beginDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var beginDate: Date
 
         /// 返回数量，默认为10，最大值为100。

--- a/Sources/Teco/Yunjing/V20180228/actions/DescribeWeeklyReportVuls.swift
+++ b/Sources/Teco/Yunjing/V20180228/actions/DescribeWeeklyReportVuls.swift
@@ -25,8 +25,8 @@ extension Yunjing {
     public struct DescribeWeeklyReportVulsRequest: TCPaginatedRequest {
         /// 专业版周报开始时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$beginDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var beginDate: Date
 
         /// 返回数量，默认为10，最大值为100。

--- a/Sources/Teco/Yunjing/V20180228/models.swift
+++ b/Sources/Teco/Yunjing/V20180228/models.swift
@@ -46,14 +46,14 @@ extension Yunjing {
 
         /// 帐号创建时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$accountCreateTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var accountCreateTime: Date
 
         /// 帐号最后登录时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$lastLoginTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var lastLoginTime: Date
 
         enum CodingKeys: String, CodingKey {
@@ -103,8 +103,8 @@ extension Yunjing {
 
         /// 最后扫描时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$lastScanTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var lastScanTime: Date
 
         /// 漏洞描述。
@@ -276,8 +276,8 @@ extension Yunjing {
 
         /// 发生时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date
 
         /// 主机名称。
@@ -365,8 +365,8 @@ extension Yunjing {
 
         /// 组件检测更新时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$modifyTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var modifyTime: Date
 
         enum CodingKeys: String, CodingKey {
@@ -521,8 +521,8 @@ extension Yunjing {
 
         /// 变更时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$modifyTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var modifyTime: Date
 
         enum CodingKeys: String, CodingKey {
@@ -549,8 +549,8 @@ extension Yunjing {
 
         /// 最后检测时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$lastScanTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var lastScanTime: Date
 
         /// 漏洞状态。
@@ -606,14 +606,14 @@ extension Yunjing {
 
         /// 创建白名单时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date
 
         /// 修改白名单时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$modifyTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var modifyTime: Date
 
         /// 机器名
@@ -832,14 +832,14 @@ extension Yunjing {
 
         /// 发现时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date
 
         /// 记录合并时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$mergeTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var mergeTime: Date
 
         /// 进程MD5
@@ -898,14 +898,14 @@ extension Yunjing {
 
         /// 木马文件创建时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$fileCreateTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var fileCreateTime: Date
 
         /// 木马文件修改时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$modifyTime`) in case the synthesized encoding is incorrect.
         @TCTimestampISO8601Encoding public var modifyTime: Date
 
         /// 云镜客户端唯一标识UUID。
@@ -957,8 +957,8 @@ extension Yunjing {
 
         /// 登录时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$loginTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var loginTime: Date
 
         /// 云镜客户端唯一标识Uuid。
@@ -1004,14 +1004,14 @@ extension Yunjing {
 
         /// 记录创建时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date
 
         /// 记录更新时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$modifyTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var modifyTime: Date
 
         enum CodingKeys: String, CodingKey {
@@ -1255,8 +1255,8 @@ extension Yunjing {
 
         /// 创建时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$createTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var createTime: Date
 
         enum CodingKeys: String, CodingKey {
@@ -1449,8 +1449,8 @@ extension Yunjing {
 
         /// 安全事件发生事件。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$eventTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var eventTime: Date
 
         /// 安全事件类型。
@@ -1484,8 +1484,8 @@ extension Yunjing {
     public struct SecurityTrend: TCOutputModel {
         /// 事件时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$date`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var date: Date
 
         /// 事件数量。
@@ -1592,8 +1592,8 @@ extension Yunjing {
 
         /// 最后扫描时间
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$lastScanTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var lastScanTime: Date
 
         /// 受影响机器数量
@@ -1618,14 +1618,14 @@ extension Yunjing {
     public struct WeeklyReport: TCOutputModel {
         /// 周报开始时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$beginDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var beginDate: Date
 
         /// 周报结束时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$endDate`) in case the synthesized encoding is incorrect.
         @TCDateEncoding public var endDate: Date
 
         enum CodingKeys: String, CodingKey {
@@ -1650,8 +1650,8 @@ extension Yunjing {
 
         /// 攻击时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$attackTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var attackTime: Date
 
         enum CodingKeys: String, CodingKey {
@@ -1676,8 +1676,8 @@ extension Yunjing {
 
         /// 木马发现时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$findTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var findTime: Date
 
         /// 当前木马状态。
@@ -1719,8 +1719,8 @@ extension Yunjing {
 
         /// 登录时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$loginTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var loginTime: Date
 
         enum CodingKeys: String, CodingKey {
@@ -1759,8 +1759,8 @@ extension Yunjing {
 
         /// 最后扫描时间。
         ///
-        /// While the wrapped date value is immutable just like other fields, you can customize the projected
-        /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+        /// While the wrapped date value is immutable just like other fields, you can customize the underlying
+        /// string value (through `$lastScanTime`) in case the synthesized encoding is incorrect.
         @TCTimestampEncoding public var lastScanTime: Date
 
         enum CodingKeys: String, CodingKey {


### PR DESCRIPTION
This PR slightly improves the documentation of date members by specializing the wording of "`$`-prefix" in documentation into the real symbol name. Companioned by https://github.com/teco-project/teco-code-generators/pull/51.